### PR TITLE
refactor(backend): move repository/folder router data access into services

### DIFF
--- a/backend/repositories/media_repository.py
+++ b/backend/repositories/media_repository.py
@@ -19,6 +19,23 @@ class MediaRepository:
         return db.query(Media).filter(Media.repository_id == repository_id).all()
 
     @staticmethod
+    def list_by_repository_and_folder(
+        repository_id: int,
+        folder_id: Optional[int],
+        db: Session,
+    ) -> List[Media]:
+        """List media for a repository with optional folder filtering."""
+        query = db.query(Media).filter(Media.repository_id == repository_id)
+
+        if folder_id is not None:
+            if folder_id == 0:
+                query = query.filter(Media.folder_id.is_(None))
+            else:
+                query = query.filter(Media.folder_id == folder_id)
+
+        return query.order_by(Media.create_date.desc()).all()
+
+    @staticmethod
     def commit(db: Session) -> None:
         """
         Commit the current transaction

--- a/backend/routers/internal/folders.py
+++ b/backend/routers/internal/folders.py
@@ -50,15 +50,14 @@ async def get_root_folders(
     # TODO: Add app access validation
     
     try:
-        root_folders = FolderService.get_root_folders(repository_id, db)
+        root_folders_data = FolderService.get_root_folders_with_counts(repository_id, db)
         
         # Convert to schema format
         folder_items = []
-        for folder in root_folders:
-            # Get subfolder and resource counts
-            from repositories.folder_repository import FolderRepository
-            subfolder_count = len(FolderRepository.get_subfolders(db, folder.folder_id))
-            resource_count = len(folder.resources)
+        for item in root_folders_data:
+            folder = item["folder"]
+            subfolder_count = item["subfolder_count"]
+            resource_count = item["resource_count"]
             
             folder_item = FolderListItemSchema(
                 folder_id=folder.folder_id,

--- a/backend/routers/internal/repositories.py
+++ b/backend/routers/internal/repositories.py
@@ -517,17 +517,11 @@ async def list_media(
     auth_context: AuthContext = Depends(get_current_user_oauth)
 ):
     """List all media in repository"""
-    from models.media import Media
-    
-    query = db.query(Media).filter(Media.repository_id == repository_id)
-    
-    if folder_id is not None:
-        if folder_id == 0:
-            query = query.filter(Media.folder_id.is_(None))
-        else:
-            query = query.filter(Media.folder_id == folder_id)
-    
-    media_list = query.order_by(Media.create_date.desc()).all()
+    media_list = MediaService.list_media(
+        repository_id=repository_id,
+        folder_id=folder_id,
+        db=db,
+    )
     return [MediaResponse(**{k: v for k, v in m.__dict__.items() if not k.startswith('_')}) for m in media_list]
 
 @repositories_router.post("/{repository_id}/media/{media_id}/move",

--- a/backend/services/folder_service.py
+++ b/backend/services/folder_service.py
@@ -43,6 +43,34 @@ class FolderService:
             List of root Folder instances
         """
         return FolderRepository.get_by_repository_id(db, repository_id)
+
+    @staticmethod
+    def get_root_folders_with_counts(repository_id: int, db: Session) -> List[Dict[str, Any]]:
+        """
+        Get root folders plus subfolder/resource counts for list rendering.
+
+        Args:
+            repository_id: Repository ID
+            db: Database session
+
+        Returns:
+            List of dictionaries with folder and count metadata
+        """
+        root_folders = FolderRepository.get_by_repository_id(db, repository_id)
+        result = []
+
+        for folder in root_folders:
+            subfolder_count = len(FolderRepository.get_subfolders(db, folder.folder_id))
+            resource_count = len(folder.resources)
+            result.append(
+                {
+                    "folder": folder,
+                    "subfolder_count": subfolder_count,
+                    "resource_count": resource_count,
+                }
+            )
+
+        return result
     
     @staticmethod
     def get_folder_tree(repository_id: int, db: Session) -> List[Dict[str, Any]]:

--- a/backend/services/media_service.py
+++ b/backend/services/media_service.py
@@ -16,6 +16,19 @@ class MediaService:
     # Supported file extensions
     SUPPORTED_VIDEO_EXTENSIONS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.flv', '.wmv', '.mpeg', '.mpg'}
     SUPPORTED_AUDIO_EXTENSIONS = {'.mp3', '.wav', '.m4a', '.aac', '.ogg', '.flac', '.wma'}
+
+    @staticmethod
+    def list_media(
+        repository_id: int,
+        folder_id: Optional[int],
+        db: Session,
+    ) -> List[Media]:
+        """List media for a repository with optional folder filtering."""
+        return MediaRepository.list_by_repository_and_folder(
+            repository_id=repository_id,
+            folder_id=folder_id,
+            db=db,
+        )
     
     @staticmethod
     async def upload_media_files(

--- a/backend/tests/test_folder_service_root_folders.py
+++ b/backend/tests/test_folder_service_root_folders.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock
+
+from services.folder_service import FolderService
+
+
+class TestGetRootFoldersWithCounts:
+    def test_returns_folder_count_metadata(self, mocker):
+        folder_one = MagicMock()
+        folder_one.folder_id = 1
+        folder_one.resources = [MagicMock(), MagicMock()]
+
+        folder_two = MagicMock()
+        folder_two.folder_id = 2
+        folder_two.resources = []
+
+        mocker.patch(
+            "services.folder_service.FolderRepository.get_by_repository_id",
+            return_value=[folder_one, folder_two],
+        )
+
+        subfolders_map = {
+            1: [MagicMock()],
+            2: [MagicMock(), MagicMock(), MagicMock()],
+        }
+
+        def fake_get_subfolders(_db, folder_id):
+            return subfolders_map[folder_id]
+
+        mocker.patch(
+            "services.folder_service.FolderRepository.get_subfolders",
+            side_effect=fake_get_subfolders,
+        )
+
+        result = FolderService.get_root_folders_with_counts(repository_id=99, db=MagicMock())
+
+        assert len(result) == 2
+        assert result[0]["folder"] is folder_one
+        assert result[0]["subfolder_count"] == 1
+        assert result[0]["resource_count"] == 2
+        assert result[1]["folder"] is folder_two
+        assert result[1]["subfolder_count"] == 3
+        assert result[1]["resource_count"] == 0

--- a/backend/tests/test_media_service_list.py
+++ b/backend/tests/test_media_service_list.py
@@ -1,0 +1,30 @@
+from unittest.mock import MagicMock
+
+from services.media_service import MediaService
+
+
+class TestMediaServiceListMedia:
+    def test_list_media_delegates_to_repository(self, mocker):
+        db = MagicMock()
+        expected = [MagicMock(), MagicMock()]
+
+        list_mock = mocker.patch(
+            "services.media_service.MediaRepository.list_by_repository_and_folder",
+            return_value=expected,
+        )
+
+        result = MediaService.list_media(repository_id=10, folder_id=3, db=db)
+
+        assert result == expected
+        list_mock.assert_called_once_with(repository_id=10, folder_id=3, db=db)
+
+    def test_list_media_supports_root_folder_filter(self, mocker):
+        db = MagicMock()
+        list_mock = mocker.patch(
+            "services.media_service.MediaRepository.list_by_repository_and_folder",
+            return_value=[],
+        )
+
+        MediaService.list_media(repository_id=20, folder_id=0, db=db)
+
+        list_mock.assert_called_once_with(repository_id=20, folder_id=0, db=db)


### PR DESCRIPTION
## Summary
- Continue issue #111 with vertical slice 2: remove router-level data access from internal repositories/folders endpoints.
- Move repository media listing query logic into repository/service layers.
- Move root-folder count aggregation logic into folder service to remove router repository import.
- Keep endpoint behavior unchanged while enforcing layer separation.

## Files
- backend/repositories/media_repository.py
- backend/services/media_service.py
- backend/services/folder_service.py
- backend/routers/internal/repositories.py
- backend/routers/internal/folders.py
- backend/tests/test_media_service_list.py
- backend/tests/test_folder_service_root_folders.py

## Validation
- poetry run pytest backend/tests/test_media_service_list.py backend/tests/test_folder_service_root_folders.py -q (3 passed)

## Related
- Follow-up to issue #111 and complementary to PR #113.
