### PR TITLE
fix: Temperature field now correctly displays stored value when editing agent

### DIFF
--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -73,7 +73,7 @@ class AgentService:
             service_id=getattr(agent, 'service_id', None),
             silo_id=getattr(agent, 'silo_id', None),
             output_parser_id=getattr(agent, 'output_parser_id', None),
-            temperature=getattr(agent, 'temperature', DEFAULT_AGENT_TEMPERATURE) or DEFAULT_AGENT_TEMPERATURE,
+            temperature=agent.temperature if agent.temperature is not None else DEFAULT_AGENT_TEMPERATURE,
             tool_ids=associations['tool_ids'],
             mcp_config_ids=associations['mcp_ids'],
             created_at=agent.create_date,

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -198,7 +198,7 @@ function AgentFormPage() {
         service_id: response.service_id || undefined,
         silo_id: response.silo_id || undefined,
         output_parser_id: response.output_parser_id || undefined,
-        temperature: response.temperature || DEFAULT_AGENT_TEMPERATURE,
+        temperature: response.temperature ?? DEFAULT_AGENT_TEMPERATURE,
         tool_ids: response.tool_ids || [],
         mcp_config_ids: response.mcp_config_ids || [],
         // OCR-specific fields


### PR DESCRIPTION
## Description

Fixes the bug where the temperature field always showed the default value (0.7) when editing an existing agent, regardless of the actual stored value.

## Root Cause

The issue was caused by incorrect use of logical operators with the value `0`:
- In Python: `0 or 0.7` returns `0.7` (because `0` is falsy)
- In JavaScript: `0 || 0.7` returns `0.7` (same issue)

## Changes

### Backend (`backend/services/agent_service.py`)
- temperature=getattr(agent, 'temperature', DEFAULT_AGENT_TEMPERATURE) or DEFAULT_AGENT_TEMPERATURE,
+ temperature=agent.temperature if agent.temperature is not None else DEFAULT_AGENT_TEMPERATURE,
### Frontend (`frontend/src/pages/AgentFormPage.tsx`)
- temperature: response.temperature || DEFAULT_AGENT_TEMPERATURE,
+ temperature: response.temperature ?? DEFAULT_AGENT_TEMPERATURE,Now the default value is only used when temperature is explicitly `None`/`undefined`, not when it's `0`.

Closes #16