### PR TITLE
refactor(backend): move apps usage app lookups to app service and repository layers

### DIFF
--- a/backend/repositories/app_repository.py
+++ b/backend/repositories/app_repository.py
@@ -15,6 +15,10 @@ class AppRepository:
     def get_by_id(self, app_id: int) -> Optional[App]:
         """Get a specific app by ID"""
         return self.db.query(App).filter(App.app_id == app_id).first()
+
+    def get_all(self) -> List[App]:
+        """Get all apps."""
+        return self.db.query(App).all()
     
     def get_by_owner(self, user_id: int) -> List[App]:
         """Get apps owned by a specific user ordered by creation date"""

--- a/backend/routers/internal/apps_usage.py
+++ b/backend/routers/internal/apps_usage.py
@@ -6,8 +6,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import List, Dict, Any
 
-from models.app import App
 from db.database import get_db
+from services.app_service import AppService
 from services.rate_limit_service import rate_limit_service
 from utils.logger import get_logger
 
@@ -26,7 +26,7 @@ async def get_apps_usage_stats(db: Session = Depends(get_db)) -> List[Dict[str, 
     """
     try:
         # Get all apps with their rate limits
-        apps = db.query(App).all()
+        apps = AppService(db).get_all_apps()
         
         usage_stats = []
         
@@ -74,7 +74,7 @@ async def get_app_usage_stats(
     """
     try:
         # Get app
-        app = db.query(App).filter(App.app_id == app_id).first()
+        app = AppService(db).get_app(app_id)
         if not app:
             raise HTTPException(
                 status_code=404,

--- a/backend/services/app_service.py
+++ b/backend/services/app_service.py
@@ -23,6 +23,10 @@ class AppService:
         """Get apps where user is an accepted collaborator"""
         return self.app_repo.get_collaborated_apps(user_id)
 
+    def get_all_apps(self) -> List[App]:
+        """Get all apps."""
+        return self.app_repo.get_all()
+
     def get_apps(self, user_id: int) -> List[App]:
         """Get all apps for a specific user (owned + collaborated) ordered by creation date"""
         return self.collaboration_repo.get_user_accessible_apps(user_id)

--- a/backend/tests/test_app_service_get_all_apps.py
+++ b/backend/tests/test_app_service_get_all_apps.py
@@ -1,0 +1,15 @@
+from unittest.mock import MagicMock
+
+from services.app_service import AppService
+
+
+def test_get_all_apps_delegates_to_repository():
+    db = MagicMock()
+    service = AppService(db)
+    apps = [MagicMock(), MagicMock()]
+    service.app_repo.get_all = MagicMock(return_value=apps)
+
+    result = service.get_all_apps()
+
+    assert result == apps
+    service.app_repo.get_all.assert_called_once_with()


### PR DESCRIPTION
## Summary

Vertical slice 7 of issue #111 — enforce backend layer separation in `apps_usage` router endpoints.

This change removes direct `App` ORM queries from router handlers and routes app retrieval through `AppService` and `AppRepository`.

## Changes

### Modified
- `backend/repositories/app_repository.py`
  - Added `get_all()` for fetching all apps
- `backend/services/app_service.py`
  - Added `get_all_apps()` delegating to repository
- `backend/routers/internal/apps_usage.py`
  - Replaced direct `db.query(App)` usage with `AppService(db).get_all_apps()` and `AppService(db).get_app(app_id)`

### New
- `backend/tests/test_app_service_get_all_apps.py`
  - Focused test verifying `AppService.get_all_apps()` delegates to repository

## Validation

```bash
poetry run pytest backend/tests/test_app_service_get_all_apps.py -q
# 1 passed
```

## Related

Closes part of #111
Complementary to PR #113, PR #114, PR #115, PR #116, PR #117, and PR #118
