### PR TITLE
refactor(backend): extract public auth validation into service/repository

### DIFF
--- a/backend/repositories/api_key_repository.py
+++ b/backend/repositories/api_key_repository.py
@@ -1,7 +1,10 @@
 from typing import List, Optional
 from sqlalchemy.orm import Session
 from models.api_key import APIKey
+from models.app import App
 from utils.logger import get_logger
+from datetime import datetime
+from sqlalchemy.orm import joinedload
 
 logger = get_logger(__name__)
 
@@ -22,6 +25,30 @@ class APIKeyRepository:
             List of API keys
         """
         return db.query(APIKey).filter(APIKey.app_id == app_id).all()
+
+    @staticmethod
+    def get_active_by_app_and_key(db: Session, app_id: int, api_key: str) -> Optional[APIKey]:
+        """
+        Get an active API key by app and key value, including app owner relationship.
+
+        Args:
+            db: Database session
+            app_id: ID of the app
+            api_key: API key value
+
+        Returns:
+            API key or None if not found/active
+        """
+        return (
+            db.query(APIKey)
+            .options(joinedload(APIKey.app).joinedload(App.owner))
+            .filter(
+                APIKey.app_id == app_id,
+                APIKey.key == api_key,
+                APIKey.is_active.is_(True)
+            )
+            .first()
+        )
     
     @staticmethod
     def get_by_id_and_app(db: Session, key_id: int, app_id: int) -> Optional[APIKey]:
@@ -70,6 +97,25 @@ class APIKeyRepository:
         Returns:
             Updated API key
         """
+        db.add(api_key)
+        db.commit()
+        db.refresh(api_key)
+        return api_key
+
+    @staticmethod
+    def update_last_used_at(db: Session, api_key: APIKey, last_used_at: datetime) -> APIKey:
+        """
+        Update last used timestamp for an API key.
+
+        Args:
+            db: Database session
+            api_key: API key instance to update
+            last_used_at: Timestamp to set
+
+        Returns:
+            Updated API key
+        """
+        api_key.last_used_at = last_used_at
         db.add(api_key)
         db.commit()
         db.refresh(api_key)

--- a/backend/routers/public/v1/auth.py
+++ b/backend/routers/public/v1/auth.py
@@ -2,15 +2,13 @@ from fastapi import HTTPException, Depends, status
 from fastapi.security.api_key import APIKeyHeader
 from typing import Optional, Callable
 from pydantic import BaseModel
-from datetime import datetime
 
-from models.api_key import APIKey
-from models.app import App
-from models.user import User
 from db.database import SessionLocal
+from services.public_auth_service import PublicAuthService
 
 # API Key authentication using header
 api_key_header = APIKeyHeader(name="X-API-KEY", auto_error=False)
+public_auth_service = PublicAuthService()
 
 class APIKeyAuth(BaseModel):
     """API Key authentication result"""
@@ -44,36 +42,12 @@ def create_api_key_dependency(app_id: int) -> Callable:
         
         session = SessionLocal()
         try:
-            # Validate API key
-            api_key_obj = session.query(APIKey).filter(
-                APIKey.app_id == app_id,
-                APIKey.key == api_key,
-                APIKey.is_active == True
-            ).first()
-            
-            if not api_key_obj:
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid or inactive API key"
-                )
-            
-            # Check if the app owner is active
-            app = session.query(App).filter(App.app_id == app_id).first()
-            if app and app.owner:
-                if hasattr(app.owner, 'is_active') and not app.owner.is_active:
-                    raise HTTPException(
-                        status_code=status.HTTP_403_FORBIDDEN,
-                        detail="This API key belongs to a deactivated account"
-                    )
-            
-            # Update last used timestamp
-            api_key_obj.last_used_at = datetime.now()
-            session.commit()
+            api_key_obj = public_auth_service.validate_api_key_for_app(session, app_id, api_key)
             
             return APIKeyAuth(
                 app_id=app_id,
                 api_key=api_key,
-                api_key_obj=api_key_obj
+                key_id=api_key_obj.key_id
             )
         
         finally:
@@ -110,31 +84,7 @@ def validate_api_key_for_app(app_id: int, api_key: str) -> APIKeyAuth:
     """
     session = SessionLocal()
     try:
-        # Validate API key
-        api_key_obj = session.query(APIKey).filter(
-            APIKey.app_id == app_id,
-            APIKey.key == api_key,
-            APIKey.is_active == True
-        ).first()
-        
-        if not api_key_obj:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid or inactive API key for this app"
-            )
-        
-        # Check if the app owner is active
-        app = session.query(App).filter(App.app_id == app_id).first()
-        if app and app.owner:
-            if hasattr(app.owner, 'is_active') and not app.owner.is_active:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="This API key belongs to a deactivated account"
-                )
-        
-        # Update last used timestamp
-        api_key_obj.last_used_at = datetime.now()
-        session.commit()
+        api_key_obj = public_auth_service.validate_api_key_for_app(session, app_id, api_key)
         
         return APIKeyAuth(
             app_id=app_id,

--- a/backend/services/public_auth_service.py
+++ b/backend/services/public_auth_service.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from models.api_key import APIKey
+from repositories.api_key_repository import APIKeyRepository
+
+
+class PublicAuthService:
+    """Business logic for public API key authentication."""
+
+    def __init__(self, api_key_repository: APIKeyRepository | None = None):
+        self.api_key_repository = api_key_repository or APIKeyRepository()
+
+    def validate_api_key_for_app(self, db: Session, app_id: int, api_key: str) -> APIKey:
+        """
+        Validate API key for a specific app and update usage metadata.
+
+        Args:
+            db: Database session
+            app_id: The app ID to validate against
+            api_key: The API key value
+
+        Returns:
+            The validated API key ORM object
+
+        Raises:
+            HTTPException: If authentication fails
+        """
+        api_key_obj = self.api_key_repository.get_active_by_app_and_key(db, app_id, api_key)
+
+        if not api_key_obj:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or inactive API key for this app",
+            )
+
+        app_owner = api_key_obj.app.owner if api_key_obj.app else None
+        if app_owner and hasattr(app_owner, "is_active") and not app_owner.is_active:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="This API key belongs to a deactivated account",
+            )
+
+        self.api_key_repository.update_last_used_at(db, api_key_obj, datetime.now())
+        return api_key_obj

--- a/backend/tests/test_public_auth_router.py
+++ b/backend/tests/test_public_auth_router.py
@@ -1,0 +1,101 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException, status
+
+from routers.public.v1 import auth as auth_module
+
+
+class TestGetApiKeyAuthDependency:
+    def test_get_api_key_auth_requires_header(self):
+        with pytest.raises(HTTPException) as exc_info:
+            auth_module.get_api_key_auth(api_key=None)
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert "API key required" in exc_info.value.detail
+
+
+class TestValidateApiKeyForApp:
+    def test_validate_api_key_for_app_delegates_and_returns_model(self, mocker):
+        session = mocker.MagicMock()
+        api_key_obj = mocker.MagicMock()
+        api_key_obj.key_id = 42
+
+        mocker.patch.object(auth_module, "SessionLocal", return_value=session)
+        validate_mock = mocker.patch.object(
+            auth_module.public_auth_service,
+            "validate_api_key_for_app",
+            return_value=api_key_obj,
+        )
+
+        result = auth_module.validate_api_key_for_app(app_id=10, api_key="valid")
+
+        assert result.app_id == 10
+        assert result.api_key == "valid"
+        assert result.key_id == 42
+        validate_mock.assert_called_once_with(session, 10, "valid")
+        session.close.assert_called_once()
+
+    def test_validate_api_key_for_app_propagates_http_error(self, mocker):
+        session = mocker.MagicMock()
+        mocker.patch.object(auth_module, "SessionLocal", return_value=session)
+        mocker.patch.object(
+            auth_module.public_auth_service,
+            "validate_api_key_for_app",
+            side_effect=HTTPException(status_code=401, detail="Invalid"),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            auth_module.validate_api_key_for_app(app_id=10, api_key="invalid")
+
+        assert exc_info.value.status_code == 401
+        session.close.assert_called_once()
+
+
+class TestCreateApiKeyDependency:
+    def test_dependency_requires_header(self):
+        dependency = auth_module.create_api_key_dependency(app_id=10)
+
+        with pytest.raises(HTTPException) as exc_info:
+            dependency(api_key=None)
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert "API key required" in exc_info.value.detail
+
+    def test_dependency_delegates_and_returns_model(self, mocker):
+        dependency = auth_module.create_api_key_dependency(app_id=10)
+        session = mocker.MagicMock()
+        api_key_obj = mocker.MagicMock()
+        api_key_obj.key_id = 11
+
+        mocker.patch.object(auth_module, "SessionLocal", return_value=session)
+        validate_mock = mocker.patch.object(
+            auth_module.public_auth_service,
+            "validate_api_key_for_app",
+            return_value=api_key_obj,
+        )
+
+        result = dependency(api_key="abc")
+
+        assert result.app_id == 10
+        assert result.api_key == "abc"
+        assert result.key_id == 11
+        validate_mock.assert_called_once_with(session, 10, "abc")
+        session.close.assert_called_once()
+
+    def test_dependency_closes_session_on_http_error(self, mocker):
+        dependency = auth_module.create_api_key_dependency(app_id=10)
+        session = mocker.MagicMock()
+
+        mocker.patch.object(auth_module, "SessionLocal", return_value=session)
+        mocker.patch.object(
+            auth_module.public_auth_service,
+            "validate_api_key_for_app",
+            side_effect=HTTPException(status_code=403, detail="Disabled"),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            dependency(api_key="abc")
+
+        assert exc_info.value.status_code == 403
+        session.close.assert_called_once()

--- a/backend/tests/test_public_auth_service.py
+++ b/backend/tests/test_public_auth_service.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException, status
+
+from services.public_auth_service import PublicAuthService
+
+
+def make_api_key_record(*, key_id: int = 1, owner_active: bool = True):
+    owner = MagicMock()
+    owner.is_active = owner_active
+
+    app = MagicMock()
+    app.owner = owner
+
+    api_key_obj = MagicMock()
+    api_key_obj.key_id = key_id
+    api_key_obj.app = app
+    return api_key_obj
+
+
+class TestValidateApiKeyForApp:
+    def test_raises_401_when_api_key_is_invalid(self, mocker):
+        repo = mocker.MagicMock()
+        repo.get_active_by_app_and_key.return_value = None
+        service = PublicAuthService(api_key_repository=repo)
+
+        with pytest.raises(HTTPException) as exc_info:
+            service.validate_api_key_for_app(db=MagicMock(), app_id=10, api_key="invalid")
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert exc_info.value.detail == "Invalid or inactive API key for this app"
+        repo.update_last_used_at.assert_not_called()
+
+    def test_raises_403_when_owner_is_deactivated(self, mocker):
+        repo = mocker.MagicMock()
+        repo.get_active_by_app_and_key.return_value = make_api_key_record(owner_active=False)
+        service = PublicAuthService(api_key_repository=repo)
+
+        with pytest.raises(HTTPException) as exc_info:
+            service.validate_api_key_for_app(db=MagicMock(), app_id=10, api_key="valid")
+
+        assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+        assert exc_info.value.detail == "This API key belongs to a deactivated account"
+        repo.update_last_used_at.assert_not_called()
+
+    def test_updates_last_used_and_returns_api_key_when_valid(self, mocker):
+        api_key_obj = make_api_key_record(key_id=99, owner_active=True)
+        repo = mocker.MagicMock()
+        repo.get_active_by_app_and_key.return_value = api_key_obj
+        service = PublicAuthService(api_key_repository=repo)
+
+        result = service.validate_api_key_for_app(db=MagicMock(), app_id=10, api_key="valid")
+
+        assert result is api_key_obj
+        repo.update_last_used_at.assert_called_once()


### PR DESCRIPTION
## Summary
- Refactor public API auth flow to enforce layer separation for issue #111.
- Move API key validation and owner-active checks from router helper into a dedicated service.
- Extend API key repository with auth-specific lookup and last-used update methods.
- Add regression tests for service logic and router helper delegation/session handling.

## Files
- backend/routers/public/v1/auth.py
- backend/services/public_auth_service.py
- backend/repositories/api_key_repository.py
- backend/tests/test_public_auth_service.py
- backend/tests/test_public_auth_router.py

## Validation
- poetry run pytest backend/tests/test_public_auth_service.py backend/tests/test_public_auth_router.py -q (9 passed)

## Notes
- This is a focused vertical slice for #111 (public auth flow), preserving API behavior.
