### PR TITLE
feat(output-parser): add dict/JSON object as a supported field type

### DIFF
--- a/backend/schemas/export_schemas.py
+++ b/backend/schemas/export_schemas.py
@@ -60,7 +60,7 @@ class ExportOutputParserFieldSchema(BaseModel):
     """Output Parser field export schema"""
 
     name: str
-    type: str  # 'str', 'int', 'float', 'bool', 'date', 'list', 'parser'
+    type: str  # 'str', 'int', 'float', 'bool', 'date', 'list', 'dict', 'parser'
     description: str
     parser_name: Optional[str] = None  # For type='parser' (name-based reference)
     list_item_type: Optional[str] = None  # For type='list'

--- a/backend/schemas/output_parser_schemas.py
+++ b/backend/schemas/output_parser_schemas.py
@@ -17,7 +17,7 @@ class OutputParserListItemSchema(BaseModel):
 class OutputParserFieldSchema(BaseModel):
     """Schema for individual parser fields"""
     name: str
-    type: str  # 'str', 'int', 'float', 'bool', 'date', 'list', 'parser'
+    type: str  # 'str', 'int', 'float', 'bool', 'date', 'list', 'dict', 'parser'
     description: str
     parser_id: Optional[int] = None  # For type='parser'
     list_item_type: Optional[str] = None  # For type='list'

--- a/backend/tools/outputParserTools.py
+++ b/backend/tools/outputParserTools.py
@@ -88,7 +88,8 @@ def get_type_from_string(type_str: str, list_item_type: str = None, list_item_pa
         'int': int,
         'float': float,
         'bool': bool,
-        'date': date
+        'date': date,
+        'dict': Dict[str, Any]
     }
     
     if type_str == 'parser':

--- a/frontend/src/components/forms/FieldManager.tsx
+++ b/frontend/src/components/forms/FieldManager.tsx
@@ -22,6 +22,7 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
     { value: 'float', name: 'Float' },
     { value: 'bool', name: 'Boolean' },
     { value: 'date', name: 'Date' },
+    { value: 'dict', name: 'Dictionary (JSON Object)' },
     { value: 'list', name: 'List' },
     { value: 'parser', name: 'Parser Reference' }
   ];
@@ -79,6 +80,7 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
     { value: 'float', name: 'Float' },
     { value: 'bool', name: 'Boolean' },
     { value: 'date', name: 'Date' },
+    { value: 'dict', name: 'Dictionary (JSON Object)' },
     { value: 'parser', name: 'Parser Reference' }
   ];
 


### PR DESCRIPTION
﻿## Description
This PR adds support for `dict` (free-form JSON objects) as a first-class field type in output parsers, addressing the gap where unknown types silently fell back to `str`. 

## Changes Made
* **Backend**:
  * Updated `get_type_from_string()` in `backend/tools/outputParserTools.py` to map `'dict'` to `Dict[str, Any]`.
  * Updated schema comments in `backend/schemas/output_parser_schemas.py` and `backend/schemas/export_schemas.py` to document the new `dict` type.
* **Frontend**:
  * Added the `{ value: 'dict', name: 'Dictionary (JSON Object)' }` option to the main `fieldTypes` array in `frontend/src/components/forms/FieldManager.tsx`.
  * Included `dict` in the `getListItemTypes()` to enable lists of dictionaries (`List[Dict[str, Any]]`).

## Related Issue
Resolves https://github.com/lksnext-ai-lab/ai-core-tools/issues/137

## Acceptance Criteria Checklist
- [x] `'dict'` maps to `Dict[str, Any]` in `get_type_from_string()` in `outputParserTools.py`.
- [x] A field with `type: "dict"` in an output parser produces a valid Pydantic model field that accepts any JSON object.
- [x] An LLM response with a dict-typed field is correctly parsed and returned in the structured output.
- [x] The frontend field type selector shows "Dictionary (JSON Object)" as an option.
- [x] `dict` is available as a list item type (enabling `List[Dict[str, Any]]` fields).
- [x] Schema comments updated in `output_parser_schemas.py` and `export_schemas.py`.
- [x] Existing field types (`str`, `int`, `float`, `bool`, `date`, `list`, `parser`) are unaffected.
