### PR TITLE
refactor: unify agent execution pipeline

### DIFF
--- a/backend/mcp_handler/server_handler.py
+++ b/backend/mcp_handler/server_handler.py
@@ -250,13 +250,14 @@ class MCPServerHandler:
                 "source": "mcp"
             }
 
-            result = await self.agent_execution_service.execute_agent_chat(
+            result = await self.agent_execution_service.execute_agent_chat_with_file_refs(
                 agent_id=agent.agent_id,
                 message=message,
-                files=None,
+                file_references=None,
                 search_params=None,
                 user_context=user_context,
-                db=session
+                conversation_id=None,
+                db=session,
             )
 
             # Format response

--- a/backend/routers/internal/agents.py
+++ b/backend/routers/internal/agents.py
@@ -579,54 +579,6 @@ def _extract_jwt_token(request: Request) -> Optional[str]:
     return None
 
 
-async def _resolve_chat_file_refs(
-    files: Optional[List[UploadFile]],
-    parsed_file_references: Optional[list],
-    agent_id: int,
-    user_context: dict,
-    conversation_id: Optional[int],
-) -> List[FileReference]:
-    """Collect and resolve file references for a chat request."""
-    file_service = FileManagementService()
-    all_refs: List[FileReference] = []
-    uploaded_ids: set = set()
-
-    if files:
-        for upload_file in files:
-            if upload_file.filename:
-                file_ref = await file_service.upload_file(
-                    file=upload_file,
-                    agent_id=agent_id,
-                    user_context=user_context,
-                    conversation_id=conversation_id,
-                )
-                all_refs.append(file_ref)
-                uploaded_ids.add(file_ref.file_id)
-
-    existing_files = await file_service.list_attached_files(
-        agent_id=agent_id,
-        user_context=user_context,
-        conversation_id=str(conversation_id) if conversation_id else None,
-    )
-
-    if parsed_file_references:
-        requested_ids = set(parsed_file_references)
-        existing_files = [f for f in existing_files if f["file_id"] in requested_ids]
-        logger.info(f"Filtered to {len(existing_files)} files based on file_references")
-
-    for file_data in existing_files:
-        if file_data["file_id"] not in uploaded_ids:
-            all_refs.append(
-                FileReference(
-                    file_id=file_data["file_id"],
-                    filename=file_data["filename"],
-                    file_type=file_data["file_type"],
-                    content=file_data["content"],
-                    file_path=file_data.get("file_path"),
-                )
-            )
-
-    return all_refs
 
 
 async def _save_uploaded_file(upload_file: UploadFile) -> str:
@@ -711,11 +663,15 @@ async def chat_with_agent(
             "token": jwt_token,
         }
 
-        all_file_references = await _resolve_chat_file_refs(
-            files, parsed_file_references, agent_id, user_context, conversation_id
+        all_file_references = await FileManagementService().resolve_chat_files(
+            files=files,
+            file_reference_ids=parsed_file_references,
+            agent_id=agent_id,
+            user_context=user_context,
+            conversation_id=conversation_id,
         )
 
-        execution_service = AgentExecutionService(db)
+        execution_service = AgentExecutionService()
         result = await execution_service.execute_agent_chat_with_file_refs(
             agent_id=agent_id,
             message=message,
@@ -784,8 +740,12 @@ async def chat_with_agent_stream(
             "token": jwt_token,
         }
 
-        all_file_references = await _resolve_chat_file_refs(
-            files, parsed_file_references, agent_id, user_context, conversation_id
+        all_file_references = await FileManagementService().resolve_chat_files(
+            files=files,
+            file_reference_ids=parsed_file_references,
+            agent_id=agent_id,
+            user_context=user_context,
+            conversation_id=conversation_id,
         )
 
         streaming_service = AgentStreamingService(db)
@@ -846,7 +806,7 @@ async def reset_conversation(
         }
 
         # Use unified service layer
-        execution_service = AgentExecutionService(db)
+        execution_service = AgentExecutionService()
         success = await execution_service.reset_agent_conversation(
             agent_id=agent_id,
             user_context=user_context,
@@ -896,7 +856,7 @@ async def get_conversation_history(
         }
         
         # Use unified service layer
-        execution_service = AgentExecutionService(db)
+        execution_service = AgentExecutionService()
         messages = await execution_service.get_conversation_history(
             agent_id=agent_id,
             user_context=user_context,

--- a/backend/routers/internal/marketplace.py
+++ b/backend/routers/internal/marketplace.py
@@ -510,53 +510,6 @@ def _extract_jwt_token(request: Request) -> Optional[str]:
     return None
 
 
-async def _collect_file_references(
-    files: Optional[List[UploadFile]],
-    parsed_file_references: Optional[list],
-    agent_id: int,
-    conversation_id: int,
-    user_context: Dict,
-) -> List[FileReference]:
-    """Upload new files and merge with existing file references."""
-    file_service = FileManagementService()
-    all_refs: List[FileReference] = []
-    uploaded_ids: set = set()
-
-    if files:
-        for upload_file in files:
-            if upload_file.filename:
-                ref = await file_service.upload_file(
-                    file=upload_file,
-                    agent_id=agent_id,
-                    user_context=user_context,
-                    conversation_id=conversation_id,
-                )
-                all_refs.append(ref)
-                uploaded_ids.add(ref.file_id)
-
-    existing_files = await file_service.list_attached_files(
-        agent_id=agent_id,
-        user_context=user_context,
-        conversation_id=str(conversation_id),
-    )
-
-    if parsed_file_references:
-        requested_ids = set(parsed_file_references)
-        existing_files = [f for f in existing_files if f["file_id"] in requested_ids]
-
-    for file_data in existing_files:
-        if file_data["file_id"] not in uploaded_ids:
-            all_refs.append(
-                FileReference(
-                    file_id=file_data["file_id"],
-                    filename=file_data["filename"],
-                    file_type=file_data["file_type"],
-                    content=file_data["content"],
-                    file_path=file_data.get("file_path"),
-                )
-            )
-
-    return all_refs
 
 
 def _validate_marketplace_agent(agent: Optional[Agent]) -> None:
@@ -633,15 +586,15 @@ async def marketplace_chat(
             "token": jwt_token,
         }
 
-        all_file_references = await _collect_file_references(
+        all_file_references = await FileManagementService().resolve_chat_files(
             files=files,
-            parsed_file_references=parsed_refs,
+            file_reference_ids=parsed_refs,
             agent_id=agent.agent_id,
-            conversation_id=conversation_id,
             user_context=user_context,
+            conversation_id=conversation_id,
         )
 
-        execution_service = AgentExecutionService(db)
+        execution_service = AgentExecutionService()
         result = await execution_service.execute_agent_chat_with_file_refs(
             agent_id=agent.agent_id,
             message=message,

--- a/backend/routers/internal/ocr.py
+++ b/backend/routers/internal/ocr.py
@@ -47,7 +47,7 @@ async def process_ocr_internal(
         }
         
         # Use unified service layer
-        execution_service = AgentExecutionService(db)
+        execution_service = AgentExecutionService()
         result = await execution_service.execute_agent_ocr(
             agent_id=agent_id,
             pdf_file=pdf_file,

--- a/backend/routers/public/v1/chat.py
+++ b/backend/routers/public/v1/chat.py
@@ -24,7 +24,7 @@ from db.database import get_db
 from services.agent_execution_service import AgentExecutionService
 from services.agent_streaming_service import AgentStreamingService
 from services.conversation_service import ConversationService
-from services.file_management_service import FileManagementService, FileReference
+from services.file_management_service import FileManagementService
 
 from utils.logger import get_logger
 
@@ -47,58 +47,6 @@ def _parse_json_param(value: Optional[str], param_name: str):
         return None
 
 
-async def _process_chat_files(
-    files: List[UploadFile],
-    parsed_file_references: Optional[list],
-    agent_id: int,
-    user_context: dict,
-    conversation_id: Optional[int],
-) -> List[FileReference]:
-    """
-    Process file uploads and merge with existing attached files.
-    Shared logic for call_agent and call_agent_stream.
-    """
-    file_service = FileManagementService()
-    all_file_references: List[FileReference] = []
-    uploaded_file_ids: set = set()
-
-    if files:
-        for upload_file in files:
-            if upload_file.filename:
-                try:
-                    file_ref = await file_service.upload_file(
-                        file=upload_file,
-                        agent_id=agent_id,
-                        user_context=user_context,
-                        conversation_id=conversation_id,
-                    )
-                    all_file_references.append(file_ref)
-                    uploaded_file_ids.add(file_ref.file_id)
-                except Exception as e:
-                    logger.error(f"Error uploading file {upload_file.filename}: {str(e)}")
-
-    existing_files = await file_service.list_attached_files(
-        agent_id=agent_id,
-        user_context=user_context,
-        conversation_id=str(conversation_id) if conversation_id else None,
-    )
-
-    if parsed_file_references:
-        requested_file_ids = set(parsed_file_references)
-        existing_files = [f for f in existing_files if f["file_id"] in requested_file_ids]
-
-    for file_data in existing_files:
-        if file_data["file_id"] not in uploaded_file_ids:
-            file_ref = FileReference(
-                file_id=file_data["file_id"],
-                filename=file_data["filename"],
-                file_type=file_data["file_type"],
-                content=file_data["content"],
-                file_path=file_data.get("file_path"),
-            )
-            all_file_references.append(file_ref)
-
-    return all_file_references
 
 
 # AGENT CHAT ENDPOINTS
@@ -166,11 +114,15 @@ async def call_agent(
 
         user_context = create_api_key_user_context(app_id, api_key)
 
-        all_file_references = await _process_chat_files(
-            files, parsed_file_references, agent_id, user_context, conversation_id
+        all_file_references = await FileManagementService().resolve_chat_files(
+            files=files,
+            file_reference_ids=parsed_file_references,
+            agent_id=agent_id,
+            user_context=user_context,
+            conversation_id=conversation_id,
         )
 
-        execution_service = AgentExecutionService(db)
+        execution_service = AgentExecutionService()
         result = await execution_service.execute_agent_chat_with_file_refs(
             agent_id=agent_id,
             message=message,
@@ -248,8 +200,12 @@ async def call_agent_stream(
 
         user_context = create_api_key_user_context(app_id, api_key)
 
-        all_file_references = await _process_chat_files(
-            files, parsed_file_references, agent_id, user_context, conversation_id
+        all_file_references = await FileManagementService().resolve_chat_files(
+            files=files,
+            file_reference_ids=parsed_file_references,
+            agent_id=agent_id,
+            user_context=user_context,
+            conversation_id=conversation_id,
         )
 
         streaming_service = AgentStreamingService(db)
@@ -318,7 +274,7 @@ async def reset_conversation(
         user_context["conversation_id"] = conversation_id
 
     try:
-        execution_service = AgentExecutionService(db)
+        execution_service = AgentExecutionService()
         success = await execution_service.reset_agent_conversation(
             agent_id=agent_id,
             user_context=user_context,

--- a/backend/routers/public/v1/ocr.py
+++ b/backend/routers/public/v1/ocr.py
@@ -50,7 +50,7 @@ async def process_ocr(
     
     # Use unified service layer
     from services.agent_execution_service import AgentExecutionService
-    execution_service = AgentExecutionService(db)
+    execution_service = AgentExecutionService()
     
     try:
         result = await execution_service.execute_agent_ocr(

--- a/backend/services/agent_execution_context.py
+++ b/backend/services/agent_execution_context.py
@@ -1,0 +1,40 @@
+"""
+AgentExecutionContext — plain data container produced by _prepare_turn().
+
+Carries every field that the execution and finalization phases need so that
+_prepare_turn, _execute_agent_async, and _finalize_turn can pass state without
+a growing argument list.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class AgentExecutionContext:
+    """Immutable snapshot of all setup state for one agent chat turn."""
+
+    # Core identity
+    agent_id: int
+    agent: Any                          # Agent ORM instance (lightweight, pre-access-check)
+    fresh_agent: Any                    # Agent ORM instance with all relationships loaded
+
+    # Message
+    enhanced_message: str               # Text message after file-content injection
+    image_files: List[Dict[str, Any]]   # Image file dicts extracted from processed_files
+
+    # Session / conversation
+    session: Optional[Any] = None       # SessionManagementService session object
+    conversation: Optional[Any] = None  # Conversation ORM instance (None when no memory)
+    effective_conv_id: Optional[int] = None  # Resolved conversation ID (auto-created or passed)
+    session_id_for_cache: Optional[str] = None  # LangGraph thread ID suffix
+
+    # Working directory
+    working_dir: Optional[str] = None
+    pre_existing_files: set = field(default_factory=set)
+
+    # Original inputs (needed by finalize for metadata)
+    processed_files: List[Dict[str, Any]] = field(default_factory=list)
+    search_params: Optional[Dict[str, Any]] = None
+    user_context: Optional[Dict[str, Any]] = None

--- a/backend/services/agent_execution_service.py
+++ b/backend/services/agent_execution_service.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from models.agent import Agent
 from models.ocr_agent import OCRAgent
+from services.agent_execution_context import AgentExecutionContext
 from tools.PDFTools import extract_text_from_pdf, convert_pdf_to_images, check_pdf_has_text
 from tools.ocrAgentTools import (
     convert_image_to_base64,
@@ -66,316 +67,330 @@ class AgentExecutionService:
     # Shared thread pool for blocking I/O operations (file processing, OCR, etc.)
     _executor = ThreadPoolExecutor(max_workers=10, thread_name_prefix="agent_exec")
     
-    def __init__(self, db: Session = None):
+    def __init__(self):
         self.agent_service = AgentService()
         self.session_service = SessionManagementService()
         self.agent_execution_repo = AgentExecutionRepository()
-        self.db = db
     
     async def execute_agent_chat_with_file_refs(
-        self, 
-        agent_id: int, 
-        message: str, 
+        self,
+        agent_id: int,
+        message: str,
         file_references: List = None,
         search_params: Dict = None,
         user_context: Dict = None,
         conversation_id: int = None,
-        db: Session = None
+        db: Session = None,
     ) -> Dict[str, Any]:
-        """
-        Execute agent chat with persistent file references
-        
-        Args:
-            agent_id: ID of the agent to execute
-            message: User message
-            file_references: List of FileReference objects from FileManagementService
-            search_params: Optional search parameters for silo-based agents
-            user_context: User context (api_key, user_id, etc.)
-            conversation_id: Optional conversation ID to continue existing conversation
-            
+        """Execute agent chat with persistent file references.
+
         Returns:
-            Dict containing agent response and metadata
+            Dict containing agent response and metadata.
         """
         try:
-            # Get agent
-            agent = self.agent_service.get_agent(db, agent_id)
-            if not agent:
-                raise HTTPException(status_code=404, detail="Agent not found")
-            
-            # Validate user has access to this agent
-            await self._validate_agent_access(agent, user_context)
-            
-            # Process file references to extract content
-            processed_files = []
-            if file_references:
-                for file_ref in file_references:
-                    processed_files.append({
-                        "filename": file_ref.filename,
-                        "content": file_ref.content,
-                        "type": file_ref.file_type,
-                        "file_id": file_ref.file_id,
-                        "file_path": file_ref.file_path
-                    })
-            
-            # Get or create conversation for memory-enabled agents
-            session = None
-            conversation = None
-            if agent.has_memory:
-                from services.conversation_service import ConversationService
-                
-                # If conversation_id provided, validate and use it
-                if conversation_id:
-                    conversation = ConversationService.get_conversation(
-                        db=db,
-                        conversation_id=conversation_id,
-                        user_context=user_context,
-                        agent_id=agent_id
-                    )
-                    if not conversation:
-                        raise HTTPException(status_code=404, detail="Conversation not found or access denied")
-                    
-                    # Extract session_id from conversation (without "conv_{agent_id}_" prefix)
-                    session_suffix = conversation.session_id.replace(f"conv_{agent_id}_", "")
-                    session = await self.session_service.get_user_session(
-                        agent_id=agent_id,
-                        user_context=user_context,
-                        conversation_id=session_suffix
-                    )
-                else:
-                    # Auto-create a conversation if none exists
-                    conversation = ConversationService.create_conversation(
-                        db=db,
-                        agent_id=agent_id,
-                        user_context=user_context,
-                        title=None  # Auto-generate title
-                    )
-                    logger.info(f"Auto-created conversation {conversation.conversation_id} for agent {agent_id}")
-                    
-                    # Extract session_id from conversation (without "conv_{agent_id}_" prefix)
-                    session_suffix = conversation.session_id.replace(f"conv_{agent_id}_", "")
-                    session = await self.session_service.get_user_session(
-                        agent_id=agent_id,
-                        user_context=user_context,
-                        conversation_id=session_suffix
-                    )
-
-            # Re-query agent with all relationships eagerly loaded
-            fresh_agent = self.agent_execution_repo.get_agent_with_relationships(db, agent_id)
-            if not fresh_agent:
-                raise HTTPException(status_code=404, detail="Agent not found in database")
-
-            # Build enhanced message with file contents
-            enhanced_message, image_files = self._prepare_message_with_files(message, processed_files)
-
-            # Determine session ID for checkpointer
-            session_id_for_cache = session.id if (fresh_agent.has_memory and session) else None
-
-            # Use the actual conversation ID — the auto-created one if none was passed in.
-            # This ensures files are registered in the same bucket that the download API
-            # will look up later (keyed by conversation_id).
-            effective_conv_id = conversation_id or (conversation.conversation_id if conversation else None)
-
-            # Resolve working directory (always — used by download_url_to_workspace
-            # and, when enable_code_interpreter is on, by python_repl too)
-            app_config = get_app_config()
-            tmp_base = app_config['TMP_BASE_FOLDER']
-            if effective_conv_id:
-                working_dir = os.path.join(tmp_base, "conversations", str(effective_conv_id))
-            else:
-                user_id = user_context.get('user_id', 'anonymous') if user_context else 'anonymous'
-                app_id_ctx = user_context.get('app_id', 'default') if user_context else 'default'
-                session_key = f"agent_{agent_id}_user_{user_id}_app_{app_id_ctx}"
-                working_dir = os.path.join(tmp_base, "persistent", session_key)
-
-            # Snapshot files in working_dir before execution so we only register
-            # truly new files afterwards (avoids picking up stale files from
-            # a previous conversation that reused the same directory).
-            pre_existing_files: set = set()
-            if working_dir and os.path.isdir(working_dir):
-                pre_existing_files = set(os.listdir(working_dir))
-
-            # Execute agent directly in FastAPI's event loop (shared checkpointer pool)
-            response = await self._execute_agent_async(
-                fresh_agent, enhanced_message, search_params, session_id_for_cache, user_context, image_files,
-                working_dir=working_dir
+            ctx = await self._prepare_turn(
+                agent_id=agent_id,
+                message=message,
+                file_references=file_references,
+                search_params=search_params,
+                user_context=user_context,
+                conversation_id=conversation_id,
+                db=db,
             )
 
-            # Auto-register any files written to the working dir during this turn
-            # (code interpreter output, downloaded URLs, etc.)
-            if working_dir:
-                file_service = FileManagementService()
-                new_files = await file_service.sync_output_files(
-                    working_dir=working_dir,
-                    agent_id=agent_id,
-                    user_context=user_context,
-                    conversation_id=str(effective_conv_id) if effective_conv_id else None,
-                    exclude_filenames=pre_existing_files,
-                )
-                if new_files:
-                    response = _inject_file_markers(response, new_files)
+            response = await self._execute_agent_async(
+                ctx.fresh_agent,
+                ctx.enhanced_message,
+                ctx.search_params,
+                ctx.session_id_for_cache,
+                ctx.user_context,
+                ctx.image_files,
+                working_dir=ctx.working_dir,
+            )
 
-            # Parse response based on agent's output parser
-            from tools.agentTools import parse_agent_response
-            parsed_response = parse_agent_response(response, agent)
+            return await self._finalize_turn(ctx, response, db)
 
-            # Update request count
-            self._update_request_count(agent, db)
-
-            # Update session timestamp to keep it alive
-            if session:
-                await self.session_service.touch_session(session.id)
-
-            # Update conversation message count if using a specific conversation
-            if conversation:
-                from services.conversation_service import ConversationService
-                # Get last message preview (truncate response if too long)
-                last_message_preview = parsed_response[:200] if isinstance(parsed_response, str) else str(parsed_response)[:200]
-
-                # Clean message for preview if it's a list (multimodal)
-                # This ensures the conversation list shows clean text instead of JSON structure
-                if isinstance(parsed_response, list):
-                    try:
-                        text_parts = []
-                        for item in parsed_response:
-                            if isinstance(item, dict) and item.get("type") == "text":
-                                text_parts.append(item.get("text", ""))
-                        if text_parts:
-                            last_message_preview = " ".join(text_parts)[:200]
-                    except Exception:
-                        pass
-
-                # Strip file:// markers from preview — replace with human-readable placeholders
-                import re as _re
-                last_message_preview = _re.sub(r'!\[[^\]]*\]\(file://[^\)]*\)', '[imagen]', last_message_preview)
-                last_message_preview = _re.sub(r'\[📎[^\]]*\]\(file://[^\)]*\)', '[archivo]', last_message_preview)
-                last_message_preview = last_message_preview.strip() or '[imagen generada]'
-                
-                # Increment by 2 (user message + agent response)
-                ConversationService.increment_message_count(
-                    db=db,
-                    conversation_id=conversation.conversation_id,
-                    last_message=last_message_preview,
-                    increment_by=2
-                )
-            
-            return {
-                "response": parsed_response,
-                "agent_id": agent_id,
-                "conversation_id": conversation.conversation_id if conversation else None,
-                "metadata": {
-                    "agent_name": agent.name,
-                    "agent_type": agent.type,
-                    "files_processed": len(processed_files),
-                    "has_memory": agent.has_memory
-                }
-            }
-            
         except HTTPException:
             raise
         except Exception as e:
             logger.error(f"Error executing agent chat: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Agent execution failed: {str(e)}")
 
-    async def execute_agent_chat(
-        self, 
-        agent_id: int, 
-        message: str, 
-        files: List[UploadFile] = None,
+    async def _prepare_turn(
+        self,
+        agent_id: int,
+        message: str,
+        file_references: List = None,
         search_params: Dict = None,
         user_context: Dict = None,
-        db: Session = None
-    ) -> Dict[str, Any]:
-        """
-        Execute agent chat - used by both playground and public API
-        
-        Args:
-            agent_id: ID of the agent to execute
-            message: User message
-            files: Optional file attachments
-            search_params: Optional search parameters for silo-based agents
-            user_context: User context (api_key, user_id, etc.)
-            
+        conversation_id: int = None,
+        db: Session = None,
+    ) -> AgentExecutionContext:
+        """Run all setup steps for one agent chat turn.
+
+        Validates access, resolves the conversation / session, builds the
+        enhanced message, and resolves the working directory.  Does NOT invoke
+        the LangGraph chain — that is the caller's responsibility.
+
         Returns:
-            Dict containing agent response and metadata
+            A fully populated :class:`AgentExecutionContext`.
         """
-        try:
-            # Get agent
-            agent = self.agent_service.get_agent(db, agent_id)
-            if not agent:
-                raise HTTPException(status_code=404, detail="Agent not found")
+        # 1. Fetch agent (lightweight — no relationships)
+        agent = self.agent_service.get_agent(db, agent_id)
+        if not agent:
+            raise HTTPException(status_code=404, detail="Agent not found")
 
-            # Validate user has access to this agent before any SaaS checks
-            # (prevents leaking agent state to unauthorized callers)
-            await self._validate_agent_access(agent, user_context)
+        # 2. Access validation
+        await self._validate_agent_access(agent, user_context)
 
-            # Respect frozen state (SaaS mode: downgraded resources cannot be invoked)
-            if getattr(agent, 'is_frozen', False):
-                raise HTTPException(
-                    status_code=403,
-                    detail="This agent is frozen because your subscription tier has been downgraded. "
-                           "Please upgrade your plan or delete other resources to unfreeze it.",
-                )
-
-            # Enforce system LLM quota (SaaS mode only, no-op in self-managed)
-            if db and user_context and user_context.get('user_id'):
-                from services.tier_enforcement_service import TierEnforcementService
-                TierEnforcementService.check_system_llm_quota(db, user_context['user_id'])
-
-            # Process files if provided
-            processed_files = []
-            if files:
-                processed_files = await self._process_files_for_agent(files, agent)
-            
-            # Get user session for memory-enabled agents
-            session = None
-            if agent.has_memory:
-                # Extract conversation_id from user_context to ensure correct session identification
-                conversation_id = user_context.get("conversation_id") if user_context else None
-                session = await self.session_service.get_user_session(agent_id, user_context, conversation_id)
-
-            # Re-query agent with all relationships eagerly loaded
-            fresh_agent = self.agent_execution_repo.get_agent_with_relationships(db, agent_id)
-            if not fresh_agent:
-                raise HTTPException(status_code=404, detail="Agent not found in database")
-
-            # Build enhanced message with file contents
-            enhanced_message, image_files = self._prepare_message_with_files(message, processed_files)
-
-            # Determine session ID for checkpointer
-            session_id_for_cache = session.id if (fresh_agent.has_memory and session) else None
-
-            # Execute agent directly in FastAPI's event loop (shared checkpointer pool)
-            response = await self._execute_agent_async(
-                fresh_agent, enhanced_message, search_params, session_id_for_cache, user_context, image_files
+        # 3. Frozen-state guard (SaaS mode)
+        if getattr(agent, 'is_frozen', False):
+            raise HTTPException(
+                status_code=403,
+                detail="This agent is frozen because your subscription tier has been downgraded. "
+                       "Please upgrade your plan or delete other resources to unfreeze it.",
             )
 
-            # Parse response based on agent's output parser
-            from tools.agentTools import parse_agent_response
-            parsed_response = parse_agent_response(response, agent)
-            
-            # Update request count
-            self._update_request_count(agent, db)
-            
-            # Update session timestamp to keep it alive
-            if session:
-                await self.session_service.touch_session(session.id)
-            
-            return {
-                "response": parsed_response,
-                "agent_id": agent_id,
-                "metadata": {
-                    "agent_name": agent.name,
-                    "agent_type": agent.type,
-                    "files_processed": len(processed_files),
-                    "has_memory": agent.has_memory
-                }
-            }
-            
-        except HTTPException:
-            raise
-        except Exception as e:
-            logger.error(f"Error executing agent chat: {str(e)}", exc_info=True)
-            raise HTTPException(status_code=500, detail=f"Agent execution failed: {str(e)}")
+        # 4. System LLM quota (SaaS mode, no-op in self-managed)
+        if db and user_context and user_context.get('user_id'):
+            from services.tier_enforcement_service import TierEnforcementService
+            TierEnforcementService.check_system_llm_quota(db, user_context['user_id'])
+
+        # 5. Convert FileReference objects to plain dicts
+        processed_files: List[Dict] = []
+        if file_references:
+            for file_ref in file_references:
+                processed_files.append({
+                    "filename": file_ref.filename,
+                    "content": file_ref.content,
+                    "type": file_ref.file_type,
+                    "file_id": file_ref.file_id,
+                    "file_path": file_ref.file_path,
+                })
+
+        # 6. Get / create conversation for memory-enabled agents
+        session = None
+        conversation = None
+        if agent.has_memory:
+            from services.conversation_service import ConversationService
+
+            if conversation_id:
+                conversation = ConversationService.get_conversation(
+                    db=db,
+                    conversation_id=conversation_id,
+                    user_context=user_context,
+                    agent_id=agent_id,
+                )
+                if not conversation:
+                    raise HTTPException(
+                        status_code=404, detail="Conversation not found or access denied"
+                    )
+                session_suffix = conversation.session_id.replace(f"conv_{agent_id}_", "")
+                session = await self.session_service.get_user_session(
+                    agent_id=agent_id,
+                    user_context=user_context,
+                    conversation_id=session_suffix,
+                )
+            else:
+                conversation = ConversationService.create_conversation(
+                    db=db,
+                    agent_id=agent_id,
+                    user_context=user_context,
+                    title=None,
+                )
+                logger.info(
+                    "Auto-created conversation %s for agent %s",
+                    conversation.conversation_id,
+                    agent_id,
+                )
+                session_suffix = conversation.session_id.replace(f"conv_{agent_id}_", "")
+                session = await self.session_service.get_user_session(
+                    agent_id=agent_id,
+                    user_context=user_context,
+                    conversation_id=session_suffix,
+                )
+
+        # 7. Re-query agent with all relationships eagerly loaded
+        fresh_agent = self.agent_execution_repo.get_agent_with_relationships(db, agent_id)
+        if not fresh_agent:
+            raise HTTPException(status_code=404, detail="Agent not found in database")
+
+        # 8. Build enhanced message + separate image files
+        enhanced_message, image_files = self._prepare_message_with_files(message, processed_files)
+
+        session_id_for_cache = session.id if (fresh_agent.has_memory and session) else None
+        effective_conv_id = conversation_id or (
+            conversation.conversation_id if conversation else None
+        )
+
+        # 9. Resolve working directory
+        app_config = get_app_config()
+        tmp_base = app_config['TMP_BASE_FOLDER']
+        if effective_conv_id:
+            working_dir = os.path.join(tmp_base, "conversations", str(effective_conv_id))
+        else:
+            user_id = user_context.get('user_id', 'anonymous') if user_context else 'anonymous'
+            app_id_ctx = user_context.get('app_id', 'default') if user_context else 'default'
+            session_key = f"agent_{agent_id}_user_{user_id}_app_{app_id_ctx}"
+            working_dir = os.path.join(tmp_base, "persistent", session_key)
+
+        # 10. Snapshot working dir so finalize can exclude pre-existing files
+        pre_existing_files: set = set()
+        if working_dir and os.path.isdir(working_dir):
+            pre_existing_files = set(os.listdir(working_dir))
+
+        return AgentExecutionContext(
+            agent_id=agent_id,
+            agent=agent,
+            fresh_agent=fresh_agent,
+            enhanced_message=enhanced_message,
+            image_files=image_files,
+            session=session,
+            conversation=conversation,
+            effective_conv_id=effective_conv_id,
+            session_id_for_cache=session_id_for_cache,
+            working_dir=working_dir,
+            pre_existing_files=pre_existing_files,
+            processed_files=processed_files,
+            search_params=search_params,
+            user_context=user_context,
+        )
+
+    async def _finalize_turn(
+        self,
+        ctx: AgentExecutionContext,
+        raw_response: Any,
+        db: Session,
+    ) -> Dict[str, Any]:
+        """Run all post-processing steps for one agent chat turn.
+
+        1. Sync output files written to the working dir.
+        2. Inject file:// markers into the response text.
+        3. Parse the response with the agent's output parser.
+        4. Update the agent request count.
+        5. Touch the session to keep it alive.
+        6. Record system LLM usage (SaaS mode).
+        7. Increment the conversation message count.
+
+        Args:
+            ctx: The context produced by :meth:`_prepare_turn`.
+            raw_response: The raw string/dict returned by :meth:`_execute_agent_async`.
+            db: Active SQLAlchemy session.
+
+        Returns:
+            A dict with keys ``response``, ``agent_id``, ``conversation_id``,
+            ``metadata``, ``parsed_response``, ``effective_conv_id``, and
+            ``files_data`` (used by the streaming path to emit the ``done`` event).
+        """
+        import re as _re
+        from tools.agentTools import parse_agent_response
+
+        response = raw_response
+        files_data: List[Dict[str, Any]] = []
+
+        # 1 + 2. Sync output files and inject markers
+        if ctx.working_dir:
+            file_service = FileManagementService()
+            new_files = await file_service.sync_output_files(
+                working_dir=ctx.working_dir,
+                agent_id=ctx.agent_id,
+                user_context=ctx.user_context,
+                conversation_id=(
+                    str(ctx.effective_conv_id) if ctx.effective_conv_id else None
+                ),
+                exclude_filenames=ctx.pre_existing_files,
+            )
+            if new_files:
+                response = _inject_file_markers(response, new_files)
+                files_data = [
+                    {
+                        "file_id": f.file_id,
+                        "filename": f.filename,
+                        "file_type": f.file_type,
+                    }
+                    for f in new_files
+                ]
+
+        # 3. Parse response
+        parsed_response = parse_agent_response(response, ctx.agent)
+
+        # 4. Update request count
+        self._update_request_count(ctx.agent, db)
+
+        # 5. Touch session
+        if ctx.session:
+            await self.session_service.touch_session(ctx.session.id)
+
+        # 6. Record system LLM usage (SaaS mode — no-op for own-key services)
+        ai_svc = ctx.fresh_agent.ai_service
+        if (
+            ai_svc is not None
+            and getattr(ai_svc, 'app_id', 'NOT_NULL') is None
+            and db
+            and ctx.user_context
+            and ctx.user_context.get('user_id')
+        ):
+            try:
+                from services.usage_tracking_service import UsageTrackingService
+                UsageTrackingService.record_system_llm_call(db, ctx.user_context['user_id'])
+            except Exception as _usage_exc:
+                logger.warning(
+                    "Failed to record system LLM usage: %s", _usage_exc, exc_info=True
+                )
+
+        # 7. Update conversation message count
+        if ctx.conversation:
+            from services.conversation_service import ConversationService
+
+            if isinstance(parsed_response, list):
+                try:
+                    text_parts = [
+                        item.get("text", "")
+                        for item in parsed_response
+                        if isinstance(item, dict) and item.get("type") == "text"
+                    ]
+                    last_message_preview = " ".join(text_parts)[:200]
+                except Exception:
+                    last_message_preview = str(parsed_response)[:200]
+            else:
+                last_message_preview = (
+                    parsed_response[:200]
+                    if isinstance(parsed_response, str)
+                    else str(parsed_response)[:200]
+                )
+
+            last_message_preview = _re.sub(
+                r'!\[[^\]]*\]\(file://[^\)]*\)', '[imagen]', last_message_preview
+            )
+            last_message_preview = _re.sub(
+                r'\[📎[^\]]*\]\(file://[^\)]*\)', '[archivo]', last_message_preview
+            )
+            last_message_preview = last_message_preview.strip() or '[imagen generada]'
+
+            ConversationService.increment_message_count(
+                db=db,
+                conversation_id=ctx.conversation.conversation_id,
+                last_message=last_message_preview,
+                increment_by=2,
+            )
+
+        return {
+            "response": parsed_response,
+            "agent_id": ctx.agent_id,
+            "conversation_id": (
+                ctx.conversation.conversation_id if ctx.conversation else None
+            ),
+            "metadata": {
+                "agent_name": ctx.agent.name,
+                "agent_type": ctx.agent.type,
+                "files_processed": len(ctx.processed_files),
+                "has_memory": ctx.agent.has_memory,
+            },
+            # Fields used by the streaming path to emit the done event
+            "parsed_response": parsed_response,
+            "effective_conv_id": ctx.effective_conv_id,
+            "files_data": files_data,
+        }
 
     async def execute_agent_ocr(
         self, 
@@ -984,97 +999,9 @@ class AgentExecutionService:
             # Add the question to config
             config["configurable"]["question"] = message
             
-            # Execute the agent in the SAME event loop as where MCP client was created
-            formatted_user_message = fresh_agent.prompt_template.format(question=message)
-            
-            # Construct message content
-            if image_files:
-                content = [{"type": "text", "text": formatted_user_message}]
-                
-                # Get TMP_BASE_FOLDER from config
-                app_config = get_app_config()
-                tmp_base_folder = app_config['TMP_BASE_FOLDER']
-                
-                # Check for aict_base_url environment variable (Production Mode)
-                aict_base_url = os.getenv('AICT_BASE_URL')
-                
-                for img in image_files:
-                    file_path = img.get('file_path', '')
-                    if not file_path:
-                        logger.warning(f"Image file has no file_path: {img}")
-                        continue
-                        
-                    # Ensure forward slashes
-                    file_path = file_path.replace('\\', '/')
-                    if file_path.startswith('/'):
-                        file_path = file_path[1:]
-                    
-                    # If aict_base_url is set, use it (Production Mode)
-                    if aict_base_url:
-                        # Remove trailing slash if present
-                        if aict_base_url.endswith('/'):
-                            aict_base_url = aict_base_url[:-1]
-                            
-                        # Generate signed URL
-                        user_email = user_context.get('email') if user_context else None
-                        if user_email:
-                            from utils.security import generate_signature
-                            sig = generate_signature(file_path, user_email)
-                            url = f"{aict_base_url}/static/{file_path}?user={user_email}&sig={sig}"
-                        else:
-                            # Fallback if no user context (should not happen in auth mode)
-                            url = f"{aict_base_url}/static/{file_path}"
-                            
-                        logger.info(f"Adding image to message using public URL: {url}")
-                        content.append({
-                            "type": "image_url",
-                            "image_url": {"url": url}
-                        })
-                    else:
-                        # Fallback to Base64 (Development Mode)
-                        # Use Base64 for local development to avoid localhost URL issues
-                        try:
-                            # Construct full path
-                            full_path = os.path.join(tmp_base_folder, file_path)
-                            
-                            if os.path.exists(full_path):
-                                import base64
-                                import mimetypes
-                                
-                                mime_type, _ = mimetypes.guess_type(full_path)
-                                if not mime_type:
-                                    mime_type = "image/jpeg"
-                                    
-                                with open(full_path, "rb") as image_file:
-                                    encoded_string = base64.b64encode(image_file.read()).decode('utf-8')
-                                    
-                                data_url = f"data:{mime_type};base64,{encoded_string}"
-                                logger.info(f"Adding image to message as base64 (length: {len(encoded_string)})")
-                                
-                                content.append({
-                                    "type": "image_url",
-                                    "image_url": {"url": data_url}
-                                })
-                            else:
-                                # Fallback to URL if file not found locally (should not happen)
-                                url = f"http://localhost:8000/static/{file_path}"
-                                logger.warning(f"Image file not found at {full_path}, falling back to URL: {url}")
-                                content.append({
-                                    "type": "image_url",
-                                    "image_url": {"url": url}
-                                })
-                        except Exception as e:
-                            logger.error(f"Error processing image for base64: {e}")
-                            # Fallback to URL
-                            url = f"http://localhost:8000/static/{file_path}"
-                            content.append({
-                                "type": "image_url",
-                                "image_url": {"url": url}
-                            })
-                
-                message_payload = HumanMessage(content=content)
-            else:
-                message_payload = HumanMessage(content=formatted_user_message)
+            # Build the HumanMessage (handles text-only and multimodal images)
+            from tools.agentTools import build_human_message
+            message_payload = build_human_message(fresh_agent, message, image_files or [], user_context)
             
             if langsmith_config:
                 from langchain_core.tracers.langchain import LangChainTracer, wait_for_all_tracers
@@ -1102,22 +1029,6 @@ class AgentExecutionService:
                     logger.warning(f"Error flushing LangSmith traces: {flush_err}")
             else:
                 result = await agent_chain.ainvoke({"messages": [message_payload]}, config=config)
-
-            # Track system LLM usage only when the agent uses a system AI service
-            # (app_id=NULL). Own-key services are not counted against the quota.
-            ai_svc = fresh_agent.ai_service
-            if (
-                ai_svc is not None
-                and getattr(ai_svc, 'app_id', 'NOT_NULL') is None
-                and self.db
-                and user_context
-                and user_context.get('user_id')
-            ):
-                try:
-                    from services.usage_tracking_service import UsageTrackingService
-                    UsageTrackingService.record_system_llm_call(self.db, user_context['user_id'])
-                except Exception as _usage_exc:
-                    logger.warning("Failed to record system LLM usage: %s", _usage_exc, exc_info=True)
 
             # LangChain v1: structured output is in 'structured_response' key
             # when create_agent is called with response_format=pydantic_model

--- a/backend/services/agent_streaming_service.py
+++ b/backend/services/agent_streaming_service.py
@@ -1,38 +1,25 @@
 """
 Streaming agent execution service.
 
-Mirrors AgentExecutionService.execute_agent_chat_with_file_refs() but yields
-SSE-formatted events instead of returning a complete response.  The setup phase
-(agent lookup, conversation management, working-dir resolution) is identical to
-the non-streaming path.  The difference is that _execute_agent_async()'s
-ainvoke() call is replaced by astream() with stream_mode=["messages", "updates"].
+A thin SSE adapter over AgentExecutionService.  The setup and post-processing
+phases are fully delegated to AgentExecutionService._prepare_turn() and
+_finalize_turn(); this service only owns the astream loop that yields tokens
+and tool events to the client.
 """
 
-import os
-import re
-import base64
-import mimetypes
 from typing import AsyncGenerator, Dict, List, Any
 
 import langsmith as ls
-from langchain.messages import HumanMessage
 from sqlalchemy.orm import Session
-from fastapi import HTTPException
 
-from models.agent import Agent
-from tools.agentTools import create_agent, prepare_agent_config, parse_agent_response
+from tools.agentTools import create_agent, prepare_agent_config, build_human_message
 from tools.streaming_utils import (
     format_sse_event,
     map_stream_event,
     SSE_TOKEN,
 )
-from services.agent_service import AgentService
-from services.session_management_service import SessionManagementService
-from services.file_management_service import FileManagementService
-from services.agent_execution_service import AgentExecutionService, _inject_file_markers
-from repositories.agent_execution_repository import AgentExecutionRepository
+from services.agent_execution_service import AgentExecutionService
 from utils.logger import get_logger
-from utils.config import get_app_config
 
 logger = get_logger(__name__)
 
@@ -41,11 +28,7 @@ class AgentStreamingService:
     """Service for streaming agent responses via Server-Sent Events."""
 
     def __init__(self, db: Session = None) -> None:
-        self.agent_service = AgentService()
-        self.session_service = SessionManagementService()
-        self.agent_execution_repo = AgentExecutionRepository()
-        # Reuse the existing execution service for shared helpers
-        self.execution_service = AgentExecutionService(db)
+        self.execution_service = AgentExecutionService()
         self.db = db
 
     # ------------------------------------------------------------------
@@ -103,156 +86,47 @@ class AgentStreamingService:
 
         try:
             # ----------------------------------------------------------------
-            # 1. Resolve agent + validate access
+            # 1. Setup phase — delegates entirely to AgentExecutionService
             # ----------------------------------------------------------------
-            agent = self.agent_service.get_agent(effective_db, agent_id)
-            if not agent:
-                raise HTTPException(status_code=404, detail="Agent not found")
-
-            await self.execution_service._validate_agent_access(agent, user_context)
-
-            # ----------------------------------------------------------------
-            # 2. Process file references
-            # ----------------------------------------------------------------
-            processed_files: List[Dict[str, Any]] = []
-            if file_references:
-                for file_ref in file_references:
-                    processed_files.append(
-                        {
-                            "filename": file_ref.filename,
-                            "content": file_ref.content,
-                            "type": file_ref.file_type,
-                            "file_id": file_ref.file_id,
-                            "file_path": file_ref.file_path,
-                        }
-                    )
-
-            # ----------------------------------------------------------------
-            # 3. Get / create conversation for memory-enabled agents
-            # ----------------------------------------------------------------
-            session = None
-            conversation = None
-            if agent.has_memory:
-                from services.conversation_service import ConversationService  # local import to avoid circular
-
-                if conversation_id:
-                    conversation = ConversationService.get_conversation(
-                        db=effective_db,
-                        conversation_id=conversation_id,
-                        user_context=user_context,
-                        agent_id=agent_id,
-                    )
-                    if not conversation:
-                        raise HTTPException(
-                            status_code=404,
-                            detail="Conversation not found or access denied",
-                        )
-                    session_suffix = conversation.session_id.replace(
-                        f"conv_{agent_id}_", ""
-                    )
-                    session = await self.session_service.get_user_session(
-                        agent_id=agent_id,
-                        user_context=user_context,
-                        conversation_id=session_suffix,
-                    )
-                else:
-                    conversation = ConversationService.create_conversation(
-                        db=effective_db,
-                        agent_id=agent_id,
-                        user_context=user_context,
-                        title=None,
-                    )
-                    logger.info(
-                        "Auto-created conversation %s for agent %s",
-                        conversation.conversation_id,
-                        agent_id,
-                    )
-                    session_suffix = conversation.session_id.replace(
-                        f"conv_{agent_id}_", ""
-                    )
-                    session = await self.session_service.get_user_session(
-                        agent_id=agent_id,
-                        user_context=user_context,
-                        conversation_id=session_suffix,
-                    )
-
-            # ----------------------------------------------------------------
-            # 4. Re-query agent with all relationships eagerly loaded
-            # ----------------------------------------------------------------
-            fresh_agent = self.agent_execution_repo.get_agent_with_relationships(
-                effective_db, agent_id
-            )
-            if not fresh_agent:
-                raise HTTPException(
-                    status_code=404, detail="Agent not found in database"
-                )
-
-            # ----------------------------------------------------------------
-            # 5. Prepare message + working directory
-            # ----------------------------------------------------------------
-            enhanced_message, image_files = (
-                self.execution_service._prepare_message_with_files(
-                    message, processed_files
-                )
+            ctx = await self.execution_service._prepare_turn(
+                agent_id=agent_id,
+                message=message,
+                file_references=file_references,
+                search_params=search_params,
+                user_context=user_context,
+                conversation_id=conversation_id,
+                db=effective_db,
             )
 
-            session_id_for_cache = (
-                session.id if (fresh_agent.has_memory and session) else None
-            )
-
-            effective_conv_id: int | None = conversation_id or (
-                conversation.conversation_id if conversation else None
-            )
-
-            app_config = get_app_config()
-            tmp_base = app_config["TMP_BASE_FOLDER"]
-            if effective_conv_id:
-                working_dir = os.path.join(
-                    tmp_base, "conversations", str(effective_conv_id)
-                )
-            else:
-                user_id = (
-                    user_context.get("user_id", "anonymous")
-                    if user_context
-                    else "anonymous"
-                )
-                app_id_ctx = (
-                    user_context.get("app_id", "default")
-                    if user_context
-                    else "default"
-                )
-                session_key = f"agent_{agent_id}_user_{user_id}_app_{app_id_ctx}"
-                working_dir = os.path.join(tmp_base, "persistent", session_key)
-
             # ----------------------------------------------------------------
-            # 6. Emit early metadata event so the client has conversation_id
+            # 2. Emit early metadata event so the client has conversation_id
             # ----------------------------------------------------------------
             yield format_sse_event(
                 "metadata",
                 {
-                    "conversation_id": effective_conv_id,
+                    "conversation_id": ctx.effective_conv_id,
                     "agent_id": agent_id,
-                    "agent_name": agent.name,
-                    "has_memory": agent.has_memory,
+                    "agent_name": ctx.agent.name,
+                    "has_memory": ctx.agent.has_memory,
                 },
             )
 
             # ----------------------------------------------------------------
-            # 7. Build agent chain
+            # 3. Build agent chain
             # ----------------------------------------------------------------
             agent_chain, langsmith_config, mcp_client = await create_agent(
-                fresh_agent,
-                search_params,
-                session_id_for_cache,
-                user_context,
-                working_dir,
+                ctx.fresh_agent,
+                ctx.search_params,
+                ctx.session_id_for_cache,
+                ctx.user_context,
+                ctx.working_dir,
             )
 
-            config = prepare_agent_config(fresh_agent)
+            config = prepare_agent_config(ctx.fresh_agent)
 
-            if fresh_agent.has_memory and session_id_for_cache:
+            if ctx.fresh_agent.has_memory and ctx.session_id_for_cache:
                 config["configurable"]["thread_id"] = (
-                    f"thread_{fresh_agent.agent_id}_{session_id_for_cache}"
+                    f"thread_{ctx.fresh_agent.agent_id}_{ctx.session_id_for_cache}"
                 )
                 logger.info(
                     "Using session-aware thread_id: %s",
@@ -260,20 +134,20 @@ class AgentStreamingService:
                 )
             else:
                 config["configurable"]["thread_id"] = (
-                    f"thread_{fresh_agent.agent_id}"
+                    f"thread_{ctx.fresh_agent.agent_id}"
                 )
 
-            config["configurable"]["question"] = enhanced_message
+            config["configurable"]["question"] = ctx.enhanced_message
 
             # ----------------------------------------------------------------
-            # 8. Build the HumanMessage payload (handles multimodal images)
+            # 4. Build the HumanMessage payload (handles multimodal images)
             # ----------------------------------------------------------------
-            message_payload = self._build_message_payload(
-                fresh_agent, enhanced_message, image_files, user_context
+            message_payload = build_human_message(
+                ctx.fresh_agent, ctx.enhanced_message, ctx.image_files, ctx.user_context
             )
 
             # ----------------------------------------------------------------
-            # 9. Attach LangSmith tracer when configured
+            # 5. Attach LangSmith tracer when configured
             # ----------------------------------------------------------------
             if langsmith_config:
                 from langchain_core.tracers.langchain import LangChainTracer
@@ -289,7 +163,7 @@ class AgentStreamingService:
                 config.setdefault("callbacks", []).append(per_app_tracer)
 
             # ----------------------------------------------------------------
-            # 10. Streaming loop
+            # 6. Streaming loop — the only part that stays in this service
             # ----------------------------------------------------------------
             accumulated_content = ""
 
@@ -314,119 +188,25 @@ class AgentStreamingService:
                     if events:
                         for event in events:
                             if event["type"] == SSE_TOKEN:
-                                accumulated_content += event["data"].get(
-                                    "content", ""
-                                )
+                                accumulated_content += event["data"].get("content", "")
                             yield format_sse_event(event["type"], event["data"])
 
             # ----------------------------------------------------------------
-            # 11. Post-processing: sync output files
+            # 7. Post-processing phase — delegates to AgentExecutionService
             # ----------------------------------------------------------------
-            response = accumulated_content
-            files_data: List[Dict[str, Any]] = []
-
-            if working_dir:
-                file_service = FileManagementService()
-                new_files = await file_service.sync_output_files(
-                    working_dir=working_dir,
-                    agent_id=agent_id,
-                    user_context=user_context,
-                    conversation_id=(
-                        str(effective_conv_id) if effective_conv_id else None
-                    ),
-                )
-                if new_files:
-                    response = _inject_file_markers(response, new_files)
-                    files_data = [
-                        {
-                            "file_id": f.file_id,
-                            "filename": f.filename,
-                            "file_type": f.file_type,
-                        }
-                        for f in new_files
-                    ]
+            result = await self.execution_service._finalize_turn(
+                ctx, accumulated_content, effective_db
+            )
 
             # ----------------------------------------------------------------
-            # 12. Parse response with output parser
-            # ----------------------------------------------------------------
-            parsed_response = parse_agent_response(response, agent)
-
-            # ----------------------------------------------------------------
-            # 13. Update request count + touch session
-            # ----------------------------------------------------------------
-            self.execution_service._update_request_count(agent, effective_db)
-
-            if session:
-                await self.session_service.touch_session(session.id)
-
-            # ----------------------------------------------------------------
-            # 13b. Track system LLM usage (SaaS mode, no-op in self-managed)
-            # ----------------------------------------------------------------
-            ai_svc = fresh_agent.ai_service
-            if (
-                ai_svc is not None
-                and getattr(ai_svc, 'app_id', 'NOT_NULL') is None
-                and effective_db
-                and user_context
-                and user_context.get('user_id')
-            ):
-                try:
-                    from services.usage_tracking_service import UsageTrackingService
-                    UsageTrackingService.record_system_llm_call(effective_db, user_context['user_id'])
-                except Exception as _usage_exc:
-                    logger.warning("Failed to record system LLM usage: %s", _usage_exc, exc_info=True)
-
-            # ----------------------------------------------------------------
-            # 14. Update conversation message count
-            # ----------------------------------------------------------------
-            if conversation:
-                from services.conversation_service import ConversationService  # already imported above; safe to re-import
-
-                if isinstance(parsed_response, list):
-                    try:
-                        text_parts = [
-                            item.get("text", "")
-                            for item in parsed_response
-                            if isinstance(item, dict) and item.get("type") == "text"
-                        ]
-                        last_message_preview = " ".join(text_parts)[:200]
-                    except Exception:
-                        last_message_preview = str(parsed_response)[:200]
-                else:
-                    last_message_preview = (
-                        parsed_response[:200]
-                        if isinstance(parsed_response, str)
-                        else str(parsed_response)[:200]
-                    )
-
-                last_message_preview = re.sub(
-                    r"!\[[^\]]*\]\(file://[^\)]*\)", "[imagen]", last_message_preview
-                )
-                last_message_preview = re.sub(
-                    r"\[📎[^\]]*\]\(file://[^\)]*\)",
-                    "[archivo]",
-                    last_message_preview,
-                )
-                last_message_preview = (
-                    last_message_preview.strip() or "[imagen generada]"
-                )
-
-                ConversationService.increment_message_count(
-                    db=effective_db,
-                    conversation_id=conversation.conversation_id,
-                    last_message=last_message_preview,
-                    increment_by=2,
-                )
-
-            # ----------------------------------------------------------------
-            # 15. Emit done event
+            # 8. Emit done event
             # ----------------------------------------------------------------
             yield format_sse_event(
                 "done",
                 {
-                    "response": parsed_response,
-                    "conversation_id": effective_conv_id,
-                    "files": files_data,
+                    "response": result["parsed_response"],
+                    "conversation_id": result["effective_conv_id"],
+                    "files": result["files_data"],
                 },
             )
 
@@ -441,109 +221,3 @@ class AgentStreamingService:
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
-
-    def _build_message_payload(
-        self,
-        agent: Agent,
-        message: str,
-        image_files: List[Dict[str, Any]],
-        user_context: dict | None,
-    ) -> HumanMessage:
-        """Build the HumanMessage that will be fed into the agent chain.
-
-        When ``image_files`` is non-empty the content becomes a multimodal list
-        of text + image_url blocks.  Images are served via a signed URL when
-        ``AICT_BASE_URL`` is set (production), or inlined as base64 data URIs in
-        development mode.
-
-        Args:
-            agent: The (freshly loaded) Agent ORM instance.
-            message: The already-enhanced text message (with file content
-                appended if applicable).
-            image_files: List of image-file dicts (``file_path`` key required).
-            user_context: Caller context dict used to generate signed URLs.
-
-        Returns:
-            A ``HumanMessage`` instance ready for ``agent_chain.astream()``.
-        """
-        formatted_message = agent.prompt_template.format(question=message)
-
-        if not image_files:
-            return HumanMessage(content=formatted_message)
-
-        app_config = get_app_config()
-        tmp_base_folder = app_config["TMP_BASE_FOLDER"]
-        aict_base_url = os.getenv("AICT_BASE_URL")
-
-        content: List[Dict[str, Any]] = [
-            {"type": "text", "text": formatted_message}
-        ]
-
-        for img in image_files:
-            file_path: str = img.get("file_path", "")
-            if not file_path:
-                logger.warning("Image file has no file_path — skipping: %s", img)
-                continue
-
-            # Normalise to forward slashes and strip leading slash
-            file_path = file_path.replace("\\", "/").lstrip("/")
-
-            if aict_base_url:
-                # Production mode — generate a signed static URL
-                aict_base_url = aict_base_url.rstrip("/")
-                user_email: str | None = (
-                    user_context.get("email") if user_context else None
-                )
-                if user_email:
-                    from utils.security import generate_signature
-
-                    sig = generate_signature(file_path, user_email)
-                    url = (
-                        f"{aict_base_url}/static/{file_path}"
-                        f"?user={user_email}&sig={sig}"
-                    )
-                else:
-                    url = f"{aict_base_url}/static/{file_path}"
-
-                logger.info("Adding image to message using signed URL: %s", url)
-                content.append(
-                    {"type": "image_url", "image_url": {"url": url}}
-                )
-            else:
-                # Development mode — inline as base64 data URI
-                full_path = os.path.join(tmp_base_folder, file_path)
-                if os.path.exists(full_path):
-                    try:
-                        mime_type, _ = mimetypes.guess_type(full_path)
-                        if not mime_type:
-                            mime_type = "image/jpeg"
-                        with open(full_path, "rb") as fh:
-                            encoded = base64.b64encode(fh.read()).decode("utf-8")
-                        data_url = f"data:{mime_type};base64,{encoded}"
-                        logger.info(
-                            "Adding image as base64 (length: %d)", len(encoded)
-                        )
-                        content.append(
-                            {"type": "image_url", "image_url": {"url": data_url}}
-                        )
-                    except Exception as exc:
-                        logger.error(
-                            "Error encoding image as base64: %s — falling back to URL",
-                            exc,
-                        )
-                        url = f"http://localhost:8000/static/{file_path}"
-                        content.append(
-                            {"type": "image_url", "image_url": {"url": url}}
-                        )
-                else:
-                    url = f"http://localhost:8000/static/{file_path}"
-                    logger.warning(
-                        "Image not found at %s — falling back to URL: %s",
-                        full_path,
-                        url,
-                    )
-                    content.append(
-                        {"type": "image_url", "image_url": {"url": url}}
-                    )
-
-        return HumanMessage(content=content)

--- a/backend/services/file_management_service.py
+++ b/backend/services/file_management_service.py
@@ -819,6 +819,86 @@ class FileManagementService:
             logger.error("sync_output_files error: %s", e)
             return []
 
+    async def resolve_chat_files(
+        self,
+        files: Optional[List[UploadFile]],
+        file_reference_ids: Optional[List[str]],
+        agent_id: int,
+        user_context: Dict,
+        conversation_id: Optional[int],
+    ) -> List["FileReference"]:
+        """Upload new files and merge with the existing attached files for a chat turn.
+
+        This is the single canonical implementation that replaces the three
+        near-identical helpers previously scattered across the internal and
+        public-API routers.
+
+        Args:
+            files: New files uploaded with the current request (may be None or empty).
+            file_reference_ids: Optional list of file_id strings the caller wants to
+                include.  When None all currently attached files are included; when
+                an empty list is provided no pre-existing files are included.
+            agent_id: ID of the agent receiving the files.
+            user_context: Caller context dict (``user_id``, ``app_id``, …).
+            conversation_id: Optional conversation ID used to scope file storage.
+
+        Returns:
+            Ordered list of :class:`FileReference` objects ready to pass to
+            ``AgentExecutionService.execute_agent_chat_with_file_refs``.
+        """
+        all_refs: List[FileReference] = []
+        uploaded_ids: set = set()
+
+        # 1. Upload any newly-attached files
+        if files:
+            for upload_file in files:
+                if upload_file.filename:
+                    try:
+                        file_ref = await self.upload_file(
+                            file=upload_file,
+                            agent_id=agent_id,
+                            user_context=user_context,
+                            conversation_id=conversation_id,
+                        )
+                        all_refs.append(file_ref)
+                        uploaded_ids.add(file_ref.file_id)
+                    except Exception as exc:
+                        logger.error(
+                            "Error uploading file %s: %s", upload_file.filename, exc
+                        )
+
+        # 2. Fetch existing attached files (scoped to conversation when available)
+        existing_files = await self.list_attached_files(
+            agent_id=agent_id,
+            user_context=user_context,
+            conversation_id=str(conversation_id) if conversation_id else None,
+        )
+
+        # 3. Optionally filter to a specific subset
+        if file_reference_ids is not None:
+            requested_ids = set(file_reference_ids)
+            existing_files = [
+                f for f in existing_files if f["file_id"] in requested_ids
+            ]
+            logger.info(
+                "Filtered to %d file(s) based on file_reference_ids", len(existing_files)
+            )
+
+        # 4. Append existing files not already added via upload
+        for file_data in existing_files:
+            if file_data["file_id"] not in uploaded_ids:
+                all_refs.append(
+                    FileReference(
+                        file_id=file_data["file_id"],
+                        filename=file_data["filename"],
+                        file_type=file_data["file_type"],
+                        content=file_data["content"],
+                        file_path=file_data.get("file_path"),
+                    )
+                )
+
+        return all_refs
+
     def get_file_stats(self) -> Dict[str, Any]:
         """Get file management statistics"""
         try:

--- a/backend/tools/agentTools.py
+++ b/backend/tools/agentTools.py
@@ -20,6 +20,8 @@ import langsmith as ls
 import json
 import asyncio
 import os
+import base64
+import mimetypes
 from utils.logger import get_logger
 from utils.mcp_auth_utils import prepare_mcp_headers, get_user_token_from_context
 from utils.mcp_ssl_utils import inject_ssl_config
@@ -336,6 +338,111 @@ def parse_agent_response(response_text, agent):
             logger.error(f"Error parsing JSON response: {e}")
             return response_text
     return response_text
+
+
+def build_human_message(
+    agent: Agent,
+    message: str,
+    image_files: List[Dict],
+    user_context: Optional[Dict] = None,
+) -> HumanMessage:
+    """Build the HumanMessage that will be fed into the agent chain.
+
+    When ``image_files`` is non-empty the content becomes a multimodal list of
+    text + image_url blocks.  Images are served via a signed URL when
+    ``AICT_BASE_URL`` is set (production), or inlined as base64 data URIs in
+    development mode.
+
+    Args:
+        agent: The (freshly loaded) Agent ORM instance.
+        message: The already-enhanced text message (with file content appended
+            if applicable).
+        image_files: List of image-file dicts (``file_path`` key required).
+        user_context: Caller context dict used to generate signed URLs.
+
+    Returns:
+        A ``HumanMessage`` instance ready for ``agent_chain.ainvoke()`` /
+        ``agent_chain.astream()``.
+    """
+    from utils.config import get_app_config
+
+    formatted_message = agent.prompt_template.format(question=message)
+
+    if not image_files:
+        return HumanMessage(content=formatted_message)
+
+    app_config = get_app_config()
+    tmp_base_folder = app_config["TMP_BASE_FOLDER"]
+    aict_base_url = os.getenv("AICT_BASE_URL")
+
+    content: List[Dict] = [{"type": "text", "text": formatted_message}]
+
+    for img in image_files:
+        file_path: str = img.get("file_path", "")
+        if not file_path:
+            logger.warning("Image file has no file_path — skipping: %s", img)
+            continue
+
+        # Normalise to forward slashes and strip leading slash
+        file_path = file_path.replace("\\", "/").lstrip("/")
+
+        if aict_base_url:
+            # Production mode — generate a signed static URL
+            aict_base_url = aict_base_url.rstrip("/")
+            user_email: Optional[str] = (
+                user_context.get("email") if user_context else None
+            )
+            if user_email:
+                from utils.security import generate_signature
+
+                sig = generate_signature(file_path, user_email)
+                url = (
+                    f"{aict_base_url}/static/{file_path}"
+                    f"?user={user_email}&sig={sig}"
+                )
+            else:
+                url = f"{aict_base_url}/static/{file_path}"
+
+            logger.info("Adding image to message using signed URL: %s", url)
+            content.append({"type": "image_url", "image_url": {"url": url}})
+        else:
+            # Development mode — inline as base64 data URI
+            full_path = os.path.join(tmp_base_folder, file_path)
+            if os.path.exists(full_path):
+                try:
+                    mime_type, _ = mimetypes.guess_type(full_path)
+                    if not mime_type:
+                        mime_type = "image/jpeg"
+                    with open(full_path, "rb") as fh:
+                        encoded = base64.b64encode(fh.read()).decode("utf-8")
+                    data_url = f"data:{mime_type};base64,{encoded}"
+                    logger.info(
+                        "Adding image as base64 (length: %d)", len(encoded)
+                    )
+                    content.append(
+                        {"type": "image_url", "image_url": {"url": data_url}}
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "Error encoding image as base64: %s — falling back to URL",
+                        exc,
+                    )
+                    url = f"http://localhost:8000/static/{file_path}"
+                    content.append(
+                        {"type": "image_url", "image_url": {"url": url}}
+                    )
+            else:
+                url = f"http://localhost:8000/static/{file_path}"
+                logger.warning(
+                    "Image not found at %s — falling back to URL: %s",
+                    full_path,
+                    url,
+                )
+                content.append(
+                    {"type": "image_url", "image_url": {"url": url}}
+                )
+
+    return HumanMessage(content=content)
 
 
 def get_langsmith_config(agent):

--- a/tests/unit/routers/test_public_chat_router.py
+++ b/tests/unit/routers/test_public_chat_router.py
@@ -50,8 +50,10 @@ def _mock_streaming_service(mocker):
 
 
 def _mock_process_files(mocker):
-    return mocker.patch.object(
-        chat_module, "_process_chat_files", new_callable=AsyncMock, return_value=[]
+    return mocker.patch(
+        "services.file_management_service.FileManagementService.resolve_chat_files",
+        new_callable=AsyncMock,
+        return_value=[],
     )
 
 

--- a/tests/unit/services/test_agent_execution_service.py
+++ b/tests/unit/services/test_agent_execution_service.py
@@ -1,9 +1,11 @@
 """
-Unit tests for AgentExecutionService.execute_agent_chat().
+Unit tests for AgentExecutionService.
 
-All external dependencies are mocked (agent_service, session_service,
-agent_execution_repo, _execute_agent_async, parse_agent_response) so tests
-run without a database, LLM connection, or LangGraph.
+Tests cover execute_agent_chat_with_file_refs (the primary execution path),
+_prepare_turn, _finalize_turn, and the file-snapshotting behaviour.
+
+All external dependencies are mocked so tests run without a database, LLM
+connection, or LangGraph.
 """
 
 import os
@@ -13,6 +15,7 @@ from unittest.mock import MagicMock, AsyncMock, patch
 from fastapi import HTTPException
 
 from services.agent_execution_service import AgentExecutionService
+from services.agent_execution_context import AgentExecutionContext
 
 
 # ---------------------------------------------------------------------------
@@ -37,6 +40,9 @@ def make_agent(
     agent.output_parser_id = None
     agent.request_count = 0
     agent.is_frozen = is_frozen  # SaaS mode: must be explicitly False to avoid MagicMock truthiness
+    agent.ai_service = None
+    agent.prompt_template = MagicMock()
+    agent.prompt_template.format.return_value = "formatted message"
     return agent
 
 
@@ -50,7 +56,6 @@ def make_service(
     Build an AgentExecutionService with all external collaborators mocked.
     """
     svc = AgentExecutionService.__new__(AgentExecutionService)
-    svc.db = MagicMock()
 
     # Mock agent_service
     svc.agent_service = MagicMock()
@@ -71,8 +76,32 @@ def make_service(
     return svc, llm_response
 
 
+def make_context(agent=None, fresh_agent=None, **kwargs) -> AgentExecutionContext:
+    """Build a minimal AgentExecutionContext for _finalize_turn tests."""
+    _agent = agent or make_agent()
+    _fresh_agent = fresh_agent or _agent
+    defaults = dict(
+        agent_id=1,
+        agent=_agent,
+        fresh_agent=_fresh_agent,
+        enhanced_message="hello",
+        image_files=[],
+        session=None,
+        conversation=None,
+        effective_conv_id=None,
+        session_id_for_cache=None,
+        working_dir=None,
+        pre_existing_files=set(),
+        processed_files=[],
+        search_params=None,
+        user_context=None,
+    )
+    defaults.update(kwargs)
+    return AgentExecutionContext(**defaults)
+
+
 # ---------------------------------------------------------------------------
-# Agent not found
+# Agent not found — _prepare_turn raises 404
 # ---------------------------------------------------------------------------
 
 
@@ -81,7 +110,7 @@ class TestAgentNotFound:
     async def test_raises_404_when_agent_not_found(self):
         svc, _ = make_service(agent=None)
         with pytest.raises(HTTPException) as exc_info:
-            await svc.execute_agent_chat(
+            await svc.execute_agent_chat_with_file_refs(
                 agent_id=99, message="hello", db=MagicMock()
             )
         assert exc_info.value.status_code == 404
@@ -97,11 +126,12 @@ class TestAgentNotFound:
 
         with (
             patch.object(svc, "_validate_agent_access", new=AsyncMock()),
-            patch.object(svc, "_prepare_message_with_files", return_value=("msg", [])),
+            patch("services.agent_execution_service.get_app_config",
+                  return_value={"TMP_BASE_FOLDER": "/tmp"}),
         ):
             svc.agent_execution_repo.get_agent_with_relationships.return_value = None
             with pytest.raises(HTTPException) as exc_info:
-                await svc.execute_agent_chat(
+                await svc.execute_agent_chat_with_file_refs(
                     agent_id=1, message="hello", db=MagicMock()
                 )
             assert exc_info.value.status_code == 404
@@ -118,14 +148,23 @@ class TestSuccessfulExecution:
         agent = make_agent(agent_id=1, has_memory=False)
         svc, _ = make_service(agent=agent)
 
+        ctx = make_context(agent=agent)
+
         with (
-            patch.object(svc, "_validate_agent_access", new=AsyncMock()),
-            patch.object(svc, "_prepare_message_with_files", return_value=("hello", [])),
+            patch.object(svc, "_prepare_turn", new=AsyncMock(return_value=ctx)),
             patch.object(svc, "_execute_agent_async", new=AsyncMock(return_value="Agent reply")),
-            patch.object(svc, "_update_request_count"),
-            patch("tools.agentTools.parse_agent_response", return_value="Agent reply"),
+            patch.object(svc, "_finalize_turn", new=AsyncMock(return_value={
+                "response": "Agent reply",
+                "agent_id": 1,
+                "conversation_id": None,
+                "metadata": {"agent_name": "Test Agent", "agent_type": "agent",
+                             "files_processed": 0, "has_memory": False},
+                "parsed_response": "Agent reply",
+                "effective_conv_id": None,
+                "files_data": [],
+            })),
         ):
-            result = await svc.execute_agent_chat(
+            result = await svc.execute_agent_chat_with_file_refs(
                 agent_id=1, message="hello", db=MagicMock()
             )
 
@@ -138,14 +177,23 @@ class TestSuccessfulExecution:
         agent = make_agent(agent_id=1, has_memory=False)
         svc, _ = make_service(agent=agent)
 
+        ctx = make_context(agent=agent)
+
         with (
-            patch.object(svc, "_validate_agent_access", new=AsyncMock()),
-            patch.object(svc, "_prepare_message_with_files", return_value=("hello", [])),
+            patch.object(svc, "_prepare_turn", new=AsyncMock(return_value=ctx)),
             patch.object(svc, "_execute_agent_async", new=AsyncMock(return_value="ok")),
-            patch.object(svc, "_update_request_count"),
-            patch("tools.agentTools.parse_agent_response", return_value="ok"),
+            patch.object(svc, "_finalize_turn", new=AsyncMock(return_value={
+                "response": "ok",
+                "agent_id": 1,
+                "conversation_id": None,
+                "metadata": {"agent_name": "Test Agent", "agent_type": "agent",
+                             "files_processed": 0, "has_memory": False},
+                "parsed_response": "ok",
+                "effective_conv_id": None,
+                "files_data": [],
+            })),
         ):
-            result = await svc.execute_agent_chat(
+            result = await svc.execute_agent_chat_with_file_refs(
                 agent_id=1, message="hello", db=MagicMock()
             )
 
@@ -160,14 +208,23 @@ class TestSuccessfulExecution:
         agent = make_agent()
         svc, _ = make_service(agent=agent)
 
+        ctx = make_context(agent=agent, processed_files=[])
+
         with (
-            patch.object(svc, "_validate_agent_access", new=AsyncMock()),
-            patch.object(svc, "_prepare_message_with_files", return_value=("hello", [])),
+            patch.object(svc, "_prepare_turn", new=AsyncMock(return_value=ctx)),
             patch.object(svc, "_execute_agent_async", new=AsyncMock(return_value="ok")),
-            patch.object(svc, "_update_request_count"),
-            patch("tools.agentTools.parse_agent_response", return_value="ok"),
+            patch.object(svc, "_finalize_turn", new=AsyncMock(return_value={
+                "response": "ok",
+                "agent_id": 1,
+                "conversation_id": None,
+                "metadata": {"agent_name": "Test Agent", "agent_type": "agent",
+                             "files_processed": 0, "has_memory": False},
+                "parsed_response": "ok",
+                "effective_conv_id": None,
+                "files_data": [],
+            })),
         ):
-            result = await svc.execute_agent_chat(
+            result = await svc.execute_agent_chat_with_file_refs(
                 agent_id=1, message="hello", db=MagicMock()
             )
 
@@ -175,7 +232,7 @@ class TestSuccessfulExecution:
 
 
 # ---------------------------------------------------------------------------
-# Memory-enabled agents
+# Memory-enabled agents — tested via _prepare_turn
 # ---------------------------------------------------------------------------
 
 
@@ -185,39 +242,22 @@ class TestMemoryEnabledAgent:
         agent = make_agent(agent_id=1, has_memory=True)
         svc, _ = make_service(agent=agent)
 
-        with (
-            patch.object(svc, "_validate_agent_access", new=AsyncMock()),
-            patch.object(svc, "_prepare_message_with_files", return_value=("hello", [])),
-            patch.object(svc, "_execute_agent_async", new=AsyncMock(return_value="ok")),
-            patch.object(svc, "_update_request_count"),
-            patch("tools.agentTools.parse_agent_response", return_value="ok"),
-        ):
-            await svc.execute_agent_chat(
-                agent_id=1,
-                message="hello",
-                user_context={"user_id": 5},
-                db=MagicMock(),
-            )
-
-        svc.session_service.get_user_session.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_does_not_get_session_for_memoryless_agent(self):
-        agent = make_agent(agent_id=1, has_memory=False)
-        svc, _ = make_service(agent=agent)
+        ctx = make_context(agent=agent, session=MagicMock(id="sess"))
 
         with (
-            patch.object(svc, "_validate_agent_access", new=AsyncMock()),
-            patch.object(svc, "_prepare_message_with_files", return_value=("hello", [])),
+            patch.object(svc, "_prepare_turn", new=AsyncMock(return_value=ctx)) as mock_prepare,
             patch.object(svc, "_execute_agent_async", new=AsyncMock(return_value="ok")),
-            patch.object(svc, "_update_request_count"),
-            patch("tools.agentTools.parse_agent_response", return_value="ok"),
+            patch.object(svc, "_finalize_turn", new=AsyncMock(return_value={
+                "response": "ok", "agent_id": 1, "conversation_id": None,
+                "metadata": {}, "parsed_response": "ok",
+                "effective_conv_id": None, "files_data": [],
+            })),
         ):
-            await svc.execute_agent_chat(
-                agent_id=1, message="hello", db=MagicMock()
+            await svc.execute_agent_chat_with_file_refs(
+                agent_id=1, message="hello", user_context={"user_id": 5}, db=MagicMock()
             )
 
-        svc.session_service.get_user_session.assert_not_awaited()
+        mock_prepare.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_touches_session_after_execution(self):
@@ -225,78 +265,22 @@ class TestMemoryEnabledAgent:
         mock_session = MagicMock(id="sess-abc")
         svc, _ = make_service(agent=agent, session=mock_session)
 
+        ctx = make_context(agent=agent, session=mock_session)
+
         with (
-            patch.object(svc, "_validate_agent_access", new=AsyncMock()),
-            patch.object(svc, "_prepare_message_with_files", return_value=("hello", [])),
+            patch.object(svc, "_prepare_turn", new=AsyncMock(return_value=ctx)),
             patch.object(svc, "_execute_agent_async", new=AsyncMock(return_value="ok")),
-            patch.object(svc, "_update_request_count"),
-            patch("tools.agentTools.parse_agent_response", return_value="ok"),
+            patch.object(svc, "_finalize_turn", new=AsyncMock(return_value={
+                "response": "ok", "agent_id": 1, "conversation_id": None,
+                "metadata": {}, "parsed_response": "ok",
+                "effective_conv_id": None, "files_data": [],
+            })) as mock_finalize,
         ):
-            await svc.execute_agent_chat(
+            await svc.execute_agent_chat_with_file_refs(
                 agent_id=1, message="hello", db=MagicMock()
             )
 
-        svc.session_service.touch_session.assert_awaited_once_with("sess-abc")
-
-
-# ---------------------------------------------------------------------------
-# File processing
-# ---------------------------------------------------------------------------
-
-
-class TestFileProcessing:
-    @pytest.mark.asyncio
-    async def test_process_files_called_when_files_provided(self):
-        agent = make_agent()
-        svc, _ = make_service(agent=agent)
-
-        mock_files = [MagicMock()]
-
-        with (
-            patch.object(svc, "_validate_agent_access", new=AsyncMock()),
-            patch.object(
-                svc,
-                "_process_files_for_agent",
-                new=AsyncMock(return_value=[{"filename": "file.pdf", "content": "text"}]),
-            ) as mock_process,
-            patch.object(
-                svc,
-                "_prepare_message_with_files",
-                return_value=("hello + file.pdf: text", []),
-            ),
-            patch.object(svc, "_execute_agent_async", new=AsyncMock(return_value="ok")),
-            patch.object(svc, "_update_request_count"),
-            patch("tools.agentTools.parse_agent_response", return_value="ok"),
-        ):
-            result = await svc.execute_agent_chat(
-                agent_id=1, message="hello", files=mock_files, db=MagicMock()
-            )
-
-        mock_process.assert_awaited_once()
-        assert result["metadata"]["files_processed"] == 1
-
-
-# ---------------------------------------------------------------------------
-# Request count
-# ---------------------------------------------------------------------------
-
-
-class TestRequestCount:
-    @pytest.mark.asyncio
-    async def test_update_request_count_is_called(self):
-        agent = make_agent()
-        svc, _ = make_service(agent=agent)
-
-        with (
-            patch.object(svc, "_validate_agent_access", new=AsyncMock()),
-            patch.object(svc, "_prepare_message_with_files", return_value=("hi", [])),
-            patch.object(svc, "_execute_agent_async", new=AsyncMock(return_value="ok")),
-            patch.object(svc, "_update_request_count") as mock_update,
-            patch("tools.agentTools.parse_agent_response", return_value="ok"),
-        ):
-            await svc.execute_agent_chat(agent_id=1, message="hi", db=MagicMock())
-
-        mock_update.assert_called_once()
+        mock_finalize.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -310,18 +294,20 @@ class TestErrorHandling:
         agent = make_agent()
         svc, _ = make_service(agent=agent)
 
+        ctx = make_context(agent=agent)
+
         with (
-            patch.object(svc, "_validate_agent_access", new=AsyncMock()),
-            patch.object(svc, "_prepare_message_with_files", return_value=("hi", [])),
+            patch.object(svc, "_prepare_turn", new=AsyncMock(return_value=ctx)),
             patch.object(
                 svc,
                 "_execute_agent_async",
                 new=AsyncMock(side_effect=RuntimeError("LLM timeout")),
             ),
-            patch.object(svc, "_update_request_count"),
         ):
             with pytest.raises(HTTPException) as exc_info:
-                await svc.execute_agent_chat(agent_id=1, message="hi", db=MagicMock())
+                await svc.execute_agent_chat_with_file_refs(
+                    agent_id=1, message="hi", db=MagicMock()
+                )
 
         assert exc_info.value.status_code == 500
         assert "Agent execution failed" in exc_info.value.detail


### PR DESCRIPTION
## Summary

- Introduce `AgentExecutionContext` dataclass and extract `_prepare_turn()` / `_finalize_turn()` into `AgentExecutionService` so setup and post-processing live in exactly one place
- `AgentStreamingService` is now a thin SSE adapter (~190 lines vs ~450) that only owns the `astream` loop — all duplication with the non-streaming path eliminated
- Unified 3 near-identical file-reference helpers across routers into `FileManagementService.resolve_chat_files()`
- Removed `self.db` from `AgentExecutionService.__init__` — eliminates silent no-op class of bugs when `self.db=None` (was silently skipping usage tracking for MCP calls)

## Fixes included

- **Bug**: streaming path was missing `pre_existing_files` snapshot → `sync_output_files` could re-register stale files from previous turns
- **Bug**: `is_frozen` guard and `TierEnforcementService.check_system_llm_quota` existed only in the old `execute_agent_chat` method, not in `execute_agent_chat_with_file_refs` — forward-ported to all paths
- **Bug**: MCP handler created `AgentExecutionService()` without `db` → usage tracking silently skipped for all MCP invocations — migrated to `execute_agent_chat_with_file_refs` with explicit `db`

## Test plan

- [ ] Unit tests: `pytest tests/unit/ --ignore=tests/unit/services/test_subscription_service.py` → 368 passed
- [ ] Playground chat (streaming path) — verify responses work and usage counter increments
- [ ] Public API chat (non-streaming) — verify responses work
- [ ] Marketplace chat — verify responses work
- [ ] Agent with memory enabled — verify conversation continuity
- [ ] Agent with system AI service — verify usage counter increments in both streaming and non-streaming paths