### PR TITLE
refactor(backend): move repository media listing to service and repository layers

### DIFF
--- a/backend/repositories/media_repository.py
+++ b/backend/repositories/media_repository.py
@@ -19,6 +19,23 @@ class MediaRepository:
         return db.query(Media).filter(Media.repository_id == repository_id).all()
 
     @staticmethod
+    def list_by_repository_and_folder(
+        repository_id: int,
+        folder_id: Optional[int],
+        db: Session,
+    ) -> List[Media]:
+        """List media for a repository with optional folder filtering."""
+        query = db.query(Media).filter(Media.repository_id == repository_id)
+
+        if folder_id is not None:
+            if folder_id == 0:
+                query = query.filter(Media.folder_id.is_(None))
+            else:
+                query = query.filter(Media.folder_id == folder_id)
+
+        return query.order_by(Media.create_date.desc()).all()
+
+    @staticmethod
     def commit(db: Session) -> None:
         """
         Commit the current transaction

--- a/backend/routers/internal/repositories.py
+++ b/backend/routers/internal/repositories.py
@@ -517,17 +517,7 @@ async def list_media(
     auth_context: AuthContext = Depends(get_current_user_oauth)
 ):
     """List all media in repository"""
-    from models.media import Media
-    
-    query = db.query(Media).filter(Media.repository_id == repository_id)
-    
-    if folder_id is not None:
-        if folder_id == 0:
-            query = query.filter(Media.folder_id.is_(None))
-        else:
-            query = query.filter(Media.folder_id == folder_id)
-    
-    media_list = query.order_by(Media.create_date.desc()).all()
+    media_list = MediaService.list_media(repository_id, folder_id, db)
     return [MediaResponse(**{k: v for k, v in m.__dict__.items() if not k.startswith('_')}) for m in media_list]
 
 @repositories_router.post("/{repository_id}/media/{media_id}/move",

--- a/backend/services/media_service.py
+++ b/backend/services/media_service.py
@@ -16,6 +16,15 @@ class MediaService:
     # Supported file extensions
     SUPPORTED_VIDEO_EXTENSIONS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.flv', '.wmv', '.mpeg', '.mpg'}
     SUPPORTED_AUDIO_EXTENSIONS = {'.mp3', '.wav', '.m4a', '.aac', '.ogg', '.flac', '.wma'}
+
+    @staticmethod
+    def list_media(
+        repository_id: int,
+        folder_id: Optional[int],
+        db: Session,
+    ) -> List[Media]:
+        """List media for a repository with optional folder filtering."""
+        return MediaRepository.list_by_repository_and_folder(repository_id, folder_id, db)
     
     @staticmethod
     async def upload_media_files(

--- a/backend/tests/test_media_service_list.py
+++ b/backend/tests/test_media_service_list.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock, patch
+
+from services.media_service import MediaService
+
+
+def test_list_media_delegates_to_repository():
+    db = MagicMock()
+    media_items = [MagicMock(), MagicMock()]
+
+    with patch(
+        "services.media_service.MediaRepository.list_by_repository_and_folder",
+        return_value=media_items,
+    ) as mock_repo:
+        result = MediaService.list_media(repository_id=12, folder_id=5, db=db)
+
+    assert result == media_items
+    mock_repo.assert_called_once_with(12, 5, db)
+
+
+def test_list_media_supports_root_folder_filter():
+    db = MagicMock()
+    media_items = [MagicMock()]
+
+    with patch(
+        "services.media_service.MediaRepository.list_by_repository_and_folder",
+        return_value=media_items,
+    ) as mock_repo:
+        result = MediaService.list_media(repository_id=12, folder_id=0, db=db)
+
+    assert result == media_items
+    mock_repo.assert_called_once_with(12, 0, db)


### PR DESCRIPTION
## Summary

Vertical slice 6 of issue #111 — enforce backend layer separation in repository media listing.

This refactor removes the direct `Media` ORM query from the internal repositories router and routes the listing flow through `MediaService` and `MediaRepository`.

## Changes

### New
- `backend/tests/test_media_service_list.py`
  - Verifies `MediaService.list_media()` delegates to the repository
  - Verifies root-folder filtering (`folder_id=0`) is passed through correctly

### Modified
- `backend/repositories/media_repository.py`
  - Added `list_by_repository_and_folder()`
- `backend/services/media_service.py`
  - Added `list_media()`
- `backend/routers/internal/repositories.py`
  - Updated `list_media` endpoint to delegate through `MediaService`

## Validation

```bash
poetry run pytest backend/tests/test_media_service_list.py -q
# 2 passed
```

## Related

Closes part of #111
Complementary to PR #113, PR #114, PR #115, PR #116, and PR #117
