### PR TITLE
feat: Add MCP Servers feature to expose agents as MCP tools

### DIFF
--- a/alembic/versions/mcpservers001_add_mcp_servers.py
+++ b/alembic/versions/mcpservers001_add_mcp_servers.py
@@ -1,0 +1,61 @@
+"""add MCP servers feature
+
+Revision ID: mcpservers001
+Revises: a35f5996ece4
+Create Date: 2025-11-15
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'mcpservers001'
+down_revision = 'a35f5996ece4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add slug column to App table (nullable initially for existing apps)
+    op.add_column('App', sa.Column('slug', sa.String(100), nullable=True))
+    op.create_index('ix_app_slug', 'App', ['slug'], unique=True)
+
+    # Create MCPServer table
+    op.create_table(
+        'MCPServer',
+        sa.Column('server_id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(100), nullable=False),
+        sa.Column('slug', sa.String(100), nullable=False),
+        sa.Column('description', sa.String(1000), nullable=True),
+        sa.Column('is_active', sa.Boolean(), server_default='true', nullable=False),
+        sa.Column('rate_limit', sa.Integer(), server_default='0', nullable=False),
+        sa.Column('create_date', sa.DateTime(), nullable=True),
+        sa.Column('update_date', sa.DateTime(), nullable=True),
+        sa.Column('app_id', sa.Integer(), sa.ForeignKey('App.app_id', ondelete='CASCADE'), nullable=False),
+    )
+
+    # Create unique constraint on (app_id, slug) for MCPServer
+    op.create_unique_constraint('uq_mcp_server_app_slug', 'MCPServer', ['app_id', 'slug'])
+
+    # Create mcp_server_agents association table
+    op.create_table(
+        'mcp_server_agents',
+        sa.Column('server_id', sa.Integer(), sa.ForeignKey('MCPServer.server_id', ondelete='CASCADE'), primary_key=True),
+        sa.Column('agent_id', sa.Integer(), sa.ForeignKey('Agent.agent_id', ondelete='CASCADE'), primary_key=True),
+        sa.Column('tool_name_override', sa.String(100), nullable=True),
+        sa.Column('tool_description_override', sa.String(1000), nullable=True),
+    )
+
+
+def downgrade():
+    # Drop mcp_server_agents table
+    op.drop_table('mcp_server_agents')
+
+    # Drop MCPServer unique constraint and table
+    op.drop_constraint('uq_mcp_server_app_slug', 'MCPServer', type_='unique')
+    op.drop_table('MCPServer')
+
+    # Drop App slug column
+    op.drop_index('ix_app_slug', 'App')
+    op.drop_column('App', 'slug')

--- a/backend/config.py
+++ b/backend/config.py
@@ -57,4 +57,8 @@ WEAVIATE_URL = os.getenv('WEAVIATE_URL')
 WEAVIATE_API_KEY = os.getenv('WEAVIATE_API_KEY')
 
 # Chroma Configuration (future support)
-CHROMA_PERSIST_DIR = os.getenv('CHROMA_PERSIST_DIR', './chroma_db') 
+CHROMA_PERSIST_DIR = os.getenv('CHROMA_PERSIST_DIR', './chroma_db')
+
+# MCP Server Configuration
+# Base URL for generating MCP endpoint URLs (e.g., https://your-domain.com)
+MCP_BASE_URL = os.getenv('MCP_BASE_URL', 'http://localhost:8000') 

--- a/backend/main.py
+++ b/backend/main.py
@@ -40,6 +40,7 @@ from models.url import Url
 
 from routers.internal import internal_router
 from routers.public.v1 import public_v1_router
+from routers.mcp import mcp_router
 from utils.provider import initialize_provider, shutdown_provider, get_provider
 from lks_idprovider_fastapi.dependencies import get_default_provider
 
@@ -135,6 +136,7 @@ app.add_middleware(
 # Mount routers - clean structure with no nesting
 app.include_router(internal_router, prefix="/internal")
 app.include_router(public_v1_router, prefix="/public/v1")
+app.include_router(mcp_router, prefix="/mcp/v1", tags=["MCP"])
 
 # Add client config endpoint
 @app.get("/api/internal/client-config")

--- a/backend/mcp_handler/__init__.py
+++ b/backend/mcp_handler/__init__.py
@@ -1,0 +1,1 @@
+# MCP Server Implementation for exposing agents as MCP tools

--- a/backend/mcp_handler/auth.py
+++ b/backend/mcp_handler/auth.py
@@ -1,0 +1,224 @@
+"""
+MCP Authentication Module
+
+Handles authentication for MCP endpoints supporting:
+- API Key authentication (X-API-KEY header)
+- JWT Bearer token authentication (Authorization header)
+"""
+
+from typing import Optional, Tuple
+from datetime import datetime
+from fastapi import HTTPException, status, Request
+
+from models.api_key import APIKey
+from models.app import App
+from models.mcp_server import MCPServer
+from db.database import SessionLocal
+from repositories.mcp_server_repository import MCPServerRepository, AppSlugRepository
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class MCPAuthResult:
+    """Result of MCP authentication"""
+    def __init__(
+        self,
+        app: App,
+        mcp_server: MCPServer,
+        api_key_id: Optional[int] = None,
+        user_id: Optional[int] = None
+    ):
+        # Store primitive values to avoid DetachedInstanceError after session closes
+        self.app_id = app.app_id
+        self.app_slug = app.slug
+        self.server_id = mcp_server.server_id
+        self.server_slug = mcp_server.slug
+        self.server_name = mcp_server.name
+
+        # Also store the objects for use within the same session context
+        self.app = app
+        self.mcp_server = mcp_server
+        self.api_key_id = api_key_id
+        self.user_id = user_id
+
+
+def authenticate_mcp_request(
+    request: Request,
+    app_identifier: str,
+    server_identifier: str,
+    by_id: bool = False
+) -> MCPAuthResult:
+    """
+    Authenticate an MCP request.
+
+    Args:
+        request: FastAPI request object
+        app_identifier: App slug or ID
+        server_identifier: MCP server slug or ID
+        by_id: If True, identifiers are IDs; otherwise, they are slugs
+
+    Returns:
+        MCPAuthResult with authenticated app and server
+
+    Raises:
+        HTTPException: If authentication fails
+    """
+    # Extract authentication credentials
+    api_key = request.headers.get("X-API-KEY")
+    auth_header = request.headers.get("Authorization")
+
+    if not api_key and not auth_header:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required. Provide X-API-KEY header or Authorization: Bearer <token>"
+        )
+
+    session = SessionLocal()
+    try:
+        # Find the MCP server
+        if by_id:
+            try:
+                app_id = int(app_identifier)
+                server_id = int(server_identifier)
+            except ValueError:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Invalid app_id or server_id format"
+                )
+
+            app = session.query(App).filter(App.app_id == app_id).first()
+            if not app:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="App not found"
+                )
+
+            mcp_server = MCPServerRepository.get_by_id_and_app_id(session, server_id, app_id)
+        else:
+            # Lookup by slugs
+            app = AppSlugRepository.get_by_slug(session, app_identifier)
+            if not app:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"App with slug '{app_identifier}' not found"
+                )
+
+            mcp_server = MCPServerRepository.get_by_slug(session, app_identifier, server_identifier)
+
+        if not mcp_server:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="MCP server not found"
+            )
+
+        if not mcp_server.is_active:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="MCP server is not active"
+            )
+
+        # Authenticate using API key
+        if api_key:
+            return _authenticate_with_api_key(session, app, mcp_server, api_key)
+
+        # Authenticate using JWT Bearer token
+        if auth_header:
+            return _authenticate_with_bearer_token(session, app, mcp_server, auth_header)
+
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="No valid authentication method provided"
+        )
+
+    finally:
+        session.close()
+
+
+def _authenticate_with_api_key(
+    session,
+    app: App,
+    mcp_server: MCPServer,
+    api_key: str
+) -> MCPAuthResult:
+    """Authenticate using API key"""
+    # Validate API key belongs to this app
+    api_key_obj = session.query(APIKey).filter(
+        APIKey.app_id == app.app_id,
+        APIKey.key == api_key,
+        APIKey.is_active == True
+    ).first()
+
+    if not api_key_obj:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or inactive API key"
+        )
+
+    # Check if the app owner is active
+    if app.owner and hasattr(app.owner, 'is_active') and not app.owner.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This API key belongs to a deactivated account"
+        )
+
+    # Update last used timestamp
+    api_key_obj.last_used_at = datetime.now()
+    session.commit()
+
+    logger.info(f"MCP request authenticated via API key for server {mcp_server.server_id}")
+
+    return MCPAuthResult(
+        app=app,
+        mcp_server=mcp_server,
+        api_key_id=api_key_obj.key_id
+    )
+
+
+def _authenticate_with_bearer_token(
+    session,
+    app: App,
+    mcp_server: MCPServer,
+    auth_header: str
+) -> MCPAuthResult:
+    """Authenticate using Bearer token (JWT)"""
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Authorization header format. Use: Bearer <token>"
+        )
+
+    token = auth_header[7:]  # Remove "Bearer " prefix
+
+    # For now, we'll support API keys passed as bearer tokens for simplicity
+    # In a full implementation, this would validate JWT tokens
+    api_key_obj = session.query(APIKey).filter(
+        APIKey.app_id == app.app_id,
+        APIKey.key == token,
+        APIKey.is_active == True
+    ).first()
+
+    if api_key_obj:
+        # API key used as bearer token
+        if app.owner and hasattr(app.owner, 'is_active') and not app.owner.is_active:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="This token belongs to a deactivated account"
+            )
+
+        api_key_obj.last_used_at = datetime.now()
+        session.commit()
+
+        logger.info(f"MCP request authenticated via Bearer token (API key) for server {mcp_server.server_id}")
+
+        return MCPAuthResult(
+            app=app,
+            mcp_server=mcp_server,
+            api_key_id=api_key_obj.key_id
+        )
+
+    # If not an API key, could implement JWT validation here
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid bearer token"
+    )

--- a/backend/mcp_handler/server_handler.py
+++ b/backend/mcp_handler/server_handler.py
@@ -9,13 +9,11 @@ from typing import Any, Dict, Optional
 from datetime import datetime
 import json
 
-from fastapi import HTTPException, status
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from models.mcp_server import MCPServer, MCPServerAgent
-from models.agent import Agent
+from models.mcp_server import MCPServer
 from services.agent_execution_service import AgentExecutionService
-from db.database import SessionLocal
 from utils.logger import get_logger
 
 logger = get_logger(__name__)

--- a/backend/mcp_handler/server_handler.py
+++ b/backend/mcp_handler/server_handler.py
@@ -5,7 +5,7 @@ Implements the MCP (Model Context Protocol) for exposing agents as tools.
 Supports JSON-RPC 2.0 over HTTP with Streamable HTTP transport.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 from datetime import datetime
 import json
 

--- a/backend/mcp_handler/server_handler.py
+++ b/backend/mcp_handler/server_handler.py
@@ -1,0 +1,322 @@
+"""
+MCP Server Handler
+
+Implements the MCP (Model Context Protocol) for exposing agents as tools.
+Supports JSON-RPC 2.0 over HTTP with Streamable HTTP transport.
+"""
+
+from typing import Any, Dict, List, Optional
+from datetime import datetime
+import json
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from models.mcp_server import MCPServer, MCPServerAgent
+from models.agent import Agent
+from services.agent_execution_service import AgentExecutionService
+from db.database import SessionLocal
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# MCP Protocol constants
+MCP_PROTOCOL_VERSION = "2024-11-05"
+MCP_SERVER_NAME = "mattin-ai-mcp"
+MCP_SERVER_VERSION = "1.0.0"
+
+
+class MCPError(Exception):
+    """MCP Protocol Error"""
+    def __init__(self, code: int, message: str, data: Any = None):
+        self.code = code
+        self.message = message
+        self.data = data
+        super().__init__(message)
+
+
+# JSON-RPC Error codes
+class JSONRPCError:
+    PARSE_ERROR = -32700
+    INVALID_REQUEST = -32600
+    METHOD_NOT_FOUND = -32601
+    INVALID_PARAMS = -32602
+    INTERNAL_ERROR = -32603
+
+
+class MCPServerHandler:
+    """Handles MCP protocol requests for an MCP server"""
+
+    def __init__(self, server_id: int, server_name: str, app_id: int, api_key_id: Optional[int] = None):
+        self.server_id = server_id
+        self.server_name = server_name
+        self.app_id = app_id
+        self.api_key_id = api_key_id
+        self.agent_execution_service = AgentExecutionService()
+
+    def _get_mcp_server(self, session: Session) -> Optional[MCPServer]:
+        """Load the MCP server with a fresh session"""
+        from repositories.mcp_server_repository import MCPServerRepository
+        return MCPServerRepository.get_by_id_and_app_id(session, self.server_id, self.app_id)
+
+    async def handle_request(self, request_body: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Handle an MCP JSON-RPC request.
+
+        Args:
+            request_body: The JSON-RPC request body
+
+        Returns:
+            JSON-RPC response
+        """
+        # Validate JSON-RPC request
+        if not isinstance(request_body, dict):
+            return self._error_response(None, JSONRPCError.INVALID_REQUEST, "Invalid request format")
+
+        jsonrpc = request_body.get("jsonrpc")
+        method = request_body.get("method")
+        params = request_body.get("params", {})
+        request_id = request_body.get("id")
+
+        if jsonrpc != "2.0":
+            return self._error_response(request_id, JSONRPCError.INVALID_REQUEST, "Invalid JSON-RPC version")
+
+        if not method:
+            return self._error_response(request_id, JSONRPCError.INVALID_REQUEST, "Method is required")
+
+        try:
+            result = await self._dispatch_method(method, params)
+
+            # If it's a notification (no id), don't return a response
+            if request_id is None:
+                return None
+
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": result
+            }
+
+        except MCPError as e:
+            return self._error_response(request_id, e.code, e.message, e.data)
+        except Exception as e:
+            logger.error(f"MCP request error: {str(e)}")
+            return self._error_response(request_id, JSONRPCError.INTERNAL_ERROR, str(e))
+
+    async def _dispatch_method(self, method: str, params: Dict[str, Any]) -> Any:
+        """Dispatch MCP method to appropriate handler"""
+        handlers = {
+            "initialize": self._handle_initialize,
+            "ping": self._handle_ping,
+            "tools/list": self._handle_tools_list,
+            "tools/call": self._handle_tools_call,
+            "notifications/initialized": self._handle_initialized_notification,
+        }
+
+        handler = handlers.get(method)
+        if not handler:
+            raise MCPError(JSONRPCError.METHOD_NOT_FOUND, f"Method not found: {method}")
+
+        return await handler(params)
+
+    async def _handle_initialize(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle initialize request"""
+        client_info = params.get("clientInfo", {})
+        logger.info(f"MCP client initializing: {client_info.get('name', 'unknown')}")
+
+        return {
+            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "capabilities": {
+                "tools": {
+                    "listChanged": False
+                }
+            },
+            "serverInfo": {
+                "name": f"{MCP_SERVER_NAME}-{self.server_name}",
+                "version": MCP_SERVER_VERSION
+            }
+        }
+
+    async def _handle_ping(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle ping request"""
+        return {}
+
+    async def _handle_initialized_notification(self, params: Dict[str, Any]) -> None:
+        """Handle initialized notification"""
+        logger.info(f"MCP client initialized for server {self.server_id}")
+        return None
+
+    async def _handle_tools_list(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle tools/list request - return agents as tools"""
+        session = SessionLocal()
+        try:
+            # Load MCP server with fresh session
+            mcp_server = self._get_mcp_server(session)
+            if not mcp_server:
+                raise MCPError(JSONRPCError.INTERNAL_ERROR, "MCP server not found")
+
+            tools = []
+
+            for assoc in mcp_server.agent_associations:
+                agent = assoc.agent
+                if not agent:
+                    continue
+
+                # Filter out agents that are no longer marked as tools
+                if not agent.is_tool:
+                    logger.debug(f"Skipping agent {agent.agent_id} ({agent.name}): not marked as tool")
+                    continue
+
+                # Use override names/descriptions if provided
+                tool_name = assoc.tool_name_override or self._generate_tool_name(agent.name)
+                tool_description = assoc.tool_description_override or agent.description or f"Execute the {agent.name} agent"
+
+                tool = {
+                    "name": tool_name,
+                    "description": tool_description,
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "message": {
+                                "type": "string",
+                                "description": "The message or query to send to the agent"
+                            }
+                        },
+                        "required": ["message"]
+                    }
+                }
+
+                # Add agent_id as metadata for internal reference
+                tool["_agent_id"] = agent.agent_id
+
+                tools.append(tool)
+
+            return {"tools": tools}
+
+        finally:
+            session.close()
+
+    async def _handle_tools_call(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle tools/call request - execute an agent"""
+        tool_name = params.get("name")
+        arguments = params.get("arguments", {})
+
+        if not tool_name:
+            raise MCPError(JSONRPCError.INVALID_PARAMS, "Tool name is required")
+
+        # Find the agent by tool name
+        session = SessionLocal()
+        try:
+            # Load MCP server with fresh session
+            mcp_server = self._get_mcp_server(session)
+            if not mcp_server:
+                raise MCPError(JSONRPCError.INTERNAL_ERROR, "MCP server not found")
+
+            agent = None
+            for assoc in mcp_server.agent_associations:
+                assoc_agent = assoc.agent
+                if not assoc_agent:
+                    continue
+
+                expected_name = assoc.tool_name_override or self._generate_tool_name(assoc_agent.name)
+                if expected_name == tool_name:
+                    agent = assoc_agent
+                    break
+
+            if not agent:
+                raise MCPError(JSONRPCError.INVALID_PARAMS, f"Tool not found: {tool_name}")
+
+            # Verify the agent is still marked as a tool
+            if not agent.is_tool:
+                raise MCPError(
+                    JSONRPCError.INVALID_PARAMS,
+                    f"Tool '{tool_name}' is no longer available (agent is not marked as a tool)"
+                )
+
+            # Extract message from arguments
+            message = arguments.get("message")
+            if not message:
+                raise MCPError(JSONRPCError.INVALID_PARAMS, "Message argument is required")
+
+            # Execute the agent
+            user_context = {
+                "api_key_id": self.api_key_id,
+                "mcp_server_id": self.server_id,
+                "source": "mcp"
+            }
+
+            result = await self.agent_execution_service.execute_agent_chat(
+                agent_id=agent.agent_id,
+                message=message,
+                files=None,
+                search_params=None,
+                user_context=user_context,
+                db=session
+            )
+
+            # Format response
+            response_content = result.get("response", "")
+            if isinstance(response_content, dict):
+                response_text = json.dumps(response_content, indent=2)
+            else:
+                response_text = str(response_content)
+
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": response_text
+                    }
+                ],
+                "isError": False
+            }
+
+        except MCPError:
+            raise
+        except HTTPException as e:
+            raise MCPError(JSONRPCError.INTERNAL_ERROR, e.detail)
+        except Exception as e:
+            logger.error(f"Error executing tool {tool_name}: {str(e)}")
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"Error: {str(e)}"
+                    }
+                ],
+                "isError": True
+            }
+        finally:
+            session.close()
+
+    def _generate_tool_name(self, agent_name: str) -> str:
+        """Generate a valid MCP tool name from agent name"""
+        # Convert to lowercase, replace spaces with underscores
+        name = agent_name.lower().replace(" ", "_").replace("-", "_")
+        # Remove any non-alphanumeric characters except underscores
+        name = "".join(c if c.isalnum() or c == "_" else "" for c in name)
+        # Ensure it starts with a letter
+        if name and not name[0].isalpha():
+            name = "tool_" + name
+        return name or "unnamed_tool"
+
+    def _error_response(
+        self,
+        request_id: Any,
+        code: int,
+        message: str,
+        data: Any = None
+    ) -> Dict[str, Any]:
+        """Create a JSON-RPC error response"""
+        error = {
+            "code": code,
+            "message": message
+        }
+        if data is not None:
+            error["data"] = data
+
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": error
+        }

--- a/backend/mcp_handler/server_handler.py
+++ b/backend/mcp_handler/server_handler.py
@@ -6,7 +6,6 @@ Supports JSON-RPC 2.0 over HTTP with Streamable HTTP transport.
 """
 
 from typing import Any, Dict, Optional
-from datetime import datetime
 import json
 
 from fastapi import HTTPException

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -18,9 +18,11 @@ from .resource import Resource
 from .folder import Folder
 from .domain import Domain
 from .url import Url
+from .mcp_server import MCPServer, MCPServerAgent
 
 __all__ = [
     'User', 'App', 'AppCollaborator', 'APIKey',
     'AIService', 'EmbeddingService', 'OutputParser', 'MCPConfig', 'Silo',
-    'Agent', 'OCRAgent', 'Conversation', 'Repository', 'Resource', 'Folder', 'Domain', 'Url'
+    'Agent', 'OCRAgent', 'Conversation', 'Repository', 'Resource', 'Folder', 'Domain', 'Url',
+    'MCPServer', 'MCPServerAgent'
 ] 

--- a/backend/models/app.py
+++ b/backend/models/app.py
@@ -8,6 +8,7 @@ class App(Base):
     __tablename__ = 'App'
     app_id = Column(Integer, primary_key=True)
     name = Column(String(255))
+    slug = Column(String(100), unique=True, nullable=True)  # URL-safe identifier, system-wide unique
     agent_rate_limit = Column(Integer, default=0)
     max_file_size_mb = Column(Integer, default=0)
     agent_cors_origins = Column(String(1000))
@@ -32,6 +33,7 @@ class App(Base):
     silos = relationship('Silo', back_populates='app', lazy=True)
     ai_services = relationship('AIService', back_populates='app', lazy=True)
     embedding_services = relationship('EmbeddingService', back_populates='app', lazy=True)
+    mcp_servers = relationship('MCPServer', back_populates='app', lazy=True)
     
     def get_user_role(self, user_id):
         """Get the role of a user in this app"""

--- a/backend/models/mcp_server.py
+++ b/backend/models/mcp_server.py
@@ -1,0 +1,46 @@
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, DateTime, UniqueConstraint
+from sqlalchemy.orm import relationship
+from db.database import Base
+from datetime import datetime
+
+
+class MCPServerAgent(Base):
+    """Association table for MCP servers and agents exposed as tools"""
+    __tablename__ = 'mcp_server_agents'
+
+    server_id = Column(Integer, ForeignKey('MCPServer.server_id', ondelete='CASCADE'), primary_key=True)
+    agent_id = Column(Integer, ForeignKey('Agent.agent_id', ondelete='CASCADE'), primary_key=True)
+    tool_name_override = Column(String(100), nullable=True)  # Optional custom tool name
+    tool_description_override = Column(String(1000), nullable=True)  # Optional custom description
+
+    mcp_server = relationship('MCPServer', back_populates='agent_associations')
+    agent = relationship('Agent')
+
+
+class MCPServer(Base):
+    """MCP Server that exposes agents as MCP tools for external clients"""
+    __tablename__ = 'MCPServer'
+
+    server_id = Column(Integer, primary_key=True)
+    name = Column(String(100), nullable=False)
+    slug = Column(String(100), nullable=False)  # URL-safe identifier, unique within app
+    description = Column(String(1000), nullable=True)
+    is_active = Column(Boolean, default=True)
+    rate_limit = Column(Integer, default=0)  # Requests per minute, 0 = unlimited
+
+    create_date = Column(DateTime, default=datetime.now)
+    update_date = Column(DateTime, default=datetime.now, onupdate=datetime.now)
+
+    app_id = Column(Integer, ForeignKey('App.app_id', ondelete='CASCADE'), nullable=False)
+
+    # Relationships
+    app = relationship('App', back_populates='mcp_servers')
+    agent_associations = relationship('MCPServerAgent',
+                                      back_populates='mcp_server',
+                                      cascade='all, delete-orphan',
+                                      lazy='joined')
+
+    # Unique constraint: slug must be unique per app
+    __table_args__ = (
+        UniqueConstraint('app_id', 'slug', name='uq_mcp_server_app_slug'),
+    )

--- a/backend/repositories/mcp_server_repository.py
+++ b/backend/repositories/mcp_server_repository.py
@@ -1,0 +1,175 @@
+from typing import Optional, List
+from sqlalchemy.orm import Session, joinedload
+from models.mcp_server import MCPServer, MCPServerAgent
+from models.app import App
+
+
+class MCPServerRepository:
+
+    @staticmethod
+    def get_all_by_app_id(db: Session, app_id: int) -> List[MCPServer]:
+        """Get all MCP servers for a specific app"""
+        return db.query(MCPServer).filter(
+            MCPServer.app_id == app_id
+        ).order_by(MCPServer.name).all()
+
+    @staticmethod
+    def get_by_id(db: Session, server_id: int) -> Optional[MCPServer]:
+        """Get an MCP server by ID with eager loading of agents"""
+        return db.query(MCPServer).options(
+            joinedload(MCPServer.agent_associations)
+        ).filter(
+            MCPServer.server_id == server_id
+        ).first()
+
+    @staticmethod
+    def get_by_id_and_app_id(db: Session, server_id: int, app_id: int) -> Optional[MCPServer]:
+        """Get an MCP server by ID and app ID"""
+        return db.query(MCPServer).options(
+            joinedload(MCPServer.agent_associations)
+        ).filter(
+            MCPServer.server_id == server_id,
+            MCPServer.app_id == app_id
+        ).first()
+
+    @staticmethod
+    def get_by_slug(db: Session, app_slug: str, server_slug: str) -> Optional[MCPServer]:
+        """Get an MCP server by app slug and server slug"""
+        return db.query(MCPServer).join(App).options(
+            joinedload(MCPServer.agent_associations)
+        ).filter(
+            App.slug == app_slug,
+            MCPServer.slug == server_slug
+        ).first()
+
+    @staticmethod
+    def get_by_app_slug_and_server_id(db: Session, app_slug: str, server_id: int) -> Optional[MCPServer]:
+        """Get an MCP server by app slug and server ID (fallback)"""
+        return db.query(MCPServer).join(App).options(
+            joinedload(MCPServer.agent_associations)
+        ).filter(
+            App.slug == app_slug,
+            MCPServer.server_id == server_id
+        ).first()
+
+    @staticmethod
+    def slug_exists(db: Session, app_id: int, slug: str, exclude_server_id: Optional[int] = None) -> bool:
+        """Check if a slug already exists for this app"""
+        query = db.query(MCPServer).filter(
+            MCPServer.app_id == app_id,
+            MCPServer.slug == slug
+        )
+        if exclude_server_id:
+            query = query.filter(MCPServer.server_id != exclude_server_id)
+        return query.first() is not None
+
+    @staticmethod
+    def create(db: Session, server: MCPServer) -> MCPServer:
+        """Create a new MCP server"""
+        db.add(server)
+        db.commit()
+        db.refresh(server)
+        return server
+
+    @staticmethod
+    def update(db: Session, server: MCPServer) -> MCPServer:
+        """Update an existing MCP server"""
+        db.add(server)
+        db.commit()
+        db.refresh(server)
+        return server
+
+    @staticmethod
+    def delete(db: Session, server: MCPServer) -> None:
+        """Delete an MCP server"""
+        db.delete(server)
+        db.commit()
+
+    @staticmethod
+    def delete_by_id_and_app_id(db: Session, server_id: int, app_id: int) -> bool:
+        """Delete an MCP server by ID and app ID"""
+        server = MCPServerRepository.get_by_id_and_app_id(db, server_id, app_id)
+        if server:
+            MCPServerRepository.delete(db, server)
+            return True
+        return False
+
+    @staticmethod
+    def add_agent(db: Session, server_id: int, agent_id: int,
+                  tool_name_override: Optional[str] = None,
+                  tool_description_override: Optional[str] = None) -> MCPServerAgent:
+        """Add an agent to an MCP server"""
+        association = MCPServerAgent(
+            server_id=server_id,
+            agent_id=agent_id,
+            tool_name_override=tool_name_override,
+            tool_description_override=tool_description_override
+        )
+        db.add(association)
+        db.commit()
+        db.refresh(association)
+        return association
+
+    @staticmethod
+    def remove_agent(db: Session, server_id: int, agent_id: int) -> bool:
+        """Remove an agent from an MCP server"""
+        association = db.query(MCPServerAgent).filter(
+            MCPServerAgent.server_id == server_id,
+            MCPServerAgent.agent_id == agent_id
+        ).first()
+        if association:
+            db.delete(association)
+            db.commit()
+            return True
+        return False
+
+    @staticmethod
+    def clear_agents(db: Session, server_id: int) -> None:
+        """Remove all agents from an MCP server"""
+        db.query(MCPServerAgent).filter(
+            MCPServerAgent.server_id == server_id
+        ).delete()
+        db.commit()
+
+    @staticmethod
+    def update_agent_association(db: Session, server_id: int, agent_id: int,
+                                 tool_name_override: Optional[str] = None,
+                                 tool_description_override: Optional[str] = None) -> Optional[MCPServerAgent]:
+        """Update an agent association"""
+        association = db.query(MCPServerAgent).filter(
+            MCPServerAgent.server_id == server_id,
+            MCPServerAgent.agent_id == agent_id
+        ).first()
+        if association:
+            association.tool_name_override = tool_name_override
+            association.tool_description_override = tool_description_override
+            db.commit()
+            db.refresh(association)
+        return association
+
+
+class AppSlugRepository:
+    """Repository for App slug operations"""
+
+    @staticmethod
+    def get_by_slug(db: Session, slug: str) -> Optional[App]:
+        """Get an app by its slug"""
+        return db.query(App).filter(App.slug == slug).first()
+
+    @staticmethod
+    def slug_exists(db: Session, slug: str, exclude_app_id: Optional[int] = None) -> bool:
+        """Check if a slug already exists"""
+        query = db.query(App).filter(App.slug == slug)
+        if exclude_app_id:
+            query = query.filter(App.app_id != exclude_app_id)
+        return query.first() is not None
+
+    @staticmethod
+    def update_slug(db: Session, app_id: int, slug: str) -> Optional[App]:
+        """Update an app's slug"""
+        app = db.query(App).filter(App.app_id == app_id).first()
+        if app:
+            app.slug = slug
+            db.commit()
+            db.refresh(app)
+        return app

--- a/backend/routers/internal/apps.py
+++ b/backend/routers/internal/apps.py
@@ -31,6 +31,7 @@ from .ocr import ocr_router
 from .output_parsers import output_parsers_router
 from .repositories import repositories_router
 from .folders import folders_router
+from .mcp_servers import mcp_servers_router
 
 # Import logger
 from utils.logger import get_logger
@@ -59,6 +60,7 @@ apps_router.include_router(ocr_router, prefix="/{app_id}/ocr", tags=["OCR"])
 apps_router.include_router(output_parsers_router, prefix="/{app_id}/output-parsers", tags=["Output Parsers"])
 apps_router.include_router(repositories_router, prefix="/{app_id}/repositories", tags=["Repositories"])
 apps_router.include_router(folders_router, prefix="/{app_id}/repositories/{repository_id}/folders", tags=["Folders"])
+apps_router.include_router(mcp_servers_router, prefix="/{app_id}/mcp-servers", tags=["MCP Servers"])
 
 #HELPER FUNCTIONS
 

--- a/backend/routers/internal/mcp_servers.py
+++ b/backend/routers/internal/mcp_servers.py
@@ -1,0 +1,292 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from typing import List
+from lks_idprovider import AuthContext
+from sqlalchemy.orm import Session
+
+# Import schemas and auth
+from schemas.mcp_server_schemas import (
+    MCPServerListSchema,
+    MCPServerDetailSchema,
+    CreateMCPServerSchema,
+    UpdateMCPServerSchema,
+    AppSlugResponseSchema,
+    UpdateAppSlugSchema,
+)
+from .auth_utils import get_current_user_oauth
+from routers.controls.role_authorization import require_min_role, AppRole
+
+# Import database and service
+from db.database import get_db
+from services.mcp_server_service import MCPServerService, AppSlugService
+
+# Import logger
+from utils.logger import get_logger
+
+MCP_SERVER_NOT_FOUND_ERROR = "MCP server not found"
+
+logger = get_logger(__name__)
+
+mcp_servers_router = APIRouter()
+
+# ==================== MCP SERVER MANAGEMENT ====================
+
+
+@mcp_servers_router.get("/",
+                        summary="List MCP servers",
+                        tags=["MCP Servers"],
+                        response_model=List[MCPServerListSchema])
+async def list_mcp_servers(
+    app_id: int,
+    auth_context: AuthContext = Depends(get_current_user_oauth),
+    role: AppRole = Depends(require_min_role("viewer")),
+    db: Session = Depends(get_db)
+):
+    """
+    List all MCP servers for a specific app.
+    """
+    try:
+        return MCPServerService.list_mcp_servers(db, app_id)
+    except Exception as e:
+        logger.error(f"Error listing MCP servers for app {app_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error retrieving MCP servers: {str(e)}"
+        )
+
+
+@mcp_servers_router.get("/tool-agents",
+                        summary="List available tool agents",
+                        tags=["MCP Servers"])
+async def list_tool_agents(
+    app_id: int,
+    auth_context: AuthContext = Depends(get_current_user_oauth),
+    role: AppRole = Depends(require_min_role("viewer")),
+    db: Session = Depends(get_db)
+):
+    """
+    List all agents marked as tools that can be exposed via MCP servers.
+    """
+    try:
+        return MCPServerService.get_tool_agents(db, app_id)
+    except Exception as e:
+        logger.error(f"Error listing tool agents for app {app_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error retrieving tool agents: {str(e)}"
+        )
+
+
+# ==================== APP SLUG MANAGEMENT ====================
+# NOTE: These routes MUST be before /{server_id} to avoid routing conflicts
+
+
+@mcp_servers_router.get("/slug/info",
+                        summary="Get app slug info",
+                        tags=["App Slug"])
+async def get_app_slug_info(
+    app_id: int,
+    auth_context: AuthContext = Depends(get_current_user_oauth),
+    role: AppRole = Depends(require_min_role("viewer")),
+    db: Session = Depends(get_db)
+):
+    """
+    Get the current slug configuration for the app.
+    """
+    try:
+        slug_info = AppSlugService.get_app_slug_info(db, app_id)
+
+        if slug_info is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="App not found"
+            )
+
+        return slug_info
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting slug info for app {app_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error retrieving app slug: {str(e)}"
+        )
+
+
+@mcp_servers_router.put("/slug",
+                        summary="Update app slug",
+                        tags=["App Slug"],
+                        response_model=AppSlugResponseSchema)
+async def update_app_slug(
+    app_id: int,
+    slug_data: UpdateAppSlugSchema,
+    auth_context: AuthContext = Depends(get_current_user_oauth),
+    role: AppRole = Depends(require_min_role("administrator")),
+    db: Session = Depends(get_db)
+):
+    """
+    Update the app's URL slug.
+    """
+    try:
+        slug_info = AppSlugService.update_app_slug(db, app_id, slug_data.slug)
+
+        if slug_info is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="App not found"
+            )
+
+        return slug_info
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating slug for app {app_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error updating app slug: {str(e)}"
+        )
+
+
+# ==================== MCP SERVER CRUD ====================
+
+
+@mcp_servers_router.get("/{server_id}",
+                        summary="Get MCP server details",
+                        tags=["MCP Servers"],
+                        response_model=MCPServerDetailSchema)
+async def get_mcp_server(
+    app_id: int,
+    server_id: int,
+    auth_context: AuthContext = Depends(get_current_user_oauth),
+    role: AppRole = Depends(require_min_role("viewer")),
+    db: Session = Depends(get_db)
+):
+    """
+    Get detailed information about a specific MCP server.
+    """
+    try:
+        server_detail = MCPServerService.get_mcp_server_detail(db, app_id, server_id)
+
+        if server_detail is None and server_id != 0:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=MCP_SERVER_NOT_FOUND_ERROR
+            )
+
+        return server_detail
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error retrieving MCP server {server_id} for app {app_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error retrieving MCP server: {str(e)}"
+        )
+
+
+@mcp_servers_router.post("/",
+                         summary="Create MCP server",
+                         tags=["MCP Servers"],
+                         response_model=MCPServerDetailSchema,
+                         status_code=status.HTTP_201_CREATED)
+async def create_mcp_server(
+    app_id: int,
+    server_data: CreateMCPServerSchema,
+    auth_context: AuthContext = Depends(get_current_user_oauth),
+    role: AppRole = Depends(require_min_role("administrator")),
+    db: Session = Depends(get_db)
+):
+    """
+    Create a new MCP server.
+    """
+    try:
+        server = MCPServerService.create_mcp_server(db, app_id, server_data)
+
+        if server is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Failed to create MCP server"
+            )
+
+        return server
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error creating MCP server for app {app_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error creating MCP server: {str(e)}"
+        )
+
+
+@mcp_servers_router.put("/{server_id}",
+                        summary="Update MCP server",
+                        tags=["MCP Servers"],
+                        response_model=MCPServerDetailSchema)
+async def update_mcp_server(
+    app_id: int,
+    server_id: int,
+    server_data: UpdateMCPServerSchema,
+    auth_context: AuthContext = Depends(get_current_user_oauth),
+    role: AppRole = Depends(require_min_role("administrator")),
+    db: Session = Depends(get_db)
+):
+    """
+    Update an existing MCP server.
+    """
+    try:
+        server = MCPServerService.update_mcp_server(db, app_id, server_id, server_data)
+
+        if server is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=MCP_SERVER_NOT_FOUND_ERROR
+            )
+
+        return server
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating MCP server {server_id} for app {app_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error updating MCP server: {str(e)}"
+        )
+
+
+@mcp_servers_router.delete("/{server_id}",
+                           summary="Delete MCP server",
+                           tags=["MCP Servers"])
+async def delete_mcp_server(
+    app_id: int,
+    server_id: int,
+    auth_context: AuthContext = Depends(get_current_user_oauth),
+    role: AppRole = Depends(require_min_role("administrator")),
+    db: Session = Depends(get_db)
+):
+    """
+    Delete an MCP server.
+    """
+    try:
+        success = MCPServerService.delete_mcp_server(db, app_id, server_id)
+
+        if not success:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=MCP_SERVER_NOT_FOUND_ERROR
+            )
+
+        return {"message": "MCP server deleted successfully"}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting MCP server {server_id} for app {app_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error deleting MCP server: {str(e)}"
+        )

--- a/backend/routers/mcp/__init__.py
+++ b/backend/routers/mcp/__init__.py
@@ -1,0 +1,165 @@
+"""
+MCP (Model Context Protocol) Router
+
+Exposes MCP servers as HTTP endpoints for external clients like Claude Desktop and Cursor.
+Supports Streamable HTTP transport.
+"""
+
+from fastapi import APIRouter, Request, HTTPException, status
+from fastapi.responses import JSONResponse
+from typing import Any, Dict
+
+from mcp_handler.auth import authenticate_mcp_request, MCPAuthResult
+from mcp_handler.server_handler import MCPServerHandler
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+mcp_router = APIRouter()
+
+
+@mcp_router.post("/{app_slug}/{server_slug}")
+async def mcp_endpoint_by_slug(
+    app_slug: str,
+    server_slug: str,
+    request: Request
+):
+    """
+    MCP endpoint using human-readable slugs.
+
+    URL format: /mcp/v1/{app_slug}/{server_slug}
+
+    Example: /mcp/v1/my-app/my-server
+    """
+    return await _handle_mcp_request(request, app_slug, server_slug, by_id=False)
+
+
+@mcp_router.post("/id/{app_id}/{server_id}")
+async def mcp_endpoint_by_id(
+    app_id: str,
+    server_id: str,
+    request: Request
+):
+    """
+    MCP endpoint using IDs (fallback).
+
+    URL format: /mcp/v1/id/{app_id}/{server_id}
+
+    Example: /mcp/v1/id/1/2
+    """
+    return await _handle_mcp_request(request, app_id, server_id, by_id=True)
+
+
+async def _handle_mcp_request(
+    request: Request,
+    app_identifier: str,
+    server_identifier: str,
+    by_id: bool
+) -> JSONResponse:
+    """
+    Handle an MCP request.
+
+    Args:
+        request: FastAPI request
+        app_identifier: App slug or ID
+        server_identifier: Server slug or ID
+        by_id: Whether identifiers are IDs
+
+    Returns:
+        JSON-RPC response
+    """
+    # Authenticate the request
+    try:
+        auth_result: MCPAuthResult = authenticate_mcp_request(
+            request,
+            app_identifier,
+            server_identifier,
+            by_id
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"MCP auth error: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Authentication error"
+        )
+
+    # Parse request body
+    try:
+        body = await request.json()
+    except Exception as e:
+        logger.error(f"MCP parse error: {str(e)}")
+        return JSONResponse(
+            content={
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {
+                    "code": -32700,
+                    "message": "Parse error"
+                }
+            },
+            status_code=200  # JSON-RPC errors are returned with 200 status
+        )
+
+    # Create handler and process request
+    # Pass primitive IDs instead of ORM objects to avoid DetachedInstanceError
+    handler = MCPServerHandler(
+        server_id=auth_result.server_id,
+        server_name=auth_result.server_name,
+        app_id=auth_result.app_id,
+        api_key_id=auth_result.api_key_id
+    )
+
+    try:
+        response = await handler.handle_request(body)
+
+        # If response is None (notification), return 204 No Content
+        if response is None:
+            return JSONResponse(content=None, status_code=204)
+
+        return JSONResponse(content=response)
+
+    except Exception as e:
+        logger.error(f"MCP handler error: {str(e)}")
+        return JSONResponse(
+            content={
+                "jsonrpc": "2.0",
+                "id": body.get("id") if isinstance(body, dict) else None,
+                "error": {
+                    "code": -32603,
+                    "message": f"Internal error: {str(e)}"
+                }
+            }
+        )
+
+
+# SSE endpoint for Server-Sent Events (optional, for future streaming support)
+@mcp_router.get("/{app_slug}/{server_slug}/sse")
+async def mcp_sse_endpoint_by_slug(
+    app_slug: str,
+    server_slug: str,
+    request: Request
+):
+    """
+    SSE endpoint for MCP streaming (by slug).
+    """
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="SSE transport not yet implemented. Use HTTP POST for JSON-RPC."
+    )
+
+
+@mcp_router.get("/id/{app_id}/{server_id}/sse")
+async def mcp_sse_endpoint_by_id(
+    app_id: str,
+    server_id: str,
+    request: Request
+):
+    """
+    SSE endpoint for MCP streaming (by ID).
+    """
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="SSE transport not yet implemented. Use HTTP POST for JSON-RPC."
+    )

--- a/backend/schemas/mcp_server_schemas.py
+++ b/backend/schemas/mcp_server_schemas.py
@@ -1,0 +1,107 @@
+from pydantic import BaseModel, ConfigDict, Field
+from typing import Optional, List, Dict, Any
+from datetime import datetime
+
+
+# ==================== MCP SERVER SCHEMAS ====================
+
+class MCPServerAgentSchema(BaseModel):
+    """Schema for an agent associated with an MCP server"""
+    agent_id: int
+    agent_name: str
+    agent_description: Optional[str] = None
+    tool_name_override: Optional[str] = None
+    tool_description_override: Optional[str] = None
+    is_available: bool = True  # Whether the agent is still valid (exists and is_tool=True)
+    unavailable_reason: Optional[str] = None  # Reason if not available
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class MCPServerAgentInputSchema(BaseModel):
+    """Schema for adding/updating an agent in an MCP server"""
+    agent_id: int
+    tool_name_override: Optional[str] = None
+    tool_description_override: Optional[str] = None
+
+
+class MCPConnectionHintsSchema(BaseModel):
+    """Schema for MCP connection configuration hints"""
+    claude_desktop: Dict[str, Any]
+    cursor: Dict[str, Any]
+    curl_example: str
+    endpoint_url: str
+    endpoint_url_by_id: str
+
+
+class MCPServerListSchema(BaseModel):
+    """Schema for MCP server list items"""
+    server_id: int
+    name: str
+    slug: str
+    description: Optional[str] = None
+    is_active: bool
+    agent_count: int
+    endpoint_url: str
+    create_date: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class MCPServerDetailSchema(BaseModel):
+    """Schema for detailed MCP server information"""
+    server_id: int
+    name: str
+    slug: str
+    description: Optional[str] = None
+    is_active: bool
+    rate_limit: int
+    agents: List[MCPServerAgentSchema]
+    endpoint_url: str
+    endpoint_url_by_id: str
+    connection_hints: MCPConnectionHintsSchema
+    create_date: Optional[datetime] = None
+    update_date: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CreateMCPServerSchema(BaseModel):
+    """Schema for creating a new MCP server"""
+    name: str = Field(..., min_length=1, max_length=100)
+    slug: Optional[str] = Field(None, max_length=100)  # Auto-generated if not provided
+    description: Optional[str] = Field("", max_length=1000)
+    is_active: bool = True
+    rate_limit: int = Field(0, ge=0)  # 0 = unlimited
+    agent_ids: List[int] = []
+
+
+class UpdateMCPServerSchema(BaseModel):
+    """Schema for updating an MCP server"""
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    slug: Optional[str] = Field(None, max_length=100)
+    description: Optional[str] = Field(None, max_length=1000)
+    is_active: Optional[bool] = None
+    rate_limit: Optional[int] = Field(None, ge=0)
+    agent_ids: Optional[List[int]] = None
+
+
+class UpdateMCPServerAgentsSchema(BaseModel):
+    """Schema for updating the agents in an MCP server"""
+    agents: List[MCPServerAgentInputSchema]
+
+
+# ==================== APP SLUG SCHEMAS ====================
+
+class UpdateAppSlugSchema(BaseModel):
+    """Schema for updating an app's slug"""
+    slug: str = Field(..., min_length=1, max_length=100, pattern=r'^[a-z0-9-]+$')
+
+
+class AppSlugResponseSchema(BaseModel):
+    """Schema for app slug response"""
+    app_id: int
+    slug: Optional[str] = None
+    mcp_base_url: str
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/services/mcp_server_service.py
+++ b/backend/services/mcp_server_service.py
@@ -1,0 +1,456 @@
+from typing import Optional, List
+from models.mcp_server import MCPServer, MCPServerAgent
+from models.agent import Agent
+from models.app import App
+from repositories.mcp_server_repository import MCPServerRepository, AppSlugRepository
+from sqlalchemy.orm import Session
+from datetime import datetime
+import re
+import unicodedata
+from config import MCP_BASE_URL
+from schemas.mcp_server_schemas import (
+    MCPServerListSchema,
+    MCPServerDetailSchema,
+    MCPServerAgentSchema,
+    MCPConnectionHintsSchema,
+    CreateMCPServerSchema,
+    UpdateMCPServerSchema,
+    AppSlugResponseSchema,
+)
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class MCPServerService:
+
+    @staticmethod
+    def generate_slug(name: str) -> str:
+        """Generate a URL-safe slug from a name"""
+        # Normalize unicode characters
+        slug = unicodedata.normalize('NFKD', name)
+        # Convert to ASCII, ignore non-convertible characters
+        slug = slug.encode('ascii', 'ignore').decode('ascii')
+        # Convert to lowercase
+        slug = slug.lower()
+        # Replace spaces and underscores with hyphens
+        slug = re.sub(r'[\s_]+', '-', slug)
+        # Remove all non-alphanumeric characters except hyphens
+        slug = re.sub(r'[^a-z0-9-]', '', slug)
+        # Remove multiple consecutive hyphens
+        slug = re.sub(r'-+', '-', slug)
+        # Strip leading/trailing hyphens
+        slug = slug.strip('-')
+        # Limit length
+        slug = slug[:100]
+        return slug or 'server'
+
+    @staticmethod
+    def validate_slug(db: Session, app_id: int, slug: str, exclude_server_id: Optional[int] = None) -> bool:
+        """Check if a slug is valid and unique within the app"""
+        if not slug:
+            return False
+        if not re.match(r'^[a-z0-9-]+$', slug):
+            return False
+        if len(slug) > 100:
+            return False
+        return not MCPServerRepository.slug_exists(db, app_id, slug, exclude_server_id)
+
+    @staticmethod
+    def ensure_unique_slug(db: Session, app_id: int, base_slug: str, exclude_server_id: Optional[int] = None) -> str:
+        """Ensure the slug is unique by appending a number if needed"""
+        slug = base_slug
+        counter = 1
+        while MCPServerRepository.slug_exists(db, app_id, slug, exclude_server_id):
+            slug = f"{base_slug}-{counter}"
+            counter += 1
+            if counter > 100:  # Safety limit
+                slug = f"{base_slug}-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+                break
+        return slug
+
+    @staticmethod
+    def get_endpoint_url(app: App, server: MCPServer) -> str:
+        """Get the slug-based endpoint URL for an MCP server"""
+        if app.slug and server.slug:
+            return f"{MCP_BASE_URL}/mcp/v1/{app.slug}/{server.slug}"
+        return f"{MCP_BASE_URL}/mcp/v1/id/{app.app_id}/{server.server_id}"
+
+    @staticmethod
+    def get_endpoint_url_by_id(app: App, server: MCPServer) -> str:
+        """Get the ID-based (fallback) endpoint URL for an MCP server"""
+        return f"{MCP_BASE_URL}/mcp/v1/id/{app.app_id}/{server.server_id}"
+
+    @staticmethod
+    def get_connection_hints(app: App, server: MCPServer) -> MCPConnectionHintsSchema:
+        """Generate connection configuration hints for MCP clients"""
+        endpoint_url = MCPServerService.get_endpoint_url(app, server)
+        endpoint_url_by_id = MCPServerService.get_endpoint_url_by_id(app, server)
+
+        # Claude Desktop configuration (Streamable HTTP)
+        claude_desktop = {
+            "mcpServers": {
+                server.name.lower().replace(' ', '-'): {
+                    "url": endpoint_url,
+                    "headers": {
+                        "X-API-KEY": "<your-api-key>"
+                    }
+                }
+            }
+        }
+
+        # Cursor configuration
+        cursor = {
+            "mcpServers": {
+                server.name.lower().replace(' ', '-'): {
+                    "url": endpoint_url,
+                    "headers": {
+                        "X-API-KEY": "<your-api-key>"
+                    }
+                }
+            }
+        }
+
+        # Curl example for testing
+        curl_example = (
+            f'curl -X POST "{endpoint_url}" \\\n'
+            f'  -H "X-API-KEY: <your-api-key>" \\\n'
+            f'  -H "Content-Type: application/json" \\\n'
+            f'  -d \'{{"jsonrpc": "2.0", "method": "tools/list", "id": 1}}\''
+        )
+
+        return MCPConnectionHintsSchema(
+            claude_desktop=claude_desktop,
+            cursor=cursor,
+            curl_example=curl_example,
+            endpoint_url=endpoint_url,
+            endpoint_url_by_id=endpoint_url_by_id
+        )
+
+    @staticmethod
+    def list_mcp_servers(db: Session, app_id: int) -> List[MCPServerListSchema]:
+        """Get all MCP servers for a specific app as list items"""
+        app = db.query(App).filter(App.app_id == app_id).first()
+        if not app:
+            return []
+
+        servers = MCPServerRepository.get_all_by_app_id(db, app_id)
+
+        result = []
+        for server in servers:
+            agent_count = len(server.agent_associations) if server.agent_associations else 0
+            result.append(MCPServerListSchema(
+                server_id=server.server_id,
+                name=server.name,
+                slug=server.slug,
+                description=server.description,
+                is_active=server.is_active,
+                agent_count=agent_count,
+                endpoint_url=MCPServerService.get_endpoint_url(app, server),
+                create_date=server.create_date
+            ))
+
+        return result
+
+    @staticmethod
+    def get_mcp_server_detail(db: Session, app_id: int, server_id: int) -> Optional[MCPServerDetailSchema]:
+        """Get detailed information about a specific MCP server"""
+        app = db.query(App).filter(App.app_id == app_id).first()
+        if not app:
+            return None
+
+        if server_id == 0:
+            # New MCP server - return empty form data
+            return MCPServerDetailSchema(
+                server_id=0,
+                name="",
+                slug="",
+                description="",
+                is_active=True,
+                rate_limit=0,
+                agents=[],
+                endpoint_url="",
+                endpoint_url_by_id="",
+                connection_hints=MCPConnectionHintsSchema(
+                    claude_desktop={},
+                    cursor={},
+                    curl_example="",
+                    endpoint_url="",
+                    endpoint_url_by_id=""
+                ),
+                create_date=None,
+                update_date=None
+            )
+
+        server = MCPServerRepository.get_by_id_and_app_id(db, server_id, app_id)
+        if not server:
+            return None
+
+        # Build agent list with details and availability status
+        agents = []
+        for assoc in server.agent_associations:
+            agent = assoc.agent
+            if agent:
+                # Check if agent is still available (exists and is marked as tool)
+                is_available = agent.is_tool
+                unavailable_reason = None
+                if not agent.is_tool:
+                    unavailable_reason = "Agent is no longer marked as a tool"
+
+                agents.append(MCPServerAgentSchema(
+                    agent_id=agent.agent_id,
+                    agent_name=agent.name,
+                    agent_description=agent.description,
+                    tool_name_override=assoc.tool_name_override,
+                    tool_description_override=assoc.tool_description_override,
+                    is_available=is_available,
+                    unavailable_reason=unavailable_reason
+                ))
+            else:
+                # Agent was deleted - include placeholder info
+                agents.append(MCPServerAgentSchema(
+                    agent_id=assoc.agent_id,
+                    agent_name="[Deleted Agent]",
+                    agent_description=None,
+                    tool_name_override=assoc.tool_name_override,
+                    tool_description_override=assoc.tool_description_override,
+                    is_available=False,
+                    unavailable_reason="Agent has been deleted"
+                ))
+
+        return MCPServerDetailSchema(
+            server_id=server.server_id,
+            name=server.name,
+            slug=server.slug,
+            description=server.description,
+            is_active=server.is_active,
+            rate_limit=server.rate_limit,
+            agents=agents,
+            endpoint_url=MCPServerService.get_endpoint_url(app, server),
+            endpoint_url_by_id=MCPServerService.get_endpoint_url_by_id(app, server),
+            connection_hints=MCPServerService.get_connection_hints(app, server),
+            create_date=server.create_date,
+            update_date=server.update_date
+        )
+
+    @staticmethod
+    def create_mcp_server(
+        db: Session,
+        app_id: int,
+        data: CreateMCPServerSchema
+    ) -> Optional[MCPServerDetailSchema]:
+        """Create a new MCP server"""
+        app = db.query(App).filter(App.app_id == app_id).first()
+        if not app:
+            return None
+
+        # Generate or validate slug
+        if data.slug:
+            slug = MCPServerService.generate_slug(data.slug)
+        else:
+            slug = MCPServerService.generate_slug(data.name)
+
+        # Ensure unique slug within app
+        slug = MCPServerService.ensure_unique_slug(db, app_id, slug)
+
+        # Create server
+        server = MCPServer(
+            name=data.name,
+            slug=slug,
+            description=data.description or "",
+            is_active=data.is_active,
+            rate_limit=data.rate_limit,
+            app_id=app_id,
+            create_date=datetime.now(),
+            update_date=datetime.now()
+        )
+        server = MCPServerRepository.create(db, server)
+
+        # Add agent associations
+        if data.agent_ids:
+            for agent_id in data.agent_ids:
+                # Verify agent exists and belongs to this app and is a tool
+                agent = db.query(Agent).filter(
+                    Agent.agent_id == agent_id,
+                    Agent.app_id == app_id,
+                    Agent.is_tool == True
+                ).first()
+                if agent:
+                    MCPServerRepository.add_agent(db, server.server_id, agent_id)
+
+        # Refresh to get associations
+        db.refresh(server)
+
+        return MCPServerService.get_mcp_server_detail(db, app_id, server.server_id)
+
+    @staticmethod
+    def update_mcp_server(
+        db: Session,
+        app_id: int,
+        server_id: int,
+        data: UpdateMCPServerSchema
+    ) -> Optional[MCPServerDetailSchema]:
+        """Update an existing MCP server"""
+        server = MCPServerRepository.get_by_id_and_app_id(db, server_id, app_id)
+        if not server:
+            return None
+
+        # Update fields if provided
+        if data.name is not None:
+            server.name = data.name
+
+        if data.slug is not None:
+            slug = MCPServerService.generate_slug(data.slug)
+            if not MCPServerService.validate_slug(db, app_id, slug, server_id):
+                slug = MCPServerService.ensure_unique_slug(db, app_id, slug, server_id)
+            server.slug = slug
+
+        if data.description is not None:
+            server.description = data.description
+
+        if data.is_active is not None:
+            server.is_active = data.is_active
+
+        if data.rate_limit is not None:
+            server.rate_limit = data.rate_limit
+
+        server.update_date = datetime.now()
+        server = MCPServerRepository.update(db, server)
+
+        # Update agents if provided
+        if data.agent_ids is not None:
+            # Clear existing associations
+            MCPServerRepository.clear_agents(db, server_id)
+
+            # Add new associations
+            for agent_id in data.agent_ids:
+                # Verify agent exists and belongs to this app and is a tool
+                agent = db.query(Agent).filter(
+                    Agent.agent_id == agent_id,
+                    Agent.app_id == app_id,
+                    Agent.is_tool == True
+                ).first()
+                if agent:
+                    MCPServerRepository.add_agent(db, server.server_id, agent_id)
+
+        return MCPServerService.get_mcp_server_detail(db, app_id, server.server_id)
+
+    @staticmethod
+    def delete_mcp_server(db: Session, app_id: int, server_id: int) -> bool:
+        """Delete an MCP server"""
+        return MCPServerRepository.delete_by_id_and_app_id(db, server_id, app_id)
+
+    @staticmethod
+    def get_tool_agents(db: Session, app_id: int) -> List[dict]:
+        """Get all agents marked as tools for this app"""
+        agents = db.query(Agent).filter(
+            Agent.app_id == app_id,
+            Agent.is_tool == True
+        ).all()
+
+        return [
+            {
+                "agent_id": agent.agent_id,
+                "name": agent.name,
+                "description": agent.description
+            }
+            for agent in agents
+        ]
+
+    @staticmethod
+    def get_mcp_servers_using_agent(db: Session, agent_id: int) -> List[dict]:
+        """
+        Get all MCP servers that use a specific agent.
+        Used to warn users when unmarking/deleting an agent.
+        """
+        from models.mcp_server import MCPServerAgent
+
+        # Find all MCP server associations for this agent
+        associations = db.query(MCPServerAgent).filter(
+            MCPServerAgent.agent_id == agent_id
+        ).all()
+
+        servers = []
+        for assoc in associations:
+            server = assoc.mcp_server
+            if server:
+                servers.append({
+                    "server_id": server.server_id,
+                    "server_name": server.name,
+                    "app_id": server.app_id
+                })
+
+        return servers
+
+
+class AppSlugService:
+    """Service for App slug management"""
+
+    @staticmethod
+    def generate_slug(name: str) -> str:
+        """Generate a URL-safe slug from a name"""
+        return MCPServerService.generate_slug(name)
+
+    @staticmethod
+    def validate_slug(db: Session, slug: str, exclude_app_id: Optional[int] = None) -> bool:
+        """Check if a slug is valid and unique"""
+        if not slug:
+            return False
+        if not re.match(r'^[a-z0-9-]+$', slug):
+            return False
+        if len(slug) > 100:
+            return False
+        return not AppSlugRepository.slug_exists(db, slug, exclude_app_id)
+
+    @staticmethod
+    def ensure_unique_slug(db: Session, base_slug: str, exclude_app_id: Optional[int] = None) -> str:
+        """Ensure the slug is unique by appending a number if needed"""
+        slug = base_slug
+        counter = 1
+        while AppSlugRepository.slug_exists(db, slug, exclude_app_id):
+            slug = f"{base_slug}-{counter}"
+            counter += 1
+            if counter > 100:
+                slug = f"{base_slug}-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+                break
+        return slug
+
+    @staticmethod
+    def get_app_slug_info(db: Session, app_id: int) -> Optional[AppSlugResponseSchema]:
+        """Get app slug information"""
+        app = db.query(App).filter(App.app_id == app_id).first()
+        if not app:
+            return None
+
+        mcp_base_url = f"{MCP_BASE_URL}/mcp/v1"
+        if app.slug:
+            mcp_base_url = f"{MCP_BASE_URL}/mcp/v1/{app.slug}"
+
+        return AppSlugResponseSchema(
+            app_id=app.app_id,
+            slug=app.slug,
+            mcp_base_url=mcp_base_url
+        )
+
+    @staticmethod
+    def update_app_slug(db: Session, app_id: int, slug: str) -> Optional[AppSlugResponseSchema]:
+        """Update an app's slug"""
+        app = db.query(App).filter(App.app_id == app_id).first()
+        if not app:
+            return None
+
+        # Generate and validate slug
+        clean_slug = MCPServerService.generate_slug(slug)
+        if not AppSlugService.validate_slug(db, clean_slug, app_id):
+            clean_slug = AppSlugService.ensure_unique_slug(db, clean_slug, app_id)
+
+        app = AppSlugRepository.update_slug(db, app_id, clean_slug)
+        if not app:
+            return None
+
+        return AppSlugService.get_app_slug_info(db, app_id)
+
+    @staticmethod
+    def get_app_by_slug(db: Session, slug: str) -> Optional[App]:
+        """Get an app by its slug"""
+        return AppSlugRepository.get_by_slug(db, slug)

--- a/backend/services/mcp_server_service.py
+++ b/backend/services/mcp_server_service.py
@@ -1,5 +1,5 @@
 from typing import Optional, List
-from models.mcp_server import MCPServer, MCPServerAgent
+from models.mcp_server import MCPServer
 from models.agent import Agent
 from models.app import App
 from repositories.mcp_server_repository import MCPServerRepository, AppSlugRepository

--- a/frontend/src/core/ExtensibleBaseApp.tsx
+++ b/frontend/src/core/ExtensibleBaseApp.tsx
@@ -43,6 +43,9 @@ import StatsPage from '../pages/admin/StatsPage';
 import LoginPage from '../pages/LoginPage';
 import AuthSuccessPage from '../pages/AuthSuccessPage';
 import ProfilePage from '../pages/ProfilePage';
+import MCPServersPage from '../pages/MCPServersPage';
+import MCPServerFormPage from '../pages/MCPServerFormPage';
+import MCPServerDetailPage from '../pages/MCPServerDetailPage';
 
 interface ExtensibleBaseAppProps {
   config: LibraryConfig;
@@ -230,6 +233,31 @@ export const ExtensibleBaseApp: React.FC<ExtensibleBaseAppProps> = ({
                     <ProtectedLayoutRoute {...commonLayoutProps}>
                       <DomainDetailPage />
                     </ProtectedLayoutRoute>
+                } />
+
+                {/* MCP Servers routes */}
+                <Route path="/apps/:appId/mcp-servers" element={
+                  <ProtectedLayoutRoute {...commonLayoutProps}>
+                    <MCPServersPage />
+                  </ProtectedLayoutRoute>
+                } />
+
+                <Route path="/apps/:appId/mcp-servers/new" element={
+                  <ProtectedLayoutRoute {...commonLayoutProps}>
+                    <MCPServerFormPage />
+                  </ProtectedLayoutRoute>
+                } />
+
+                <Route path="/apps/:appId/mcp-servers/:serverId" element={
+                  <ProtectedLayoutRoute {...commonLayoutProps}>
+                    <MCPServerDetailPage />
+                  </ProtectedLayoutRoute>
+                } />
+
+                <Route path="/apps/:appId/mcp-servers/:serverId/edit" element={
+                  <ProtectedLayoutRoute {...commonLayoutProps}>
+                    <MCPServerFormPage />
+                  </ProtectedLayoutRoute>
                 } />
 
                 {/* App-specific settings routes */}

--- a/frontend/src/core/defaultNavigation.ts
+++ b/frontend/src/core/defaultNavigation.ts
@@ -43,6 +43,12 @@ export const defaultNavigation: NavigationConfig = {
       section: 'appNavigation'
     },
     {
+      path: '/apps/:appId/mcp-servers',
+      name: 'MCP Servers',
+      icon: '🔌',
+      section: 'appNavigation'
+    },
+    {
       path: '/apps/:appId/settings',
       name: 'App Settings',
       icon: '⚙️',

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -79,6 +79,94 @@ export interface MCPConfig {
   created_at: string;
 }
 
+// MCP Server types - for exposing agents as MCP tools
+export interface MCPServerAgent {
+  agent_id: number;
+  agent_name: string;
+  agent_description?: string;
+  tool_name_override?: string;
+  tool_description_override?: string;
+  is_available: boolean;  // Whether agent is still valid (exists and is_tool=true)
+  unavailable_reason?: string;  // Reason if not available
+}
+
+// Agent MCP usage info
+export interface AgentMCPUsage {
+  agent_id: number;
+  is_tool: boolean;
+  mcp_servers: Array<{
+    server_id: number;
+    server_name: string;
+    app_id: number;
+  }>;
+  used_in_mcp_servers: boolean;
+}
+
+export interface MCPConnectionHints {
+  claude_desktop: Record<string, unknown>;
+  cursor: Record<string, unknown>;
+  curl_example: string;
+  endpoint_url: string;
+  endpoint_url_by_id: string;
+}
+
+export interface MCPServer {
+  server_id: number;
+  name: string;
+  slug: string;
+  description?: string;
+  is_active: boolean;
+  rate_limit: number;
+  agent_count?: number;
+  endpoint_url: string;
+  endpoint_url_by_id?: string;
+  agents?: MCPServerAgent[];
+  connection_hints?: MCPConnectionHints;
+  create_date?: string;
+  update_date?: string;
+}
+
+export interface MCPServerListItem {
+  server_id: number;
+  name: string;
+  slug: string;
+  description?: string;
+  is_active: boolean;
+  agent_count: number;
+  endpoint_url: string;
+  create_date?: string;
+}
+
+export interface CreateMCPServer {
+  name: string;
+  slug?: string;
+  description?: string;
+  is_active?: boolean;
+  rate_limit?: number;
+  agent_ids?: number[];
+}
+
+export interface UpdateMCPServer {
+  name?: string;
+  slug?: string;
+  description?: string;
+  is_active?: boolean;
+  rate_limit?: number;
+  agent_ids?: number[];
+}
+
+export interface AppSlugInfo {
+  app_id: number;
+  slug?: string;
+  mcp_base_url: string;
+}
+
+export interface ToolAgent {
+  agent_id: number;
+  name: string;
+  description?: string;
+}
+
 export interface NavigationItem {
   path: string;
   name: string;

--- a/frontend/src/pages/MCPServerDetailPage.tsx
+++ b/frontend/src/pages/MCPServerDetailPage.tsx
@@ -1,0 +1,368 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { apiService } from '../services/api';
+import { useAppRole } from '../hooks/useAppRole';
+import { AppRole } from '../types/roles';
+import type { MCPServer } from '../core/types';
+
+function MCPServerDetailPage() {
+  const { appId, serverId } = useParams();
+  const navigate = useNavigate();
+  const { hasMinRole } = useAppRole(appId);
+  const canEdit = hasMinRole(AppRole.ADMINISTRATOR);
+
+  const [server, setServer] = useState<MCPServer | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedField, setCopiedField] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!appId || !serverId) return;
+    void loadServer();
+  }, [appId, serverId]);
+
+  async function loadServer() {
+    if (!appId || !serverId) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await apiService.getMCPServer(parseInt(appId), parseInt(serverId));
+      setServer(response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load MCP server');
+      console.error('Error loading MCP server:', err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm('Are you sure you want to delete this MCP server? This action cannot be undone.')) {
+      return;
+    }
+
+    if (!appId || !serverId) return;
+
+    try {
+      await apiService.deleteMCPServer(parseInt(appId), parseInt(serverId));
+      navigate(`/apps/${appId}/mcp-servers`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete MCP server');
+    }
+  }
+
+  function copyToClipboard(text: string, field: string) {
+    navigator.clipboard.writeText(text);
+    setCopiedField(field);
+    setTimeout(() => setCopiedField(null), 2000);
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">MCP Server Details</h1>
+            <p className="text-gray-600">Loading...</p>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-center py-12">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-yellow-600"></div>
+          <span className="ml-2">Loading MCP server...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !server) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">MCP Server Details</h1>
+          </div>
+        </div>
+
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="flex">
+            <span className="text-red-400 text-xl mr-3">!</span>
+            <div>
+              <h3 className="text-sm font-medium text-red-800">Error</h3>
+              <p className="text-sm text-red-600 mt-1">{error || 'MCP server not found'}</p>
+              <Link
+                to={`/apps/${appId}/mcp-servers`}
+                className="mt-2 text-sm text-red-800 hover:text-red-900 underline inline-block"
+              >
+                Back to MCP Servers
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="flex items-center space-x-3">
+            <h1 className="text-2xl font-bold text-gray-900">{server.name}</h1>
+            <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+              server.is_active
+                ? 'bg-green-100 text-green-800'
+                : 'bg-gray-100 text-gray-800'
+            }`}>
+              {server.is_active ? 'Active' : 'Inactive'}
+            </span>
+          </div>
+          <p className="text-gray-600">{server.description || 'No description'}</p>
+        </div>
+        <div className="flex space-x-2">
+          <Link
+            to={`/apps/${appId}/mcp-servers`}
+            className="px-4 py-2 text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg"
+          >
+            Back
+          </Link>
+          {canEdit && (
+            <>
+              <Link
+                to={`/apps/${appId}/mcp-servers/${serverId}/edit`}
+                className="px-4 py-2 text-white bg-yellow-600 hover:bg-yellow-700 rounded-lg"
+              >
+                Edit
+              </Link>
+              <button
+                onClick={handleDelete}
+                className="px-4 py-2 text-white bg-red-600 hover:bg-red-700 rounded-lg"
+              >
+                Delete
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Server Info */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Basic Info Card */}
+        <div className="bg-white rounded-lg shadow-md border p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Server Information</h2>
+          <dl className="space-y-3">
+            <div>
+              <dt className="text-sm text-gray-500">Slug</dt>
+              <dd className="text-sm font-medium text-gray-900">/{server.slug}</dd>
+            </div>
+            <div>
+              <dt className="text-sm text-gray-500">Rate Limit</dt>
+              <dd className="text-sm font-medium text-gray-900">
+                {server.rate_limit === 0 ? 'Unlimited' : `${server.rate_limit} requests/min`}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-sm text-gray-500">Created</dt>
+              <dd className="text-sm font-medium text-gray-900">
+                {server.create_date ? new Date(server.create_date).toLocaleString() : 'N/A'}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-sm text-gray-500">Last Updated</dt>
+              <dd className="text-sm font-medium text-gray-900">
+                {server.update_date ? new Date(server.update_date).toLocaleString() : 'N/A'}
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        {/* Agents Card */}
+        <div className="bg-white rounded-lg shadow-md border p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Exposed Agents ({server.agents?.length || 0})</h2>
+
+          {/* Warning for unavailable agents */}
+          {server.agents && server.agents.some(a => !a.is_available) && (
+            <div className="mb-4 bg-amber-50 border border-amber-200 rounded-lg p-3">
+              <div className="flex items-start">
+                <span className="text-amber-500 mr-2">!</span>
+                <div className="text-sm text-amber-800">
+                  <strong>Warning:</strong> Some agents are unavailable and won't be exposed as tools.
+                  They may have been deleted or unmarked as tools.
+                </div>
+              </div>
+            </div>
+          )}
+
+          {server.agents && server.agents.length > 0 ? (
+            <ul className="space-y-2">
+              {server.agents.map(agent => (
+                <li
+                  key={agent.agent_id}
+                  className={`flex items-start p-2 rounded ${
+                    agent.is_available ? 'bg-gray-50' : 'bg-red-50 border border-red-200'
+                  }`}
+                >
+                  <span className={`mr-2 ${agent.is_available ? 'text-purple-500' : 'text-red-400'}`}>
+                    {agent.is_available ? 'o' : '!'}
+                  </span>
+                  <div className="flex-1">
+                    <div className={`text-sm font-medium ${agent.is_available ? 'text-gray-900' : 'text-red-700'}`}>
+                      {agent.tool_name_override || agent.agent_name}
+                      {!agent.is_available && (
+                        <span className="ml-2 px-2 py-0.5 text-xs bg-red-100 text-red-700 rounded-full">
+                          Unavailable
+                        </span>
+                      )}
+                    </div>
+                    {agent.agent_description && (
+                      <div className="text-xs text-gray-500">{agent.agent_description}</div>
+                    )}
+                    {!agent.is_available && agent.unavailable_reason && (
+                      <div className="text-xs text-red-600 mt-1">
+                        Reason: {agent.unavailable_reason}
+                      </div>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-gray-500">No agents exposed yet.</p>
+          )}
+        </div>
+      </div>
+
+      {/* Endpoint URLs */}
+      <div className="bg-white rounded-lg shadow-md border p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Endpoint URLs</h2>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Primary Endpoint (slug-based)
+            </label>
+            <div className="flex items-center space-x-2">
+              <code className="flex-1 p-3 bg-gray-100 rounded-lg text-sm font-mono break-all">
+                {server.endpoint_url}
+              </code>
+              <button
+                onClick={() => copyToClipboard(server.endpoint_url, 'endpoint')}
+                className="px-3 py-2 text-sm bg-gray-200 hover:bg-gray-300 rounded-lg"
+              >
+                {copiedField === 'endpoint' ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+          </div>
+
+          {server.endpoint_url_by_id && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Fallback Endpoint (ID-based)
+              </label>
+              <div className="flex items-center space-x-2">
+                <code className="flex-1 p-3 bg-gray-100 rounded-lg text-sm font-mono break-all">
+                  {server.endpoint_url_by_id}
+                </code>
+                <button
+                  onClick={() => copyToClipboard(server.endpoint_url_by_id!, 'endpoint_id')}
+                  className="px-3 py-2 text-sm bg-gray-200 hover:bg-gray-300 rounded-lg"
+                >
+                  {copiedField === 'endpoint_id' ? 'Copied!' : 'Copy'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Connection Hints */}
+      {server.connection_hints && (
+        <div className="bg-white rounded-lg shadow-md border p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Connection Configuration</h2>
+
+          {/* Claude Desktop */}
+          <div className="mb-6">
+            <h3 className="text-md font-medium text-gray-800 mb-2">Claude Desktop</h3>
+            <p className="text-sm text-gray-600 mb-2">
+              Add this configuration to your Claude Desktop settings file
+              (<code className="text-xs bg-gray-100 px-1 rounded">claude_desktop_config.json</code>):
+            </p>
+            <div className="relative">
+              <pre className="p-4 bg-gray-900 text-green-400 rounded-lg text-sm overflow-x-auto">
+                {JSON.stringify(server.connection_hints.claude_desktop, null, 2)}
+              </pre>
+              <button
+                onClick={() => copyToClipboard(JSON.stringify(server.connection_hints!.claude_desktop, null, 2), 'claude')}
+                className="absolute top-2 right-2 px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-white rounded"
+              >
+                {copiedField === 'claude' ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+          </div>
+
+          {/* Cursor */}
+          <div className="mb-6">
+            <h3 className="text-md font-medium text-gray-800 mb-2">Cursor</h3>
+            <p className="text-sm text-gray-600 mb-2">
+              Add this to your Cursor MCP settings:
+            </p>
+            <div className="relative">
+              <pre className="p-4 bg-gray-900 text-green-400 rounded-lg text-sm overflow-x-auto">
+                {JSON.stringify(server.connection_hints.cursor, null, 2)}
+              </pre>
+              <button
+                onClick={() => copyToClipboard(JSON.stringify(server.connection_hints!.cursor, null, 2), 'cursor')}
+                className="absolute top-2 right-2 px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-white rounded"
+              >
+                {copiedField === 'cursor' ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+          </div>
+
+          {/* Curl Example */}
+          <div>
+            <h3 className="text-md font-medium text-gray-800 mb-2">Test with curl</h3>
+            <p className="text-sm text-gray-600 mb-2">
+              Test the MCP endpoint using curl:
+            </p>
+            <div className="relative">
+              <pre className="p-4 bg-gray-900 text-green-400 rounded-lg text-sm overflow-x-auto whitespace-pre-wrap">
+                {server.connection_hints.curl_example}
+              </pre>
+              <button
+                onClick={() => copyToClipboard(server.connection_hints!.curl_example, 'curl')}
+                className="absolute top-2 right-2 px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-white rounded"
+              >
+                {copiedField === 'curl' ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Authentication Note */}
+      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+        <div className="flex">
+          <span className="text-blue-400 text-xl mr-3">(i)</span>
+          <div>
+            <h3 className="text-sm font-medium text-blue-800">Authentication Required</h3>
+            <p className="text-sm text-blue-600 mt-1">
+              MCP endpoints require authentication. Use an API key from your app's API Keys settings
+              and include it in the <code className="bg-blue-100 px-1 rounded">X-API-KEY</code> header.
+            </p>
+            <Link
+              to={`/apps/${appId}/settings/api-keys`}
+              className="mt-2 text-sm text-blue-800 hover:text-blue-900 underline inline-block"
+            >
+              Manage API Keys
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MCPServerDetailPage;

--- a/frontend/src/pages/MCPServerFormPage.tsx
+++ b/frontend/src/pages/MCPServerFormPage.tsx
@@ -1,0 +1,336 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { apiService } from '../services/api';
+import type { MCPServer, ToolAgent } from '../core/types';
+
+function MCPServerFormPage() {
+  const { appId, serverId } = useParams();
+  const navigate = useNavigate();
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [toolAgents, setToolAgents] = useState<ToolAgent[]>([]);
+
+  // Form state
+  const [formData, setFormData] = useState({
+    name: '',
+    slug: '',
+    description: '',
+    is_active: true,
+    rate_limit: 0,
+    agent_ids: [] as number[],
+  });
+
+  const isEditing = serverId !== undefined && serverId !== 'new';
+
+  useEffect(() => {
+    if (!appId) {
+      setLoading(false);
+      return;
+    }
+
+    void loadData();
+  }, [appId, serverId, isEditing]);
+
+  async function loadData() {
+    if (!appId) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      // Load available tool agents
+      const agents = await apiService.getMCPServerToolAgents(parseInt(appId));
+      setToolAgents(agents);
+
+      // Load existing server if editing
+      if (isEditing && serverId) {
+        const server: MCPServer = await apiService.getMCPServer(parseInt(appId), parseInt(serverId));
+        setFormData({
+          name: server.name || '',
+          slug: server.slug || '',
+          description: server.description || '',
+          is_active: server.is_active ?? true,
+          rate_limit: server.rate_limit || 0,
+          agent_ids: server.agents?.map(a => a.agent_id) || [],
+        });
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load data');
+      console.error('Error loading data:', err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) {
+    const { name, value, type } = e.target;
+    const checked = (e.target as HTMLInputElement).checked;
+
+    setFormData(prev => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : type === 'number' ? parseInt(value) || 0 : value,
+    }));
+  }
+
+  function handleAgentToggle(agentId: number) {
+    setFormData(prev => ({
+      ...prev,
+      agent_ids: prev.agent_ids.includes(agentId)
+        ? prev.agent_ids.filter(id => id !== agentId)
+        : [...prev.agent_ids, agentId],
+    }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!appId) return;
+
+    try {
+      setSaving(true);
+      setError(null);
+
+      if (isEditing && serverId) {
+        await apiService.updateMCPServer(parseInt(appId), parseInt(serverId), formData);
+      } else {
+        await apiService.createMCPServer(parseInt(appId), formData);
+      }
+
+      navigate(`/apps/${appId}/mcp-servers`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save MCP server');
+      console.error('Error saving MCP server:', err);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleCancel() {
+    navigate(`/apps/${appId}/mcp-servers`);
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">
+              {isEditing ? 'Edit MCP Server' : 'Create MCP Server'}
+            </h1>
+            <p className="text-gray-600">Configure your MCP server settings</p>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-center py-12">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-yellow-600"></div>
+          <span className="ml-2">Loading...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">
+            {isEditing ? 'Edit MCP Server' : 'Create MCP Server'}
+          </h1>
+          <p className="text-gray-600">Configure your MCP server to expose agents as tools</p>
+        </div>
+        <button
+          onClick={handleCancel}
+          className="px-4 py-2 text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg"
+        >
+          Back
+        </button>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="flex">
+            <span className="text-red-400 text-xl mr-3">!</span>
+            <div>
+              <h3 className="text-sm font-medium text-red-800">Error</h3>
+              <p className="text-sm text-red-600 mt-1">{error}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* Basic Information */}
+        <div className="bg-white rounded-lg shadow-md border p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Basic Information</h2>
+
+          <div className="space-y-4">
+            <div>
+              <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-1">
+                Name *
+              </label>
+              <input
+                type="text"
+                id="name"
+                name="name"
+                value={formData.name}
+                onChange={handleInputChange}
+                required
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent"
+                placeholder="My MCP Server"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="slug" className="block text-sm font-medium text-gray-700 mb-1">
+                URL Slug
+              </label>
+              <div className="flex items-center">
+                <span className="text-gray-500 text-sm mr-2">/mcp/v1/app-slug/</span>
+                <input
+                  type="text"
+                  id="slug"
+                  name="slug"
+                  value={formData.slug}
+                  onChange={handleInputChange}
+                  className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent"
+                  placeholder="my-server (auto-generated if empty)"
+                  pattern="[a-z0-9-]+"
+                />
+              </div>
+              <p className="text-xs text-gray-500 mt-1">
+                URL-safe identifier. Use lowercase letters, numbers, and hyphens only.
+              </p>
+            </div>
+
+            <div>
+              <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
+                Description
+              </label>
+              <textarea
+                id="description"
+                name="description"
+                value={formData.description}
+                onChange={handleInputChange}
+                rows={3}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent"
+                placeholder="Describe what this MCP server does..."
+              />
+            </div>
+
+            <div className="flex items-center space-x-4">
+              <div className="flex items-center">
+                <input
+                  type="checkbox"
+                  id="is_active"
+                  name="is_active"
+                  checked={formData.is_active}
+                  onChange={handleInputChange}
+                  className="h-4 w-4 text-yellow-600 focus:ring-yellow-500 border-gray-300 rounded"
+                />
+                <label htmlFor="is_active" className="ml-2 text-sm text-gray-700">
+                  Active (server accepts requests)
+                </label>
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="rate_limit" className="block text-sm font-medium text-gray-700 mb-1">
+                Rate Limit (requests per minute)
+              </label>
+              <input
+                type="number"
+                id="rate_limit"
+                name="rate_limit"
+                value={formData.rate_limit}
+                onChange={handleInputChange}
+                min={0}
+                className="w-32 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent"
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                0 = unlimited
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Agent Selection */}
+        <div className="bg-white rounded-lg shadow-md border p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Select Agents to Expose</h2>
+          <p className="text-sm text-gray-600 mb-4">
+            Choose which agents (marked as tools) to expose through this MCP server.
+            These agents will be available as MCP tools for external clients.
+          </p>
+
+          {toolAgents.length === 0 ? (
+            <div className="text-center py-8 bg-gray-50 rounded-lg">
+              <div className="text-4xl mb-2">o</div>
+              <p className="text-gray-600">No agents marked as tools available.</p>
+              <p className="text-sm text-gray-500 mt-1">
+                Create an agent and enable "Use as Tool" to expose it via MCP.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-2 max-h-64 overflow-y-auto">
+              {toolAgents.map(agent => (
+                <label
+                  key={agent.agent_id}
+                  className={`flex items-start p-3 rounded-lg border cursor-pointer transition-colors ${
+                    formData.agent_ids.includes(agent.agent_id)
+                      ? 'bg-purple-50 border-purple-300'
+                      : 'bg-white border-gray-200 hover:bg-gray-50'
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={formData.agent_ids.includes(agent.agent_id)}
+                    onChange={() => handleAgentToggle(agent.agent_id)}
+                    className="h-4 w-4 text-purple-600 focus:ring-purple-500 border-gray-300 rounded mt-1"
+                  />
+                  <div className="ml-3">
+                    <div className="text-sm font-medium text-gray-900">{agent.name}</div>
+                    {agent.description && (
+                      <div className="text-xs text-gray-500 mt-1">{agent.description}</div>
+                    )}
+                  </div>
+                </label>
+              ))}
+            </div>
+          )}
+
+          <div className="mt-4 text-sm text-gray-500">
+            {formData.agent_ids.length} agent{formData.agent_ids.length !== 1 ? 's' : ''} selected
+          </div>
+        </div>
+
+        {/* Form Actions */}
+        <div className="flex justify-end space-x-4">
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="px-6 py-2 text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={saving || !formData.name}
+            className="px-6 py-2 text-white bg-yellow-600 hover:bg-yellow-700 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
+          >
+            {saving ? (
+              <>
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
+                Saving...
+              </>
+            ) : (
+              isEditing ? 'Update MCP Server' : 'Create MCP Server'
+            )}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default MCPServerFormPage;

--- a/frontend/src/pages/MCPServersPage.tsx
+++ b/frontend/src/pages/MCPServersPage.tsx
@@ -1,0 +1,269 @@
+import { useState, useEffect } from 'react';
+import { Link, useParams, useNavigate } from 'react-router-dom';
+import { apiService } from '../services/api';
+import ActionDropdown from '../components/ui/ActionDropdown';
+import Table from '../components/ui/Table';
+import { useAppRole } from '../hooks/useAppRole';
+import { AppRole } from '../types/roles';
+import ReadOnlyBanner from '../components/ui/ReadOnlyBanner';
+import type { MCPServerListItem } from '../core/types';
+
+function MCPServersPage() {
+  const { appId } = useParams();
+  const { hasMinRole, userRole } = useAppRole(appId);
+  const canEdit = hasMinRole(AppRole.ADMINISTRATOR);
+
+  const [servers, setServers] = useState<MCPServerListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedId, setCopiedId] = useState<number | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    loadServers();
+  }, [appId]);
+
+  async function loadServers() {
+    if (!appId) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await apiService.getMCPServers(parseInt(appId));
+      setServers(response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load MCP servers');
+      console.error('Error loading MCP servers:', err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleDelete(serverId: number) {
+    if (!confirm('Are you sure you want to delete this MCP server? This action cannot be undone.')) {
+      return;
+    }
+
+    if (!appId) return;
+
+    try {
+      await apiService.deleteMCPServer(parseInt(appId), serverId);
+      setServers(servers.filter(s => s.server_id !== serverId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete MCP server');
+      console.error('Error deleting MCP server:', err);
+    }
+  }
+
+  function copyToClipboard(text: string, serverId: number) {
+    navigator.clipboard.writeText(text);
+    setCopiedId(serverId);
+    setTimeout(() => setCopiedId(null), 2000);
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">MCP Servers</h1>
+            <p className="text-gray-600">Expose your agents as MCP tools for Claude Desktop, Cursor, and other clients</p>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-center py-12">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-yellow-600"></div>
+          <span className="ml-2">Loading MCP servers...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">MCP Servers</h1>
+            <p className="text-gray-600">Expose your agents as MCP tools for Claude Desktop, Cursor, and other clients</p>
+          </div>
+        </div>
+
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="flex">
+            <span className="text-red-400 text-xl mr-3">!</span>
+            <div>
+              <h3 className="text-sm font-medium text-red-800">Error Loading MCP Servers</h3>
+              <p className="text-sm text-red-600 mt-1">{error}</p>
+              <button
+                onClick={() => loadServers()}
+                className="mt-2 text-sm text-red-800 hover:text-red-900 underline"
+              >
+                Try again
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">MCP Servers</h1>
+          <p className="text-gray-600">Expose your agents as MCP tools for Claude Desktop, Cursor, and other clients</p>
+        </div>
+        {canEdit && (
+          <Link
+            to={`/apps/${appId}/mcp-servers/new`}
+            className="bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-2 rounded-lg flex items-center"
+          >
+            <span aria-hidden="true" className="mr-2">+</span>
+            <span>Create MCP Server</span>
+          </Link>
+        )}
+      </div>
+
+      {!canEdit && <ReadOnlyBanner userRole={userRole} minRole={AppRole.ADMINISTRATOR} />}
+
+      {/* MCP Servers List */}
+      {servers.length === 0 ? (
+        <div className="bg-white rounded-lg shadow-md border p-8 text-center">
+          <div className="text-6xl mb-4">-o-</div>
+          <h3 className="text-lg font-semibold text-gray-900 mb-2">No MCP Servers Yet</h3>
+          <p className="text-gray-600 mb-4">
+            Create an MCP server to expose your agents as tools for external MCP clients like Claude Desktop and Cursor.
+          </p>
+          {canEdit && (
+            <Link
+              to={`/apps/${appId}/mcp-servers/new`}
+              className="bg-yellow-600 hover:bg-yellow-700 text-white px-6 py-2 rounded-lg inline-flex items-center"
+            >
+              <span aria-hidden="true" className="mr-2">+</span>
+              <span>Create Your First MCP Server</span>
+            </Link>
+          )}
+        </div>
+      ) : (
+        <Table
+          data={servers}
+          keyExtractor={(server) => server.server_id.toString()}
+          columns={[
+            {
+              header: 'Name',
+              render: (server) => (
+                <div className="flex items-center">
+                  <div className="flex-shrink-0 h-10 w-10">
+                    <div className="h-10 w-10 rounded-lg bg-purple-100 flex items-center justify-center">
+                      <span className="text-purple-600 text-lg">-o-</span>
+                    </div>
+                  </div>
+                  <div className="ml-4">
+                    <div className="text-sm font-medium text-gray-900">
+                      <Link
+                        to={`/apps/${appId}/mcp-servers/${server.server_id}`}
+                        className="text-sm font-medium text-gray-900 hover:text-blue-600 transition-colors"
+                      >
+                        {server.name}
+                      </Link>
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      /{server.slug}
+                    </div>
+                  </div>
+                </div>
+              )
+            },
+            {
+              header: 'Status',
+              render: (server) => (
+                <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                  server.is_active
+                    ? 'bg-green-100 text-green-800'
+                    : 'bg-gray-100 text-gray-800'
+                }`}>
+                  {server.is_active ? 'Active' : 'Inactive'}
+                </span>
+              )
+            },
+            {
+              header: 'Agents',
+              render: (server) => (
+                <span className="text-sm text-gray-900">
+                  {server.agent_count} {server.agent_count === 1 ? 'agent' : 'agents'}
+                </span>
+              )
+            },
+            {
+              header: 'Endpoint',
+              render: (server) => (
+                <div className="flex items-center space-x-2">
+                  <code className="text-xs bg-gray-100 px-2 py-1 rounded truncate max-w-xs">
+                    {server.endpoint_url}
+                  </code>
+                  <button
+                    onClick={() => copyToClipboard(server.endpoint_url, server.server_id)}
+                    className="text-gray-400 hover:text-gray-600"
+                    title="Copy endpoint URL"
+                  >
+                    {copiedId === server.server_id ? (
+                      <span className="text-green-500">Done</span>
+                    ) : (
+                      <span>Copy</span>
+                    )}
+                  </button>
+                </div>
+              )
+            },
+            {
+              header: 'Created',
+              render: (server) => server.create_date ? new Date(server.create_date).toLocaleDateString() : 'N/A',
+              className: 'px-6 py-4 whitespace-nowrap text-sm text-gray-500'
+            },
+            {
+              header: 'Actions',
+              headerClassName: 'px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider',
+              className: 'px-6 py-4 whitespace-nowrap text-right text-sm font-medium',
+              render: (server) => (
+                <ActionDropdown
+                  actions={[
+                    {
+                      label: 'View Details',
+                      onClick: () => navigate(`/apps/${appId}/mcp-servers/${server.server_id}`),
+                      icon: '(i)',
+                      variant: 'primary'
+                    },
+                    ...(canEdit ? [
+                      {
+                        label: 'Edit',
+                        onClick: () => navigate(`/apps/${appId}/mcp-servers/${server.server_id}/edit`),
+                        icon: '*',
+                        variant: 'primary' as const
+                      },
+                      {
+                        label: 'Delete',
+                        onClick: () => { void handleDelete(server.server_id); },
+                        icon: 'x',
+                        variant: 'danger' as const
+                      }
+                    ] : [])
+                  ]}
+                  size="sm"
+                />
+              )
+            }
+          ]}
+          emptyIcon="-o-"
+          emptyMessage="No MCP Servers Yet"
+          emptySubMessage="Create an MCP server to expose your agents as tools."
+          loading={loading}
+        />
+      )}
+    </div>
+  );
+}
+
+export default MCPServersPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -184,6 +184,10 @@ class ApiService {
     });
   }
 
+  async getAgentMCPUsage(appId: number, agentId: number) {
+    return this.request(`/internal/apps/${appId}/agents/${agentId}/mcp-usage`);
+  }
+
   async updateAgentPrompt(appId: number, agentId: number, promptType: 'system' | 'template', prompt: string) {
     return this.request(`/internal/apps/${appId}/agents/${agentId}/update-prompt`, {
       method: 'POST',
@@ -322,6 +326,50 @@ class ApiService {
     return this.request(`/internal/apps/${appId}/mcp-configs/test-connection`, {
       method: 'POST',
       body: JSON.stringify(data),
+    });
+  }
+
+  // ==================== MCP SERVERS (Expose Agents as MCP Tools) ====================
+  async getMCPServers(appId: number) {
+    return this.request(`/internal/apps/${appId}/mcp-servers/`);
+  }
+
+  async getMCPServer(appId: number, serverId: number) {
+    return this.request(`/internal/apps/${appId}/mcp-servers/${serverId}`);
+  }
+
+  async createMCPServer(appId: number, data: any) {
+    return this.request(`/internal/apps/${appId}/mcp-servers/`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateMCPServer(appId: number, serverId: number, data: any) {
+    return this.request(`/internal/apps/${appId}/mcp-servers/${serverId}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteMCPServer(appId: number, serverId: number) {
+    return this.request(`/internal/apps/${appId}/mcp-servers/${serverId}`, {
+      method: 'DELETE',
+    });
+  }
+
+  async getMCPServerToolAgents(appId: number) {
+    return this.request(`/internal/apps/${appId}/mcp-servers/tool-agents`);
+  }
+
+  async getAppSlugInfo(appId: number) {
+    return this.request(`/internal/apps/${appId}/mcp-servers/slug/info`);
+  }
+
+  async updateAppSlug(appId: number, slug: string) {
+    return this.request(`/internal/apps/${appId}/mcp-servers/slug`, {
+      method: 'PUT',
+      body: JSON.stringify({ slug }),
     });
   }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                  
                                                                                                                                                                                              
  - Add MCP (Model Context Protocol) integration allowing users to expose agents as tools for external clients like Claude Desktop and Cursor                                                 
  - Implement complete backend with models, API endpoints, and JSON-RPC 2.0 protocol handler                                                                                                  
  - Add frontend pages for MCP server management with connection configuration hints                                                                                                          
  - Add agent availability tracking with user warnings when agents are deleted/unmarked                                                                                                       
                                                                                                                                                                                              
  ## Changes                                                                                                                                                                                  
                                                                                                                                                                                              
  ### Backend                                                                                                                                                                                 
  - New `MCPServer` and `MCPServerAgent` models with database migration                                                                                                                       
  - Add `slug` field to `App` model for human-readable URLs                                                                                                                                   
  - MCP protocol endpoint (`/mcp/v1/{app_slug}/{server_slug}`) with JSON-RPC 2.0                                                                                                              
  - API key and Bearer token authentication for MCP endpoints                                                                                                                                 
  - Endpoint to check agent MCP usage before delete/unmark                                                                                                                                    
                                                                                                                                                                                              
  ### Frontend                                                                                                                                                                                
  - MCP Servers list, detail, and form pages                                                                                                                                                  
  - App slug management in General Settings                                                                                                                                                   
  - Warnings when agents become unavailable in MCP servers                                                                                                                                    
  - Confirmation dialogs when modifying agents used in MCP servers                                                                                                                            
                                                                                                                                                                                              
  ## Test plan                                                                                                                                                                                
                                                                                                                                                                                              
  - [ ] Run database migration (`alembic upgrade head`)                                                                                                                                       
  - [ ] Create an MCP server and add tool agents                                                                                                                                              
  - [ ] Test connection with MCP Inspector using the provided endpoint URL                                                                                                                    
  - [ ] Verify connection hints work with Claude Desktop/Cursor                                                                                                                               
  - [ ] Test unmarking an agent as tool shows warning                                                                                                                                         
  - [ ] Test deleting an agent shows MCP usage warning                                                                                                                                        
                                                                                                                                                                                              
  🤖 Generated with [Claude Code](https://claude.ai/code)     