### PR TITLE
refactor(backend): move collaboration invite user lookups to service layer

### DIFF
--- a/backend/routers/internal/collaboration.py
+++ b/backend/routers/internal/collaboration.py
@@ -9,6 +9,7 @@ from db.database import get_db
 # Import services
 from services.app_collaboration_service import AppCollaborationService
 from services.app_service import AppService
+from services.user_service import UserService
 
 # Import schemas and auth
 from schemas.apps_schemas import (
@@ -32,6 +33,37 @@ collaboration_router = APIRouter()
 def get_services(db: Session) -> Tuple[AppService, AppCollaborationService]:
     """Get app and collaboration services instances."""
     return AppService(db), AppCollaborationService(db)
+
+
+def _serialize_user_summary(user) -> Optional[dict]:
+    """Convert a user object into the nested schema shape."""
+    if not user:
+        return None
+
+    return {
+        "user_id": user.user_id,
+        "email": user.email,
+        "name": user.name,
+    }
+
+
+def _build_collaborator_detail_schema(db: Session, app_id: int, collaboration) -> CollaboratorDetailSchema:
+    """Build collaborator detail response using service-layer user lookups."""
+    user_data = UserService.get_user_by_id(db, collaboration.user_id)
+    inviter_data = UserService.get_user_by_id(db, collaboration.invited_by)
+
+    return CollaboratorDetailSchema(
+        id=collaboration.id,
+        app_id=app_id,
+        user_id=collaboration.user_id,
+        role=collaboration.role.value,
+        status=collaboration.status.value,
+        invited_by=collaboration.invited_by,
+        invited_at=collaboration.invited_at,
+        accepted_at=collaboration.accepted_at,
+        user=_serialize_user_summary(user_data),
+        inviter=_serialize_user_summary(inviter_data),
+    )
 
 
 # ==================== COLLABORATION MANAGEMENT ====================
@@ -126,31 +158,8 @@ async def invite_collaborator(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to send invitation"
             )
-        
-        from models.user import User
-        user_data = db.query(User).filter(User.user_id == collaboration.user_id).first()
-        inviter_data = db.query(User).filter(User.user_id == collaboration.invited_by).first()
-        
-        return CollaboratorDetailSchema(
-            id=collaboration.id,
-            app_id=app_id,
-            user_id=collaboration.user_id,
-            role=collaboration.role.value,
-            status=collaboration.status.value,
-            invited_by=collaboration.invited_by,
-            invited_at=collaboration.invited_at,
-            accepted_at=collaboration.accepted_at,
-            user={
-                "user_id": user_data.user_id,
-                "email": user_data.email,
-                "name": user_data.name
-            } if user_data else None,
-            inviter={
-                "user_id": inviter_data.user_id,
-                "email": inviter_data.email,
-                "name": inviter_data.name
-            } if inviter_data else None
-        )
+
+        return _build_collaborator_detail_schema(db, app_id, collaboration)
         
     except ValueError as e:
         raise HTTPException(

--- a/backend/tests/test_collaboration_router_layer_separation.py
+++ b/backend/tests/test_collaboration_router_layer_separation.py
@@ -1,0 +1,48 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from routers.internal.collaboration import _build_collaborator_detail_schema, _serialize_user_summary
+
+
+def test_serialize_user_summary_returns_none_for_missing_user():
+    assert _serialize_user_summary(None) is None
+
+
+def test_build_collaborator_detail_schema_uses_user_service_for_nested_users():
+    db = MagicMock()
+    collaboration = SimpleNamespace(
+        id=5,
+        user_id=7,
+        role=SimpleNamespace(value="editor"),
+        status=SimpleNamespace(value="pending"),
+        invited_by=9,
+        invited_at=None,
+        accepted_at=None,
+    )
+    invited_user = SimpleNamespace(user_id=7, email="invitee@example.com", name="Invitee")
+    inviter_user = SimpleNamespace(user_id=9, email="owner@example.com", name="Owner")
+
+    with patch(
+        "routers.internal.collaboration.UserService.get_user_by_id",
+        side_effect=[invited_user, inviter_user],
+    ) as mock_get_user:
+        result = _build_collaborator_detail_schema(db, 42, collaboration)
+
+    assert result.app_id == 42
+    assert result.user_id == 7
+    assert result.role == "editor"
+    assert result.status == "pending"
+    assert result.user == {
+        "user_id": 7,
+        "email": "invitee@example.com",
+        "name": "Invitee",
+    }
+    assert result.inviter == {
+        "user_id": 9,
+        "email": "owner@example.com",
+        "name": "Owner",
+    }
+    assert mock_get_user.call_args_list == [
+        ((db, 7),),
+        ((db, 9),),
+    ]


### PR DESCRIPTION
## Summary

Vertical slice 5 of issue #111 — enforce backend layer separation in the collaboration invite flow.

This refactor removes direct user ORM lookups from the internal collaboration router and routes nested user/inviter resolution through the service layer.

## Changes

### Modified
- `backend/routers/internal/collaboration.py`
  - Added `_serialize_user_summary()` helper for nested user payloads
  - Added `_build_collaborator_detail_schema()` helper using `UserService.get_user_by_id`
  - Replaced direct `db.query(User)` lookups in `invite_collaborator`

### New
- `backend/tests/test_collaboration_router_layer_separation.py`
  - Tests nested user serialization
  - Tests collaborator detail schema building through `UserService.get_user_by_id`

## Validation

```bash
poetry run pytest backend/tests/test_collaboration_router_layer_separation.py -q
# 2 passed
```

## Related

Closes part of #111
Complementary to PR #113, PR #114, PR #115, and PR #116
