### PR TITLE
fix(backend): fix NoneType iterable error for non-conversational agents

### DIFF
--- a/.github/agents/alembic-expert.agent.md
+++ b/.github/agents/alembic-expert.agent.md
@@ -291,18 +291,39 @@ poetry run alembic upgrade <revision_id> --sql
 
 ### Plan Executor (`@plan-executor`)
 When your task originates from a plan execution step file (`/plans/<slug>/execution/step_NNN.md`):
-- **After completing the task**:
-  1. Append a `## Result` section to the step file with:
-     - `**Completed by**: @alembic-expert`
-     - `**Completed at**: YYYY-MM-DD`
-     - `**Status**: done | blocked | needs-revision`
-     - A summary of what migration was created, files changed, and any issues
-  2. **Update the status.yaml manifest** at `/plans/<slug>/execution/status.yaml`:
-     - Find the step in the `steps:` array by its `id` (e.g., `step_002`)
-     - Update the step's `status:` field to match (e.g., `done`, `blocked`, `needs-revision`)
-     - If status is `done`, add `completed_at: YYYY-MM-DD`
-     - Save the updated manifest
-- **Then** suggest the user invoke `@plan-executor` to continue with the next step
+
+> ⚠️ **Sub-agent constraint**: When invoked by `@plan-executor`, you do NOT have terminal access. You cannot run `poetry run alembic` commands. You must write migration files directly as file operations, and delegate all terminal commands back to plan-executor via a `## Terminal Commands Required` block in your Result.
+
+**How to handle migration creation as a sub-agent:**
+1. **Write the migration file manually**: Based on the model changes described in the step prompt, craft the migration file content directly (`alembic/versions/<revision_id>_<slug>.py`). Do NOT rely on autogenerate — write the `upgrade()` and `downgrade()` functions yourself from the model changes you know about.
+2. **Use the latest revision as `down_revision`**: Read the `alembic/versions/` directory to find the most recent migration file and use its revision ID as `down_revision`.
+3. **Generate a plausible revision ID**: Use a short hex string (e.g., `a1b2c3d4e5f6`) as the revision ID in the filename and in the migration file header.
+
+**After completing the task**:
+1. Append a `## Result` section to the step file with:
+   - `**Completed by**: @alembic-expert`
+   - `**Completed at**: YYYY-MM-DD`
+   - `**Status**: done | blocked | needs-revision`
+   - A summary of what migration was created, files changed, and any issues
+2. **Include a `## Terminal Commands Required` block** listing the exact commands plan-executor must run before staging the commit:
+   ```
+   ## Terminal Commands Required
+   Run these in order before committing:
+   1. poetry run alembic upgrade head
+   2. poetry run alembic downgrade -1
+   3. poetry run alembic upgrade head
+   ```
+   If the migration has issues that require autogenerate, include instead:
+   ```
+   ## Terminal Commands Required
+   Run autogenerate to produce the migration (the manually-written file is a draft):
+   1. poetry run alembic revision --autogenerate -m "<slug>"
+   2. Review generated file and remove the draft
+   3. poetry run alembic upgrade head
+   ```
+3. **Update the status.yaml manifest** at `/plans/<slug>/execution/status.yaml`:
+   - Find the step in the `steps:` array and update `status:` to `done` (or `blocked`/`needs-revision`)
+   - If `done`, add `completed_at: YYYY-MM-DD`
 - If the task cannot be completed, set status to `blocked` and explain why
 
 ## Companion Instruction File

--- a/.github/agents/backend-expert.agent.md
+++ b/.github/agents/backend-expert.agent.md
@@ -162,13 +162,23 @@ You are an expert Python backend developer with deep knowledge of modern backend
 7. **Testing**: Write unit and integration tests
 8. **Documentation**: Ensure OpenAPI docs are clear
 
+### Python Environment (Poetry)
+This project uses **Poetry** for dependency management. All Python commands must be run through the Poetry-managed virtual environment:
+```bash
+poetry run <command>     # Run any command in the venv
+poetry run uvicorn ...   # Start the dev server
+poetry run pytest ...    # Run tests
+poetry run alembic ...   # Run alembic (see @alembic-expert)
+```
+Never use bare `python`, `alembic`, `pytest`, or `uvicorn` commands unless you have already activated the venv manually via `poetry shell`.
+
 ### Database Development
 1. **Model Design**: Plan schema, relationships, constraints
 2. **Create Models**: Define SQLAlchemy models
-3. **Generate Migration**: `alembic revision --autogenerate -m "description"`
+3. **Generate Migration**: `poetry run alembic revision --autogenerate -m "description"`
 4. **Review Migration**: Check generated migration script
 5. **Test Migration**: Test on dev database
-6. **Apply Migration**: `alembic upgrade head`
+6. **Apply Migration**: `poetry run alembic upgrade head`
 7. **Repository Methods**: Implement CRUD operations
 
 ### Debugging Strategies

--- a/.github/agents/plan-executor.agent.md
+++ b/.github/agents/plan-executor.agent.md
@@ -204,7 +204,7 @@ When the user confirms a commit or returns after a pause:
 3. **Identify next actionable step**: Find the next `pending` step whose dependencies are all `done`.
 4. **Process next step**:
    - **Implementation step** (@backend-expert, @react-expert, @alembic-expert, @docs-manager): **Use the `agent` tool** with the agent's slug (no `@`) and the step's full task+context as the prompt. Wait for the result, append it to the step file's `## Result` section, update manifest to `done`, then proceed to commit confirmation. Do NOT describe what the agent will do — call the `agent` tool immediately.
-   - **Commit confirmation**: Run `git status` and `git diff --stat`, show the user the files and commit message, wait for confirmation before running `git add` + `git commit -S` + `git pull` + `git push`.
+   - **Commit confirmation**: Run `git status --porcelain` and `git add <specific files>` and `git diff --staged --name-status` **first**, then show the user the **actual** staged file list and commit message. Only after user confirmation run `git commit -S` + `git pull` + `git push`. See Section 5 for the full procedure.
 5. **Generate new steps if needed**: If fewer than 2 pending steps remain, generate the next 2-3 steps.
 6. **Continue until pause point**: After each confirmed commit, automatically invoke the next implementation step. Always pause before each commit.
 
@@ -230,40 +230,61 @@ Follow the procedure in `.github/instructions/.plan-extensions.instructions.md` 
 
 When a step file has a Result section appended by an implementation agent:
 
-- If status is `done`: Update manifest, move to next step.
+- If status is `done`: Check for a `## Terminal Commands Required` block (see below), then update manifest and move to commit confirmation.
 - If status is `blocked`: Explain the blocker, suggest resolution, potentially regenerate the step or create a fix-up step.
 - If status is `needs-revision`: Read the feedback, regenerate the step prompt with corrections, create a new step file (e.g., `step_NNN_retry.md`).
 
+#### Terminal Commands Required (sub-agent delegation)
+
+Some sub-agents (especially `@alembic-expert`) cannot execute terminal commands and will include a `## Terminal Commands Required` block in their Result. When you see this block:
+
+1. **Run each listed command in order** using your terminal access before proceeding to commit confirmation.
+2. **Check the output** — if any command fails, set the step to `blocked`, report the error, and do not commit.
+3. **Only after all commands succeed**, proceed to the commit confirmation flow (Section 5).
+
+Example block from `@alembic-expert`:
+```
+## Terminal Commands Required
+Run these in order before committing:
+1. poetry run alembic upgrade head
+2. poetry run alembic downgrade -1
+3. poetry run alembic upgrade head
+```
+You run these directly (you have terminal access, subagents do not).
+
 ### 5. Commit Confirmation Flow
 
-After every implementation step completes, pause and show the user what will be committed:
+After every implementation step completes, pause and show the user what will be committed. **You MUST execute all terminal commands first and use their actual output — never show placeholder text.**
 
-1. **Run `git status` and `git diff --stat`**: Identify which files the implementation agent created/modified.
-2. **Stage the relevant files**: `git add <specific files>` — only application files (`backend/`, `frontend/`, `alembic/`, `docs/`, etc.). **Never stage anything under `/plans/`.**
-3. **Compose commit message**: Use Conventional Commits format. For plan steps, include the body with `Plan:`, `Step:`, and `FR:` references.
-4. **Present to user**:
+1. **Run `git status --porcelain`**: Execute this terminal command NOW. Collect the actual output to identify which files were created or modified by the implementation agent.
+2. **Stage the relevant files**: `git add <specific files>` — only application files (`backend/`, `frontend/`, `alembic/`, `docs/`, etc.). **Never stage anything under `/plans/`.** Use the actual file paths from step 1.
+3. **Run `git diff --staged --name-status`**: Execute this terminal command to confirm exactly what is staged. Use its output for the "Files staged" section below.
+4. **Compose commit message**: Use Conventional Commits format derived from the step's FR and the work actually done. Include the body with `Plan:`, `Step:`, and `FR:` references using the real step number and FR identifiers.
+5. **Present to user — every value must be filled in from real command output and step context**:
 
 ```
 ⏸️  COMMIT CONFIRMATION — Step NNN [Extension-1 if applicable]
 ═══════════════════════════════════════════════════════════
 Files staged:
-  M  <file1>
-  A  <file2>
+  M  backend/models/agent.py       ← ACTUAL lines from git diff --staged --name-status
+  A  alembic/versions/abc123.py    ← never use placeholder text like <file1>
 
 Commit message:
-  type(scope): description
+  feat(backend): add visibility field to Agent model  ← ACTUAL message
 
-  Plan: <slug>
-  Step: NNN
-  FR: FR-N
+  Plan: agent-marketplace   ← ACTUAL plan slug
+  Step: 002                 ← ACTUAL step number
+  FR: FR-1                  ← ACTUAL FR reference
 
 Confirm? (yes / skip / abort)
 ═══════════════════════════════════════════════════════════
 ```
 
-5. **On "yes"**: Run `git commit -S -m "..."`, then `git pull origin <branch>`, then `git push origin <branch>`. Update manifest step to `done`. Proceed to next implementation step.
-6. **On "skip"**: Mark step as `done` without committing. Continue execution.
-7. **On "abort"**: Stop execution. Leave manifest in current state. User can resume later.
+> ⚠️ **Do NOT show placeholder text** (`<file1>`, `<description>`, `NNN`, `<slug>`, etc.) in the confirmation block. If a section would be empty, explain why (e.g., "No files were modified — the agent reported no changes") and offer skip or abort.
+
+6. **On "yes"**: Run `git commit -S -m "..."`, then `git pull origin <branch>`, then `git push origin <branch>`. Update manifest step to `done`. Proceed to next implementation step.
+7. **On "skip"**: Mark step as `done` without committing. Continue execution.
+8. **On "abort"**: Stop execution. Leave manifest in current state. User can resume later.
 
 ### 6. Completion
 

--- a/.github/agents/plan-executor.agent.md
+++ b/.github/agents/plan-executor.agent.md
@@ -203,7 +203,7 @@ When the user confirms a commit or returns after a pause:
 2. **Check for completed steps**: Scan all step files for appended Result sections that haven't been reflected in the manifest yet. Update the manifest accordingly.
 3. **Identify next actionable step**: Find the next `pending` step whose dependencies are all `done`.
 4. **Process next step**:
-   - **Implementation step** (@backend-expert, @react-expert, @alembic-expert, @docs-manager): Invoke directly, wait for result, update manifest to `done`, then proceed to commit confirmation.
+   - **Implementation step** (@backend-expert, @react-expert, @alembic-expert, @docs-manager): **Use the `agent` tool** with the agent's slug (no `@`) and the step's full task+context as the prompt. Wait for the result, append it to the step file's `## Result` section, update manifest to `done`, then proceed to commit confirmation. Do NOT describe what the agent will do — call the `agent` tool immediately.
    - **Commit confirmation**: Run `git status` and `git diff --stat`, show the user the files and commit message, wait for confirmation before running `git add` + `git commit -S` + `git pull` + `git push`.
 5. **Generate new steps if needed**: If fewer than 2 pending steps remain, generate the next 2-3 steps.
 6. **Continue until pause point**: After each confirmed commit, automatically invoke the next implementation step. Always pause before each commit.
@@ -466,18 +466,59 @@ FR: FR-1
 
 ## Delegatable Agents
 
-| Agent | When to Delegate | Invocation Mode |
-|-------|-----------------|-----------------|
-| `@backend-expert` | Models, schemas, services, repositories, routes | **Auto-invoke** (subagent, file ops) |
-| `@react-expert` | Pages, components, hooks, forms | **Auto-invoke** (subagent, file ops) |
-| `@alembic-expert` | Database migrations | **Auto-invoke** (subagent, file ops) |
-| `@docs-manager` | Documentation updates | **Auto-invoke** (subagent, file ops) |
+| Agent | Slug for Tool Call | When to Delegate |
+|-------|-------------------|-----------------|
+| `@backend-expert` | `backend-expert` | Models, schemas, services, repositories, routes |
+| `@react-expert` | `react-expert` | Pages, components, hooks, forms |
+| `@alembic-expert` | `alembic-expert` | Database migrations |
+| `@docs-manager` | `docs-manager` | Documentation updates |
 
 **Git operations** (branch creation, commits, push, PR creation) are handled **directly by this agent** using the `git-github` skill — no delegation needed.
 
 **Note**: Subagents (the four agents above) do not have terminal access. This means they handle only file operations. Git is handled by plan-executor itself.
 
 The `@test-expert` agent is **not included** for now.
+
+---
+
+## Subagent Invocation Mechanism
+
+### How to Actually Invoke a Subagent
+
+**CRITICAL**: Step files use `@react-expert` as a display label — that is documentation only. To actually run a subagent you MUST use the **`agent` tool** with the slug **without `@`**.
+
+When you process an implementation step whose `target_agent` is (for example) `@react-expert`, you must:
+
+1. Read the full task content from the step file
+2. **Immediately call the `agent` tool** with:
+   - Agent slug: `react-expert` (no `@`)
+   - Prompt: the complete task description from the step's `## Task` section (plus relevant context sections)
+3. Wait for the agent's response
+4. Update the step file's `## Result` section with the outcome
+5. Update `status.yaml`
+
+The mapping from step `target_agent` value → tool call slug:
+
+| `target_agent` in step file | `agent` tool slug to use |
+|----------------------------|--------------------------|
+| `@backend-expert` | `backend-expert` |
+| `@react-expert` | `react-expert` |
+| `@alembic-expert` | `alembic-expert` |
+| `@docs-manager` | `docs-manager` |
+
+### What "Auto-Invoke" Means
+
+"Auto-invoke" means: **in the same turn**, without asking the user, call the `agent` tool with the target agent's slug and the step's task as the prompt. Do NOT describe what the agent *should* do — actually invoke it.
+
+### What to Pass as the Prompt
+
+Pass the entire `## Task` section of the step file, followed by any `## Context` and `## Expected Outcome` sections. The subagent should receive a self-contained prompt that does not require reading the spec.
+
+### Do NOT
+
+- ❌ Describe the invocation without making the tool call ("I will now invoke @react-expert to…")
+- ❌ Use `@react-expert` (with `@`) as the agent slug in the tool call — this is display notation only
+- ❌ Skip the invocation and just update status.yaml to `done` without actually running the agent
 
 ## Skills
 
@@ -504,7 +545,7 @@ Project rules (signing, remotes, branch naming, `--body-file` rule) are in `.git
 - ✅ **Pause for commit confirmation** after every implementation step — show files + message before committing
 - ✅ Update `status.yaml` on every change
 - ✅ Reference specific files, patterns, and conventions from the Mattin AI codebase in step prompts
-- ✅ **Directly invoke** file-operation agents (@backend-expert, @react-expert, @alembic-expert, @docs-manager)
+- ✅ **Directly invoke** file-operation agents (@backend-expert, @react-expert, @alembic-expert, @docs-manager) — use the `agent` tool with the slug **without `@`** (e.g., `react-expert`) and the step's full task as the prompt; never just describe the invocation
 - ✅ **Run git commands directly** following the `git-github` skill
 - ✅ Check for and process results from invoked agents before proceeding to next steps
 - ✅ Map every step to its source FR and AC
@@ -525,6 +566,8 @@ Project rules (signing, remotes, branch naming, `--body-file` rule) are in `.git
 - ❌ Assume a step is done without a Result section in the step file
 - ❌ Commit without first showing the user the staged files and message
 - ❌ Stage or commit any file under `/plans/` — plan files never go into source control
+- ❌ Describe an agent invocation in text without actually calling the `agent` tool — "I will now invoke @react-expert" is NOT an invocation
+- ❌ Use `@agentname` (with `@`) as the agent slug in a tool call — slugs have no `@`
 
 ---
 

--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -1,7 +1,7 @@
 ---
 name: release-manager
 description: Expert in release workflow orchestration for Mattin AI. Handles version bumping, changelog updates, git tagging, branch merging, and GitHub release creation following GitFlow-style branching with develop and main.
-tools: [execute, read, edit]
+tools: [execute, agent, read, edit]
 agents: ["version-bumper", "oss-manager", "git-github"]
 ---
 

--- a/backend/services/agent_execution_service.py
+++ b/backend/services/agent_execution_service.py
@@ -263,7 +263,7 @@ class AgentExecutionService:
             }
             
         except Exception as e:
-            logger.error(f"Error executing agent chat: {str(e)}")
+            logger.error(f"Error executing agent chat: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Agent execution failed: {str(e)}")
 
     async def execute_agent_chat(
@@ -348,7 +348,7 @@ class AgentExecutionService:
             }
             
         except Exception as e:
-            logger.error(f"Error executing agent chat: {str(e)}")
+            logger.error(f"Error executing agent chat: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Agent execution failed: {str(e)}")
     
     async def execute_agent_ocr(

--- a/backend/tools/agentTools.py
+++ b/backend/tools/agentTools.py
@@ -276,7 +276,7 @@ async def create_agent(agent: Agent, search_params=None, session_id=None, user_c
             response_format=pydantic_model,
             tools=tools,
             checkpointer=checkpointer,
-            middleware=middleware if middleware else None,
+            middleware=middleware or (),
         )
     else:
         agent_chain = create_langchain_agent(
@@ -284,7 +284,7 @@ async def create_agent(agent: Agent, search_params=None, session_id=None, user_c
             system_prompt=system_prompt_content,
             tools=tools,
             checkpointer=checkpointer,
-            middleware=middleware if middleware else None,
+            middleware=middleware or (),
         )
 
     # Add logging for the created agent


### PR DESCRIPTION
## Summary

Fixes `'NoneType' object is not iterable` error that occurred when executing agents **not** marked as conversational (i.e. `has_memory=False`).

## Root Cause

In `agentTools.py`, `middleware` is initialized as an empty list `[]`. For non-conversational agents, no `SummarizationMiddleware` is appended, so it stays `[]`.

The `create_langchain_agent` calls used `middleware if middleware else None`, but `[]` is falsy in Python — so `None` was passed. LangChain's `create_agent` internally iterates over `middleware` to validate for duplicates, throwing `TypeError: 'NoneType' object is not iterable`.

## Fix

- `backend/tools/agentTools.py`: Changed `middleware if middleware else None` → `middleware or ()` in both `create_langchain_agent` calls. An empty tuple `()` is a valid `Sequence` that LangChain accepts.
- `backend/services/agent_execution_service.py`: Added `exc_info=True` to error logging in both `execute_agent_chat_with_file_refs` and `execute_agent_chat` for better traceback visibility.

## Testing

Verified the fix resolves the error for non-conversational agents. Existing tests unchanged.
