### PR TITLE
Fix OOM kill in K8s: replace per-request checkpointer connections with shared pool

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -75,16 +75,24 @@ async def lifespan(app: FastAPI):
                 "EntraID provider NOT initialized (development/testing only)"
             )
         
+        # Initialize checkpointer connection pool for LangGraph agent memory
+        from services.agent_cache_service import CheckpointerCacheService
+        await CheckpointerCacheService.initialize_pool()
+
         print("✅ Application startup complete")
     except Exception as e:
         logger.error(f"❌ Error during startup: {e}", exc_info=True)
         print(f"❌ Error during startup: {e}")
         raise
-    
+
     yield
-    
+
     # Shutdown
     try:
+        # Close checkpointer connection pool
+        from services.agent_cache_service import CheckpointerCacheService
+        await CheckpointerCacheService.close_pool()
+
         # Only shutdown provider if it was initialized (OIDC mode)
         if AuthConfig.LOGIN_MODE == "OIDC":
             await shutdown_provider()


### PR DESCRIPTION
Summary
Replace per-request AsyncConnection creation with a shared AsyncConnectionPool for the LangGraph checkpointer, eliminating the root cause of OOM kills in Kubernetes when calling memory-enabled agents
Remove the asyncio.run() + ThreadPoolExecutor pattern from agent chat execution, running directly on FastAPI's event loop instead
Set debug=False on create_react_agent to reduce memory overhead in production
Problem
Each request to a memory-enabled agent created a new event loop (asyncio.run()) inside a thread, which opened a new TCP connection to PostgreSQL for the checkpointer. These resources (event loop + psycopg connection + compiled LangGraph graph) weren't garbage-collected fast enough between requests. After just 2 calls, the accumulated memory exceeded the K8s pod limit, causing an OOM kill.

This only affected agents with has_memory=True because agents without memory skip the checkpointer entirely.

Changes
agent_cache_service.py: AsyncConnectionPool (min=2, max=10) created once at startup via initialize_pool(), single AsyncPostgresSaver instance reused across all requests
agentTools.py: create_agent() returns 3-tuple (removed checkpointer_cm), debug=False on graph creation
agent_execution_service.py: Removed _execute_langchain_agent sync bridge and asyncio.run(), agent execution now runs directly in FastAPI's event loop via await _execute_agent_async()
main.py: Pool init/close wired into FastAPI lifespan
