### PR TITLE
feat: platform-wide chatbot widget with follow-up suggestions

### DIFF
--- a/backend/routers/internal/__init__.py
+++ b/backend/routers/internal/__init__.py
@@ -12,6 +12,7 @@ from .auth import router as auth_router
 from .user import router as user_router
 from .marketplace import marketplace_router
 from .config import router as config_router
+from .platform_chatbot import platform_chatbot_router
 
 # Create the main internal router
 internal_router = APIRouter()
@@ -29,6 +30,7 @@ internal_router.include_router(auth_router, prefix="/auth")
 internal_router.include_router(user_router)
 internal_router.include_router(marketplace_router)
 internal_router.include_router(config_router)
+internal_router.include_router(platform_chatbot_router, prefix="/platform-chatbot")
 
 # SaaS-specific routers (conditionally registered based on deployment mode)
 from deployment_mode import is_saas_mode

--- a/backend/routers/internal/platform_chatbot.py
+++ b/backend/routers/internal/platform_chatbot.py
@@ -1,0 +1,169 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import StreamingResponse
+from typing import Annotated
+from sqlalchemy.orm import Session
+from lks_idprovider import AuthContext
+
+from db.database import get_db
+from routers.internal.auth_utils import get_current_user_oauth
+from services.system_settings_service import SystemSettingsService
+from services.agent_service import AgentService
+from services.agent_execution_service import AgentExecutionService
+from services.agent_streaming_service import AgentStreamingService
+from schemas.platform_chatbot_schemas import (
+    PlatformChatbotConfigResponse,
+    PlatformChatbotChatRequest,
+)
+from schemas.chat_schemas import ChatResponseSchema
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+platform_chatbot_router = APIRouter(tags=["Platform Chatbot"])
+
+CHATBOT_NOT_CONFIGURED = "Platform chatbot is not configured"
+CHATBOT_AGENT_NOT_FOUND = "Configured chatbot agent not found"
+
+
+def _get_agent_id(db: Session) -> int | None:
+    """Read the configured platform chatbot agent ID from system settings."""
+    return SystemSettingsService(db).get_setting("platform_chatbot_agent_id")
+
+
+@platform_chatbot_router.get(
+    "/config",
+    response_model=PlatformChatbotConfigResponse,
+    summary="Get platform chatbot configuration",
+)
+async def get_platform_chatbot_config(
+    db: Annotated[Session, Depends(get_db)],
+    current_user: Annotated[AuthContext, Depends(get_current_user_oauth)],
+) -> PlatformChatbotConfigResponse:
+    """Return whether the platform chatbot is enabled and its display metadata."""
+    agent_id = _get_agent_id(db)
+    if agent_id is None or agent_id == -1:
+        return PlatformChatbotConfigResponse(enabled=False)
+
+    agent = AgentService().get_agent(db=db, agent_id=agent_id)
+    if agent is None:
+        return PlatformChatbotConfigResponse(enabled=False)
+
+    return PlatformChatbotConfigResponse(
+        enabled=True,
+        agent_name=agent.name,
+        agent_description=agent.description,
+    )
+
+
+@platform_chatbot_router.post(
+    "/chat",
+    response_model=ChatResponseSchema,
+    summary="Send a message to the platform chatbot",
+)
+async def platform_chatbot_chat(
+    body: PlatformChatbotChatRequest,
+    db: Annotated[Session, Depends(get_db)],
+    current_user: Annotated[AuthContext, Depends(get_current_user_oauth)],
+) -> ChatResponseSchema:
+    """Proxy a chat message to the configured platform chatbot agent."""
+    agent_id = _get_agent_id(db)
+    if agent_id is None or agent_id == -1:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=CHATBOT_NOT_CONFIGURED,
+        )
+
+    agent = AgentService().get_agent(db=db, agent_id=agent_id)
+    if agent is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=CHATBOT_AGENT_NOT_FOUND,
+        )
+
+    user_context = {
+        "user_id": int(current_user.identity.id),
+        "email": current_user.identity.email,
+        "oauth": True,
+        "app_id": agent.app_id,
+    }
+
+    try:
+        result = await AgentExecutionService().execute_agent_chat_with_file_refs(
+            agent_id=agent.agent_id,
+            message=body.message,
+            file_references=None,
+            search_params=None,
+            user_context=user_context,
+            conversation_id=None,
+            db=db,
+        )
+        return ChatResponseSchema(**result)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Platform chatbot execution error: {exc}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Chatbot temporarily unavailable",
+        )
+
+
+@platform_chatbot_router.post(
+    "/chat/stream",
+    summary="Stream a message to the platform chatbot via SSE",
+)
+async def platform_chatbot_chat_stream(
+    body: PlatformChatbotChatRequest,
+    db: Annotated[Session, Depends(get_db)],
+    current_user: Annotated[AuthContext, Depends(get_current_user_oauth)],
+) -> StreamingResponse:
+    """Stream a chat response from the configured platform chatbot agent via SSE."""
+    agent_id = _get_agent_id(db)
+    if agent_id is None or agent_id == -1:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=CHATBOT_NOT_CONFIGURED,
+        )
+
+    agent = AgentService().get_agent(db=db, agent_id=agent_id)
+    if agent is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=CHATBOT_AGENT_NOT_FOUND,
+        )
+
+    user_context = {
+        "user_id": int(current_user.identity.id),
+        "email": current_user.identity.email,
+        "oauth": True,
+        "app_id": agent.app_id,
+    }
+
+    try:
+        streaming_service = AgentStreamingService(db)
+        generator = streaming_service.stream_agent_chat(
+            agent_id=agent.agent_id,
+            message=body.message,
+            file_references=None,
+            search_params=None,
+            user_context=user_context,
+            conversation_id=None,
+            db=db,
+        )
+        return StreamingResponse(
+            generator,
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Platform chatbot streaming error: {exc}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Chatbot temporarily unavailable",
+        )

--- a/backend/schemas/platform_chatbot_schemas.py
+++ b/backend/schemas/platform_chatbot_schemas.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class PlatformChatbotConfigResponse(BaseModel):
+    """Response schema for the platform chatbot config endpoint."""
+    enabled: bool
+    agent_name: Optional[str] = None
+    agent_description: Optional[str] = None
+
+
+class PlatformChatbotChatRequest(BaseModel):
+    """Request schema for platform chatbot chat endpoints."""
+    message: str
+    session_id: str

--- a/backend/services/resource_service.py
+++ b/backend/services/resource_service.py
@@ -14,7 +14,7 @@ logger = get_logger(__name__)
 class ResourceService:
 
     # Supported file extensions
-    SUPPORTED_EXTENSIONS = {'.pdf', '.docx', '.txt'}
+    SUPPORTED_EXTENSIONS = {'.pdf', '.docx', '.txt', '.md'}
 
 
     @staticmethod

--- a/backend/services/silo_service.py
+++ b/backend/services/silo_service.py
@@ -420,7 +420,7 @@ class SiloService:
             loader = PyPDFLoader(file_path, extract_images=False)
         elif file_extension == '.docx':
             loader = Docx2txtLoader(file_path)
-        elif file_extension == '.txt':
+        elif file_extension in ('.txt', '.md'):
             loader = TextLoader(file_path, encoding='utf-8')
         else:
             logger.error(f"Unsupported file type: {file_extension}")

--- a/backend/system_defaults.yaml
+++ b/backend/system_defaults.yaml
@@ -10,6 +10,12 @@ settings:
     category: "marketplace"
     description: "Maximum API calls per user per month to marketplace agents. 0 = unlimited."
 
+  platform_chatbot_agent_id:
+    value: "-1"
+    type: "integer"
+    category: "platform"
+    description: "Agent ID for the platform-wide chatbot widget. -1 = disabled."
+
 # Tier configuration defaults - used when no DB override exists
 # -1 means unlimited
 tier_config:

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ The project aims to simplify the integration and use of AI technologies within L
 - [Authentication Guide](guides/authentication.md) — OIDC, Entra ID, FAKE mode, and session auth
 - [App Export and Import](guides/app-export-import.md) — Export app configuration and import into a new workspace
 - [Agent Marketplace](guides/marketplace.md) — Publish agents to the platform-wide marketplace, manage profiles, ratings, and quotas
+- [Platform Chatbot](guides/platform-chatbot.md) — Configure a global AI assistant widget backed by any agent; includes knowledge base files and prompt template for a platform guide agent
 
 ### Testing
 - [Testing Overview](testing/README.md) — Test pyramid, quick start, running tests for the first time

--- a/docs/guides/chat-bot/README.md
+++ b/docs/guides/chat-bot/README.md
@@ -1,0 +1,51 @@
+# Platform Chatbot — Knowledge Base & Prompt Template
+
+> Part of [Platform Chatbot Guide](../platform-chatbot.md) · [Mattin AI Documentation](../../index.md)
+
+## What Is This?
+
+This folder contains ready-to-use materials for setting up a **platform guide agent** — an AI assistant that helps users navigate and get the most out of Mattin AI.
+
+You can use these files as the knowledge base for the platform chatbot by indexing them into a Silo (via a Repository). Any user who wants to deploy a guide bot can copy these files manually and upload them to their setup.
+
+---
+
+## Contents
+
+| File | Description |
+|------|-------------|
+| [`agent-prompt.md`](agent-prompt.md) | System prompt template for the guide agent |
+| [`kb-overview.md`](kb-overview.md) | What Mattin AI is and how it is organized |
+| [`kb-apps.md`](kb-apps.md) | Apps (workspaces), roles, and collaboration |
+| [`kb-ai-services.md`](kb-ai-services.md) | Configuring LLM providers (AI Services) |
+| [`kb-agents.md`](kb-agents.md) | Creating and configuring agents |
+| [`kb-silos-and-rag.md`](kb-silos-and-rag.md) | Silos, Repositories, Domains, and RAG |
+| [`kb-conversations.md`](kb-conversations.md) | Playground, conversations, and file attachments |
+| [`kb-skills.md`](kb-skills.md) | Skills — reusable prompt blocks |
+| [`kb-output-parsers.md`](kb-output-parsers.md) | Output parsers for structured responses |
+| [`kb-marketplace.md`](kb-marketplace.md) | Agent Marketplace — discovering and sharing agents |
+| [`kb-mcp.md`](kb-mcp.md) | MCP integration — connecting external tools |
+
+---
+
+## How to Use
+
+### Option A — Repository (recommended)
+
+1. Create a **Silo** in your app (e.g. "Platform Guide KB").
+2. Create a **Repository** inside that Silo.
+3. Upload all `kb-*.md` files to the Repository. The platform will vectorize them automatically.
+4. Create an agent, link it to the Silo, and paste the contents of `agent-prompt.md` as the system prompt.
+5. Enable the agent as the platform chatbot in **System Settings → Platform**.
+
+### Option B — System prompt only (no RAG)
+
+If you prefer a self-contained agent without a knowledge base, paste the contents of all `kb-*.md` files directly into the system prompt (after the role instructions in `agent-prompt.md`). Note that this approach is limited by the LLM's context window and works best with concise models.
+
+---
+
+## Customizing
+
+- Edit `agent-prompt.md` to reflect your organization's name, tone, and any platform-specific notes.
+- Add your own `kb-*.md` files to cover internal processes, team conventions, or custom platform extensions.
+- Remove files that are not relevant to your users (e.g. `kb-mcp.md` if your users don't use MCP).

--- a/docs/guides/chat-bot/agent-prompt.md
+++ b/docs/guides/chat-bot/agent-prompt.md
@@ -1,0 +1,63 @@
+# Platform Guide Agent — System Prompt Template
+
+Copy the text below as the **system prompt** of your guide agent. Adjust the bracketed sections to match your organization.
+
+---
+
+```
+You are the Mattin AI Platform Assistant — a helpful, friendly guide for users of [Your Organization]'s Mattin AI platform.
+
+Your role is to help users:
+- Understand the core concepts of the platform (Apps, Agents, Silos, AI Services, etc.)
+- Navigate the interface and find the right features for their needs
+- Complete common tasks step by step (create an agent, upload documents, start a conversation, etc.)
+- Troubleshoot common problems
+
+## CRITICAL: Response format
+
+You MUST respond with ONLY a raw JSON object. No text before it, no text after it, no markdown code fences, no explanations outside the JSON. Your entire response must be parseable by JSON.parse().
+
+Format:
+
+{"content": "Your answer here.", "follow_ups": ["Follow-up question 1", "Follow-up question 2"]}
+
+Rules:
+- Output ONLY the JSON object — nothing else. Not even a greeting before it.
+- "content": your full answer. Use markdown inside this string (bullet points, numbered steps, **bold**, etc.). Escape newlines as \n.
+- "follow_ups": array of 2–3 short, specific follow-up questions the user might want to ask next.
+- Every response, without exception, must start with { and end with }.
+
+Example:
+{
+  "content": "To create an agent:\n1. Open your App and go to **Agents**.\n2. Click **New Agent**.\n3. Fill in the name and select an AI Service.\n4. Write a system prompt, then save.",
+  "follow_ups": [
+    "How do I link a knowledge base to my agent?",
+    "What should I write in the system prompt?",
+    "How do I test the agent after creating it?"
+  ]
+}
+
+## How to respond
+
+- Be concise and clear. Prefer short, direct answers over long explanations.
+- When explaining how to do something, use numbered steps inside "content".
+- If a question is outside the scope of the platform, say so politely and redirect to what you can help with.
+- Do not make up features or settings that you are not sure exist. If you are uncertain, say so and suggest the user check the documentation or contact an administrator.
+- Do not ask for or handle sensitive information (passwords, API keys, personal data).
+
+## Tone
+
+[Adjust to your organization's preferences — e.g.: "Professional and concise." or "Friendly and approachable."]
+
+## Platform context
+
+The platform is Mattin AI — an extensible AI toolbox. Users interact with it through a web interface. The key concepts they will ask about are: Apps, Agents, AI Services, Silos, Repositories, Domains, Conversations (Playground), Skills, Output Parsers, MCP, and the Agent Marketplace.
+
+If you have access to a knowledge base (Silo), use it to retrieve accurate, up-to-date answers. Prefer retrieved content over your general knowledge when answering platform-specific questions.
+
+## What you cannot do
+
+- You cannot make changes to the platform on behalf of the user — you can only guide them.
+- You do not have access to user data, configurations, or any specific app's content.
+- You cannot reset passwords or manage accounts.
+```

--- a/docs/guides/chat-bot/kb-agents.md
+++ b/docs/guides/chat-bot/kb-agents.md
@@ -1,0 +1,67 @@
+# Agents
+
+## What is an Agent?
+
+An **Agent** is an AI assistant you configure inside an App. You control its personality and instructions (via a system prompt), the LLM it uses, whether it has access to a knowledge base, and what tools it can call.
+
+## Creating an Agent
+
+1. Open your App and go to **Agents**.
+2. Click **New Agent**.
+3. Fill in the required fields:
+   - **Name** — a label for this agent
+   - **AI Service** — the LLM to use
+4. Optionally configure:
+   - **System Prompt** — instructions that define the agent's role and behavior
+   - **Description** — a short summary (shown in the UI and Marketplace)
+   - **Silo** — link a knowledge base for retrieval-augmented generation (RAG)
+   - **Temperature** — controls response randomness (0 = deterministic, 1 = creative)
+5. Save.
+
+## System Prompt
+
+The system prompt is the most important configuration field. It tells the agent:
+- What its role is ("You are a customer support agent for Acme Corp.")
+- How it should behave ("Be concise. Answer only questions related to our products.")
+- Any constraints ("Do not discuss competitors.")
+
+A good system prompt is specific, clear, and tested interactively in the Playground.
+
+## Linking a Knowledge Base (RAG)
+
+If your agent needs to answer questions based on specific documents:
+1. Create a **Silo** and populate it with your documents (see [Silos and RAG](kb-silos-and-rag.md)).
+2. In the agent configuration, set the **Silo** field to that Silo.
+3. When users send messages, the agent automatically searches the Silo for relevant content and uses it to inform its answers.
+
+## Memory
+
+Agents can remember previous messages in a conversation. By default:
+- **Memory** is enabled — the agent remembers the conversation history.
+- **Max messages**: configurable limit on how many messages are kept.
+- **Max tokens**: configurable token budget for the memory window.
+- **Summarize threshold**: when reached, old messages are automatically summarized to save space.
+
+Memory is per conversation session — different conversations with the same agent do not share memory.
+
+## Temperature
+
+| Value | Effect |
+|-------|--------|
+| 0.0 – 0.3 | Consistent, factual, deterministic |
+| 0.4 – 0.7 | Balanced (default: 0.7) |
+| 0.8 – 1.0 | Creative, varied, less predictable |
+
+Use low temperature for support bots, data extraction, or factual Q&A. Use higher temperature for creative writing or brainstorming.
+
+## Agent as Tool
+
+Agents with **"Use as Tool"** enabled can be used by other agents as a callable sub-agent. This allows you to build multi-agent workflows where a coordinator agent delegates to specialist agents.
+
+## OCR Agent
+
+**OCR Agents** are a special subtype designed to process scanned documents. They use two LLMs: a vision model for reading the scanned pages, and a text model for structuring the output. OCR Agents appear as a separate type when creating an agent.
+
+## Deleting an Agent
+
+Deleting an agent removes it and all its conversations permanently. If the agent is configured as the platform chatbot, the widget will automatically disappear until a new agent is configured.

--- a/docs/guides/chat-bot/kb-ai-services.md
+++ b/docs/guides/chat-bot/kb-ai-services.md
@@ -1,0 +1,40 @@
+# AI Services
+
+## What is an AI Service?
+
+An **AI Service** is a connection to an LLM (Large Language Model) provider. Agents use AI Services to power their responses. You configure the provider, model, and API key once — then any agent in your App can use it.
+
+## Supported Providers
+
+| Provider | Notes |
+|----------|-------|
+| **OpenAI** | GPT-4, GPT-4o, GPT-3.5, and other OpenAI models |
+| **Anthropic** | Claude models (Claude 3.5, Claude 3, etc.) |
+| **Azure OpenAI** | OpenAI models hosted on Azure (requires endpoint + deployment name) |
+| **MistralAI** | Mistral models |
+| **Google** | Gemini models |
+| **Custom** | Any OpenAI-compatible API endpoint (local models, LM Studio, Ollama, etc.) |
+
+## Creating an AI Service
+
+1. Open your App and go to **AI Services**.
+2. Click **New AI Service**.
+3. Select the provider.
+4. Enter the required fields:
+   - **Name** — a label for this service (e.g. "GPT-4o Production")
+   - **Model** — the model identifier (e.g. `gpt-4o`, `claude-3-5-sonnet-20241022`)
+   - **API Key** — your provider's API key
+   - For Azure: also the endpoint URL and deployment name
+5. Save.
+
+## Using an AI Service
+
+When creating an agent, select the AI Service in the **LLM Service** field. The agent will use that model for all its responses.
+
+## System AI Services
+
+Platform administrators may configure system-level AI Services that are available to all Apps without users needing to provide their own API keys. These appear in the AI Service selector alongside your own services.
+
+## Embedding Services
+
+**Embedding Services** are similar to AI Services but are used for generating vector embeddings for Silos (knowledge bases). They are configured separately under **Embedding Services** in your App. The supported providers are the same as for AI Services.

--- a/docs/guides/chat-bot/kb-apps.md
+++ b/docs/guides/chat-bot/kb-apps.md
@@ -1,0 +1,38 @@
+# Apps and Workspaces
+
+## What is an App?
+
+An **App** is the top-level workspace in Mattin AI. Everything you create — agents, knowledge bases, AI service connections, API keys — lives inside an App. You can have multiple Apps for different teams, projects, or purposes.
+
+## Creating an App
+
+1. Click **New App** from the home screen or the app selector.
+2. Give it a name and an optional description.
+3. The App is created and you become its **Owner**.
+
+## Roles
+
+Every member of an App has a role that controls what they can do:
+
+| Role | Permissions |
+|------|-------------|
+| **Viewer** | Can view agents and conversations, but cannot create or edit anything |
+| **Editor** | Can create and edit agents, silos, skills, and other resources |
+| **Administrator** | Can manage collaborators and all resources |
+| **Owner** | Full control, including deleting the App |
+| **Omniadmin** | Platform-wide admin — can access all Apps and system settings |
+
+## Inviting Collaborators
+
+1. Open your App and go to **Settings → Collaborators**.
+2. Enter the email address of the person you want to invite.
+3. Choose their role (Viewer, Editor, or Administrator).
+4. They receive an invitation. Once they accept, they can access the App.
+
+## Switching Between Apps
+
+Use the **App selector** at the top of the page to switch between your Apps.
+
+## Deleting an App
+
+Only the **Owner** can delete an App. Deleting an App permanently removes all its agents, silos, conversations, and other resources. This action cannot be undone.

--- a/docs/guides/chat-bot/kb-conversations.md
+++ b/docs/guides/chat-bot/kb-conversations.md
@@ -1,0 +1,50 @@
+# Conversations and the Playground
+
+## What is the Playground?
+
+The **Playground** is the chat interface where you interact with an agent. Each Playground session is a **Conversation** — a persistent chat thread with its own history.
+
+## Starting a Conversation
+
+1. Open your App and go to **Agents**.
+2. Click on an agent to open it.
+3. Click **Open Playground** (or the chat icon).
+4. Type a message and press **Enter** or click **Send**.
+
+## Conversation History
+
+Conversations are saved automatically. You can:
+- Return to a previous conversation and continue where you left off.
+- Browse all your conversations for a specific agent.
+- Delete conversations you no longer need.
+
+## File Attachments
+
+You can attach files to messages in the Playground. The agent will process the file and use its content to answer your question.
+
+**Supported file types:**
+
+| Type | How the agent uses it |
+|------|----------------------|
+| PDF | Extracts and reads the text |
+| Images (PNG, JPG) | Reads text via OCR, or analyzes the image directly (if the LLM is multimodal) |
+| Audio (MP3, WAV) | Transcribes the audio to text |
+| TXT, MD | Reads the content directly |
+
+**How to attach a file:**
+1. Click the attachment icon (paperclip) in the chat input area.
+2. Select the file from your device.
+3. Type your message and send.
+
+## Streaming Responses
+
+Responses appear word by word as the LLM generates them (streaming). You can stop a response mid-stream by clicking **Stop**.
+
+## Clearing Memory
+
+If the agent is configured with memory, it remembers previous messages in the conversation. To start a fresh session:
+- Click **New Conversation** to create a new thread. The old conversation is preserved in history.
+
+## The Platform Chatbot
+
+The floating chat button in the bottom-right corner of the platform (if enabled by your administrator) is the **Platform Chatbot** — a special agent available on every page. It works just like the Playground but is always accessible. Your conversation with it persists across page navigations. Click **New conversation** in its header to start fresh.

--- a/docs/guides/chat-bot/kb-marketplace.md
+++ b/docs/guides/chat-bot/kb-marketplace.md
@@ -1,0 +1,57 @@
+# Agent Marketplace
+
+## What is the Marketplace?
+
+The **Agent Marketplace** is a platform-wide catalog where teams can publish agents and make them available to other users — without those users needing their own App or AI service configuration.
+
+Think of it as an internal app store for AI agents.
+
+## Browsing the Marketplace
+
+1. Go to **Marketplace** in the main navigation.
+2. Browse the catalog or search by name, description, or tag.
+3. Filter by category (Productivity, Research, Writing, Code, Data Analysis, etc.).
+4. Click an agent card to see its full description.
+
+## Chatting with a Marketplace Agent
+
+1. Open an agent's detail page in the Marketplace.
+2. Click **Start conversation**.
+3. Chat with the agent just as you would in the Playground.
+
+Marketplace conversations are separate from your App's agent conversations — they are tracked independently.
+
+## Rating an Agent
+
+After having at least one conversation with a marketplace agent, you can give it a star rating (1–5):
+1. Open the agent's detail page.
+2. Click the star rating widget.
+3. Your rating contributes to the agent's average score shown in the catalog.
+
+## Publishing an Agent
+
+If you have **Editor** role or higher on an App, you can publish agents from that App to the Marketplace.
+
+1. Open the agent in your App.
+2. Go to **Marketplace Settings**.
+3. Create a **Marketplace Profile**:
+   - Display name and description (shown in the catalog)
+   - Category and tags
+   - Optional icon and cover image
+4. Set **Visibility** to `Private` (visible to your collaborators) or `Public` (visible to all platform users).
+
+Unpublished agents are not visible in the catalog.
+
+## Marketplace Quotas
+
+Platform administrators can set a **monthly call quota** per user for marketplace agents. If you reach your quota, you will see a message in the chat and will not be able to send more messages until the next month.
+
+Omniadmin users are always exempt from quotas.
+
+## Visibility Levels
+
+| Level | Who sees it |
+|-------|------------|
+| **Unpublished** (default) | Only members of the owning App |
+| **Private** | Members and accepted collaborators of the owning App |
+| **Public** | All authenticated platform users |

--- a/docs/guides/chat-bot/kb-mcp.md
+++ b/docs/guides/chat-bot/kb-mcp.md
@@ -1,0 +1,77 @@
+# MCP Integration
+
+## What is MCP?
+
+**MCP** (Model Context Protocol) is an open standard for connecting AI agents to external tools and data sources. Mattin AI supports MCP in two directions:
+
+| Direction | Description |
+|-----------|-------------|
+| **MCP Client** | Your agents connect to external MCP servers and use their tools |
+| **MCP Server** | Your agents are exposed as MCP tools to external clients (e.g. Claude Desktop, Cursor) |
+
+## MCP Client — Using External Tools
+
+You can connect your agents to any MCP-compatible tool server. This gives agents access to external capabilities such as database queries, file systems, APIs, or custom business tools.
+
+### Adding an MCP Config to your App
+
+1. Open your App and go to **MCP Configs**.
+2. Click **New MCP Config**.
+3. Enter the server connection details (URL, transport type, and any required authentication).
+4. Save.
+
+### Attaching an MCP Config to an Agent
+
+1. Open the agent configuration.
+2. Go to the **MCP** section.
+3. Select one or more MCP Configs.
+4. Save.
+
+The agent will now have access to the tools provided by those MCP servers during conversations.
+
+## MCP Server — Exposing Your Agents
+
+You can expose one or more of your agents as MCP tools, allowing external AI clients (Claude Desktop, Cursor, custom apps) to call them.
+
+### Creating an MCP Server
+
+1. Open your App and go to **MCP Servers**.
+2. Click **New MCP Server**.
+3. Give it a name.
+4. Select the **agents** you want to expose as tools.
+5. Save.
+
+The platform will provide a connection URL and an API key for external clients to connect to this MCP Server.
+
+### Connecting from an External Client
+
+Use the connection details provided by the MCP Server configuration. For example, in Claude Desktop's `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "my-mattin-agents": {
+      "url": "https://your-platform/mcp/v1/...",
+      "headers": {
+        "X-API-KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+## API Keys for MCP Access
+
+External MCP clients and the public API authenticate using **API Keys**.
+
+To create an API Key:
+1. Open your App and go to **API Keys**.
+2. Click **New API Key**.
+3. Copy the key — it is shown only once.
+4. Use it as the `X-API-KEY` header in API or MCP requests.
+
+## Notes
+
+- MCP tools are only available when the agent is actively processing a message — they are not background processes.
+- Tool results are included in the agent's context and may be visible in the conversation.
+- Connecting to external MCP servers requires the server to be accessible from the platform's network.

--- a/docs/guides/chat-bot/kb-output-parsers.md
+++ b/docs/guides/chat-bot/kb-output-parsers.md
@@ -1,0 +1,60 @@
+# Output Parsers
+
+## What is an Output Parser?
+
+An **Output Parser** defines a JSON schema that forces an agent to return structured data instead of free-form text. This is useful when you need the agent's response to be machine-readable — for example, to feed it into another system, display it in a form, or process it programmatically.
+
+When an Output Parser is attached to an agent, the LLM is instructed to always return a JSON object that matches the defined schema.
+
+## Creating an Output Parser
+
+1. Open your App and go to **Output Parsers**.
+2. Click **New Output Parser**.
+3. Give it a name.
+4. Define the **JSON schema** — describe the fields you want the agent to return.
+5. Save.
+
+## Example
+
+**Schema:**
+```json
+{
+  "type": "object",
+  "properties": {
+    "summary": { "type": "string", "description": "A one-sentence summary" },
+    "sentiment": { "type": "string", "enum": ["positive", "neutral", "negative"] },
+    "action_required": { "type": "boolean" }
+  },
+  "required": ["summary", "sentiment", "action_required"]
+}
+```
+
+**Agent response (with this parser):**
+```json
+{
+  "summary": "The customer is happy with the product but had a shipping issue.",
+  "sentiment": "positive",
+  "action_required": true
+}
+```
+
+## Attaching an Output Parser to an Agent
+
+1. Open the agent configuration.
+2. Set the **Output Parser** field.
+3. Save.
+
+All responses from this agent will now follow the defined schema.
+
+## When to Use Output Parsers
+
+- **Data extraction**: Extract specific fields from documents or user inputs.
+- **Classification**: Classify messages into categories.
+- **Automation**: Feed structured agent output into workflows, databases, or APIs.
+- **Form filling**: Have the agent populate a structured form from unstructured input.
+
+## Notes
+
+- Output Parsers work best with capable LLMs (GPT-4, Claude 3+). Smaller models may not reliably follow complex schemas.
+- The Playground displays structured output in a readable format.
+- If the LLM fails to produce valid JSON, the platform returns the raw response with an error indicator.

--- a/docs/guides/chat-bot/kb-overview.md
+++ b/docs/guides/chat-bot/kb-overview.md
@@ -1,0 +1,43 @@
+# Mattin AI — Platform Overview
+
+## What is Mattin AI?
+
+Mattin AI is an AI toolbox platform that lets teams create, configure, and use AI-powered assistants and workflows. It brings together large language models (LLMs), knowledge bases, and automation tools in a single web interface — without requiring users to write code.
+
+## Main Concepts
+
+| Concept | What it is |
+|---------|-----------|
+| **App** | A workspace that groups all your AI resources together. Think of it as a project or team space. |
+| **Agent** | An AI assistant you configure. You define its instructions, the LLM it uses, and optionally a knowledge base. |
+| **AI Service** | A connection to an LLM provider (OpenAI, Anthropic, Azure, etc.). Agents use AI Services to power their responses. |
+| **Silo** | A vector knowledge base. You fill it with documents or web content; agents search it to give informed answers. |
+| **Repository** | A collection of uploaded files inside a Silo. |
+| **Domain** | A web source whose pages are crawled and indexed into a Silo. |
+| **Conversation** | A chat session with an agent (also called the Playground). |
+| **Skill** | A reusable block of instructions that can be attached to agents. |
+| **Output Parser** | A schema that makes an agent return structured data (JSON) instead of free text. |
+| **MCP** | Model Context Protocol — a standard for connecting agents to external tools and services. |
+| **Marketplace** | A catalog of shared agents that can be used across the platform. |
+
+## How Everything Fits Together
+
+```
+App (workspace)
+├── AI Services      ← LLM provider connections
+├── Agents           ← AI assistants (use AI Services + optional Silo)
+│   ├── Skills       ← Reusable instruction blocks
+│   └── Output Parser ← Structured response schema
+├── Silos            ← Knowledge bases
+│   ├── Repositories ← Uploaded document collections
+│   └── Domains      ← Crawled web sources
+└── Conversations    ← Chat sessions with agents
+```
+
+## Getting Started
+
+1. Create an **App** (your workspace).
+2. Add an **AI Service** to connect an LLM provider.
+3. Create an **Agent** and configure its instructions and LLM.
+4. Optionally, create a **Silo** and upload documents for the agent to search.
+5. Chat with the agent in the **Playground**.

--- a/docs/guides/chat-bot/kb-silos-and-rag.md
+++ b/docs/guides/chat-bot/kb-silos-and-rag.md
@@ -1,0 +1,74 @@
+# Silos, Repositories, Domains, and RAG
+
+## What is a Silo?
+
+A **Silo** is a knowledge base. It stores documents and web content as vector embeddings so that agents can search it semantically — finding relevant information even when the user's question doesn't match exact keywords.
+
+When an agent has a linked Silo, it automatically retrieves relevant content from the Silo before answering. This technique is called **RAG** (Retrieval-Augmented Generation).
+
+## Creating a Silo
+
+1. Open your App and go to **Silos**.
+2. Click **New Silo**.
+3. Give it a name (e.g. "Product Documentation").
+4. Select an **Embedding Service** — this determines how documents are vectorized.
+5. Save.
+
+The Silo is now empty. You need to populate it with content via Repositories or Domains.
+
+## Repositories — Uploading Files
+
+A **Repository** is a collection of uploaded files inside a Silo.
+
+**To add a Repository:**
+1. Open a Silo and click **New Repository**.
+2. Give it a name.
+3. Upload files — supported formats: PDF, Word, TXT, Markdown, images (with OCR), and audio (transcribed).
+
+Uploaded files are automatically processed and indexed into the Silo's vector store. Large documents are chunked automatically.
+
+**Supported file types:**
+
+| Type | Processing |
+|------|-----------|
+| PDF | Text extraction (or OCR if scanned) |
+| DOCX, TXT, MD | Direct text extraction |
+| Images (PNG, JPG) | OCR via vision model |
+| Audio (MP3, WAV) | Transcription via Whisper |
+
+## Domains — Web Crawling
+
+A **Domain** is a web source whose pages are crawled and indexed into a Silo.
+
+**To add a Domain:**
+1. Open a Silo and click **New Domain**.
+2. Enter the base URL (e.g. `https://docs.yourcompany.com`).
+3. Configure the crawl depth and any URL filters.
+4. Start the crawl.
+
+Pages discovered during the crawl are vectorized and stored in the Silo. You can re-crawl a Domain to pick up updated content.
+
+## Linking a Silo to an Agent
+
+1. Open the agent configuration.
+2. Set the **Silo** field to the Silo you want the agent to search.
+3. Save.
+
+The agent will now automatically search the Silo for relevant content when answering questions.
+
+## RAG in Practice
+
+When a user sends a message to an agent with a linked Silo:
+
+1. The platform searches the Silo for document chunks semantically similar to the user's message.
+2. The relevant chunks are injected into the agent's context alongside the user's message.
+3. The agent uses that context to give a grounded, accurate answer.
+
+The agent can tell the user which document a piece of information came from if the system prompt instructs it to do so.
+
+## Tips
+
+- **Keep documents clean**: Remove headers/footers, page numbers, and boilerplate before uploading for better retrieval quality.
+- **Chunk size matters**: Very long documents may need to be split manually if retrieval quality is poor.
+- **Re-index after updates**: If you update a document, delete the old version and re-upload to refresh the index.
+- **Test retrieval**: Use the agent's Playground to ask questions and check whether it retrieves the right content.

--- a/docs/guides/chat-bot/kb-skills.md
+++ b/docs/guides/chat-bot/kb-skills.md
@@ -1,0 +1,43 @@
+# Skills
+
+## What is a Skill?
+
+A **Skill** is a reusable block of instructions (Markdown text) that can be attached to one or more agents. When a skill is attached to an agent, its content is automatically injected into the agent's system prompt at execution time.
+
+Skills are useful for:
+- Shared instructions that apply to multiple agents (e.g. "Always respond in the user's language.")
+- Domain knowledge that doesn't belong in the main system prompt (e.g. a glossary, a list of products, a formatting guide).
+- Modular prompt building — combine a base agent with different skill sets for different contexts.
+
+## Creating a Skill
+
+1. Open your App and go to **Skills**.
+2. Click **New Skill**.
+3. Enter a **Name** and a **Description** (used to help the agent understand when to apply the skill).
+4. Write the **content** — plain text or Markdown instructions.
+5. Save.
+
+## Attaching a Skill to an Agent
+
+1. Open the agent configuration.
+2. Go to the **Skills** section.
+3. Select one or more skills from your App's skill library.
+4. Save.
+
+The skill content is injected into the system prompt automatically every time the agent runs.
+
+## Example Use Cases
+
+| Skill | Content |
+|-------|---------|
+| Language rule | "Always respond in the same language the user writes in." |
+| Tone guide | "Use a formal, professional tone. Avoid jargon." |
+| Product glossary | A list of product names, abbreviations, and definitions. |
+| Formatting rules | "Format all lists with bullet points. Use headers for sections." |
+| Escalation instructions | "If you cannot answer, tell the user to contact support@company.com." |
+
+## Notes
+
+- Skills are scoped to an App — they cannot be shared directly across Apps (but you can copy the content).
+- The order in which skills are injected follows the order they were attached to the agent.
+- Keep skills focused and concise. Very long skills can consume a large portion of the LLM's context window.

--- a/docs/guides/platform-chatbot.md
+++ b/docs/guides/platform-chatbot.md
@@ -1,0 +1,121 @@
+# Platform Chatbot Guide
+
+> Part of [Mattin AI Documentation](../index.md)
+
+## Overview
+
+The **Platform Chatbot** is a global AI assistant widget that appears as a floating button in the bottom-right corner of the Mattin AI interface. When enabled, it is available to all logged-in users on every page of the platform.
+
+An OMNIADMIN configures any existing agent as the backend for the chatbot. That agent can have a knowledge base (Silo), skills, memory, and any other capabilities — making it suitable for use cases such as platform onboarding guides, internal FAQ bots, IT support assistants, or general-purpose helpers.
+
+---
+
+## How It Works
+
+1. The OMNIADMIN sets `platform_chatbot_agent_id` in **System Settings → Platform** to the ID of the desired agent.
+2. On login, the platform checks whether a valid chatbot agent is configured.
+3. If configured, a floating chat button appears in the bottom-right corner for all users.
+4. Clicking the button opens a chat panel backed by the configured agent.
+5. Conversations persist per user across page navigations and browser reloads.
+
+The chatbot calls do **not** count toward any usage quotas (SaaS tier LLM call limits or marketplace quotas).
+
+---
+
+## Configuration
+
+### Step 1 — Prepare the agent
+
+Before enabling the chatbot, create and configure the agent you want to use:
+
+1. Go to any App you manage.
+2. Create a new agent (or use an existing one).
+3. Configure the agent's system prompt, LLM service, and optionally a Silo for knowledge retrieval.
+4. Test the agent in the Playground to make sure it behaves as expected.
+5. Note the agent's **ID** — you will need it in the next step.
+
+> **Finding the agent ID**: Open the agent in the UI. The ID appears in the browser URL:
+> `…/apps/{app_id}/agents/{agent_id}`
+
+### Step 2 — Enable the chatbot in System Settings
+
+Requires **OMNIADMIN** role.
+
+1. Go to **System Settings** (top-level admin menu).
+2. Select the **Platform** category.
+3. Set `platform_chatbot_agent_id` to the agent's integer ID.
+4. Save. The chatbot becomes active immediately for all users on their next page load (no restart required).
+
+### Step 3 — Disable the chatbot
+
+Set `platform_chatbot_agent_id` back to `-1` (the default). The widget will no longer appear.
+
+---
+
+## System Setting Reference
+
+| Setting key | Type | Default | Description |
+|-------------|------|---------|-------------|
+| `platform_chatbot_agent_id` | integer | `-1` | ID of the agent to use as the platform chatbot. `-1` = disabled. |
+
+This setting is stored in `backend/system_defaults.yaml` under the `platform` category and can be overridden via the environment variable `AICT_SYSTEM_PLATFORM_CHATBOT_AGENT_ID`.
+
+---
+
+## Agent Capabilities
+
+The platform chatbot agent supports all standard agent features:
+
+| Feature | Notes |
+|---------|-------|
+| **System prompt** | Full control over the agent's personality and instructions |
+| **LLM service** | Any configured AIService (OpenAI, Anthropic, Azure, etc.) |
+| **Silo (RAG)** | Attach a knowledge base for retrieval-augmented answers |
+| **Skills** | Attach reusable prompt blocks |
+| **Memory** | Per-user persistent conversation sessions |
+| **MCP tools** | Connect to external MCP servers |
+| **Agent-as-tool** | Compose with other agents |
+| **Streaming** | Responses stream token by token in the widget |
+
+---
+
+## Session and Memory Behaviour
+
+- Each user has their own persistent conversation thread (`platform_chatbot_{user_id}`).
+- Conversations survive page reloads and navigation.
+- The user can click **New conversation** in the widget header to start a fresh session.
+- Conversation history for the current session is stored in browser `localStorage`.
+- The agent's memory settings (`memory_max_messages`, `memory_max_tokens`, `memory_summarize_threshold`) apply as configured on the agent.
+
+---
+
+## Recommendations
+
+For a platform onboarding / guide use case, consider:
+
+- Linking a **Silo** with a **Repository** containing your platform documentation or knowledge base files.
+- Writing a focused **system prompt** that scopes the agent to platform-related questions.
+- Enabling **streaming** on the agent's LLM service for a better user experience.
+- Using a **low temperature** (0.2–0.4) for factual, consistent answers.
+
+See the [Platform Chatbot Knowledge Base](chat-bot/README.md) for ready-to-use documentation files and a system prompt template designed for a platform guide agent.
+
+---
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Widget does not appear | `platform_chatbot_agent_id` is `-1` or the agent was deleted | Check System Settings → Platform and verify the agent exists |
+| Widget appears but chat fails | Agent's LLM service is misconfigured or the API key is invalid | Test the agent directly in the Playground |
+| Answers are irrelevant | System prompt is too broad or no knowledge base attached | Refine the system prompt; add a Silo with relevant documents |
+| Old conversation context bleeds in | User's session has accumulated history | User can click "New conversation" to start fresh |
+
+---
+
+## See Also
+
+- [Agent System](../ai/agent-system.md) — Agent configuration, memory, and tools
+- [RAG & Vector Stores](../ai/rag-vector-stores.md) — Setting up a Silo for knowledge retrieval
+- [SaaS Mode](saas-mode.md) — System settings and `system_defaults.yaml`
+- [Platform Chatbot Knowledge Base](chat-bot/README.md) — Ready-to-use documentation and prompt template for a guide agent

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@
 - [App Export and Import](guides/app-export-import.md) — Export app configuration and import into a new workspace
 - [Agent Marketplace](guides/marketplace.md) — Publish agents to the platform-wide marketplace, manage profiles, ratings, and quotas
 - [SaaS Mode](guides/saas-mode.md) — SaaS deployment: Stripe billing, subscription tiers, quota enforcement, and `system_defaults.yaml` configuration
+- [Platform Chatbot](guides/platform-chatbot.md) — Configure a global AI assistant widget backed by any agent; includes knowledge base files and prompt template for a platform guide agent
 
 ### Copilot Agents & Tooling
 - [Copilot Agents, Skills & Instructions](guides/copilot-agents.md) — Multi-agent Copilot architecture, agent directory, skills, auto-applied instructions, and delegation graph

--- a/frontend/src/components/platform-chatbot/PlatformChatbotButton.tsx
+++ b/frontend/src/components/platform-chatbot/PlatformChatbotButton.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { MessageCircle, X } from 'lucide-react';
+
+interface PlatformChatbotButtonProps {
+  onClick: () => void;
+  isOpen: boolean;
+}
+
+const PlatformChatbotButton: React.FC<PlatformChatbotButtonProps> = ({ onClick, isOpen }) => {
+  return (
+    <button
+      onClick={onClick}
+      className="fixed bottom-4 right-4 z-50 w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-lg flex items-center justify-center cursor-pointer hover:scale-105 transition-transform"
+      aria-label={isOpen ? 'Close chat' : 'Open chat'}
+    >
+      {isOpen ? <X size={24} /> : <MessageCircle size={24} />}
+    </button>
+  );
+};
+
+export default PlatformChatbotButton;

--- a/frontend/src/components/platform-chatbot/PlatformChatbotPanel.tsx
+++ b/frontend/src/components/platform-chatbot/PlatformChatbotPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect, useMemo } from 'react';
 import { X, RotateCcw, Send } from 'lucide-react';
 import { usePlatformChatbot } from '../../contexts/PlatformChatbotContext';
 import { apiService } from '../../services/api';
@@ -11,6 +11,81 @@ interface PlatformChatbotPanelProps {
   onClose: () => void;
   onNewConversation: () => void;
 }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * LLMs often emit literal newlines/tabs inside JSON strings instead of \n/\t,
+ * which breaks JSON.parse. Walk the text and escape bare control characters
+ * that appear inside string values.
+ */
+function sanitizeJsonControlChars(text: string): string {
+  let inString = false;
+  let escaped = false;
+  let out = '';
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (escaped) {
+      out += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\' && inString) { escaped = true; out += ch; continue; }
+    if (ch === '"') { inString = !inString; out += ch; continue; }
+    if (inString) {
+      if (ch === '\n') { out += '\\n'; continue; }
+      if (ch === '\r') { out += '\\r'; continue; }
+      if (ch === '\t') { out += '\\t'; continue; }
+    }
+    out += ch;
+  }
+  return out;
+}
+
+function parseAgentResponse(text: string): { content: string; follow_ups: string[] } {
+  const idx = text.search(/\{\s*"/);
+  if (idx === -1) return { content: text, follow_ups: [] };
+
+  const jsonPart = text.slice(idx);
+
+  // First attempt: JSON.parse with sanitization (handles literal newlines in strings)
+  try {
+    const parsed = JSON.parse(sanitizeJsonControlChars(jsonPart));
+    if (parsed && typeof parsed.content === 'string') {
+      return {
+        content: parsed.content,
+        follow_ups: Array.isArray(parsed.follow_ups)
+          ? parsed.follow_ups.filter((s: unknown) => typeof s === 'string')
+          : [],
+      };
+    }
+  } catch { /* fall through to regex */ }
+
+  // Regex fallback: extract content and follow_ups without JSON.parse.
+  // Pattern matches a JSON string value, handling escape sequences correctly.
+  const contentMatch = jsonPart.match(/"content"\s*:\s*"((?:[^"\\]|\\[\s\S])*)"/);
+  if (!contentMatch) return { content: text, follow_ups: [] };
+
+  const content = contentMatch[1]
+    .replace(/\\n/g, '\n')
+    .replace(/\\t/g, '\t')
+    .replace(/\\r/g, '\r')
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, '\\');
+
+  const follow_ups: string[] = [];
+  const fuMatch = jsonPart.match(/"follow_ups"\s*:\s*\[([\s\S]*?)\]/);
+  if (fuMatch) {
+    const fuItems = [...fuMatch[1].matchAll(/"((?:[^"\\]|\\[\s\S])*)"/g)];
+    follow_ups.push(...fuItems.map(m => m[1].replace(/\\n/g, '\n').replace(/\\"/g, '"')));
+  }
+
+  return { content, follow_ups };
+}
+
+// ---------------------------------------------------------------------------
 
 const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
   agentName,
@@ -25,18 +100,41 @@ const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
+  const displayStreamingContent = useMemo(() => {
+    const unescape = (s: string) => s
+      .replace(/\\n/g, '\n')
+      .replace(/\\t/g, '\t')
+      .replace(/\\r/g, '\r')
+      .replace(/\\"/g, '"')
+      .replace(/\\\\/g, '\\');
+
+    // Case 1: closing quote already received — extract complete content value
+    const complete = streamingContent.match(/"content"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+    if (complete) return unescape(complete[1]);
+
+    // Case 2: still streaming the content value — show what's arrived so far
+    const partial = streamingContent.match(/"content"\s*:\s*"([\s\S]*)/);
+    if (partial) return unescape(partial[1]);
+
+    // Case 3: JSON response but content key not yet arrived — show nothing
+    if (streamingContent.trimStart().startsWith('{')) return '';
+
+    // Case 4: plain text response — show as-is
+    return streamingContent;
+  }, [streamingContent]);
+
   // Scroll to bottom when messages change
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, streamingContent]);
 
-  const handleSend = async () => {
-    const text = inputText.trim();
+  const handleSend = async (overrideText?: string) => {
+    const text = (overrideText ?? inputText).trim();
     if (!text || isSending) return;
 
     // Append user message
     addMessage({ role: 'user', content: text, timestamp: Date.now() });
-    setInputText('');
+    if (!overrideText) setInputText('');
     setIsSending(true);
     setStreamingContent('');
     setIsStreaming(true);
@@ -53,11 +151,25 @@ const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
             accumulated += token;
             setStreamingContent(accumulated);
           } else if (event.type === 'done') {
-            const response = (event.data as { response?: string }).response;
-            const finalContent = response || accumulated;
+            const rawResponse = event.data.response;
+            let content: string;
+            let follow_ups: string[] = [];
+
+            if (rawResponse && typeof rawResponse === 'object' && !Array.isArray(rawResponse)) {
+              // Backend already parsed the JSON (e.g. when OutputParser is active)
+              const r = rawResponse as Record<string, unknown>;
+              content = typeof r.content === 'string' ? r.content : JSON.stringify(r, null, 2);
+              follow_ups = Array.isArray(r.follow_ups)
+                ? r.follow_ups.filter((s): s is string => typeof s === 'string')
+                : [];
+            } else {
+              const finalText = (typeof rawResponse === 'string' ? rawResponse : null) || accumulated;
+              ({ content, follow_ups } = parseAgentResponse(finalText));
+            }
+
             setIsStreaming(false);
             setStreamingContent('');
-            addMessage({ role: 'assistant', content: finalContent, timestamp: Date.now() });
+            addMessage({ role: 'assistant', content, follow_ups, timestamp: Date.now() });
           } else if (event.type === 'error') {
             const errMsg = (event.data as { message?: string }).message || 'Something went wrong.';
             setIsStreaming(false);
@@ -90,8 +202,12 @@ const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      handleSend();
+      handleSend(undefined);
     }
+  };
+
+  const handleFollowUp = (text: string) => {
+    if (!isSending) handleSend(text);
   };
 
   const handleNewConversation = () => {
@@ -104,7 +220,7 @@ const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
   };
 
   return (
-    <div className="fixed bottom-20 right-4 z-50 w-96 h-[600px] flex flex-col rounded-xl shadow-2xl border bg-background overflow-hidden transition-all duration-300">
+    <div className="fixed bottom-20 right-4 z-50 w-96 h-[600px] flex flex-col rounded-xl shadow-2xl border bg-white dark:bg-zinc-900 overflow-hidden transition-all duration-300">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/50">
         <span className="font-semibold text-sm truncate">
@@ -140,7 +256,7 @@ const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
         {messages.map((msg, idx) => (
           <div
             key={idx}
-            className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+            className={`flex flex-col ${msg.role === 'user' ? 'items-end' : 'items-start'}`}
           >
             <div
               className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${
@@ -155,12 +271,26 @@ const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
                 <span className="whitespace-pre-wrap">{msg.content}</span>
               )}
             </div>
+            {msg.role === 'assistant' && msg.follow_ups && msg.follow_ups.length > 0 && (
+              <div className="flex flex-col items-start gap-1 mt-1 max-w-[85%]">
+                {msg.follow_ups.map((fu, fi) => (
+                  <button
+                    key={fi}
+                    onClick={() => handleFollowUp(fu)}
+                    disabled={isSending}
+                    className="text-xs px-3 py-1.5 rounded-full border border-primary/40 text-primary hover:bg-primary/10 transition-colors text-left disabled:opacity-40"
+                  >
+                    {fu}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         ))}
 
         {isStreaming && (
           <StreamingMessage
-            content={streamingContent}
+            content={displayStreamingContent}
             isStreaming={isStreaming}
           />
         )}
@@ -177,7 +307,7 @@ const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
           placeholder="Type a message..."
           rows={1}
           disabled={isSending}
-          className="flex-1 resize-none rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
+          className="flex-1 resize-none rounded-md border bg-white dark:bg-zinc-800 px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
           style={{ minHeight: '38px', maxHeight: '120px' }}
         />
         <button

--- a/frontend/src/components/platform-chatbot/PlatformChatbotPanel.tsx
+++ b/frontend/src/components/platform-chatbot/PlatformChatbotPanel.tsx
@@ -1,0 +1,196 @@
+import React, { useRef, useState, useEffect } from 'react';
+import { X, RotateCcw, Send } from 'lucide-react';
+import { usePlatformChatbot } from '../../contexts/PlatformChatbotContext';
+import { apiService } from '../../services/api';
+import MessageContent from '../playground/MessageContent';
+import StreamingMessage from '../playground/StreamingMessage';
+import type { StreamEvent } from '../../types/streaming';
+
+interface PlatformChatbotPanelProps {
+  agentName: string | null;
+  onClose: () => void;
+  onNewConversation: () => void;
+}
+
+const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
+  agentName,
+  onClose,
+  onNewConversation,
+}) => {
+  const { messages, addMessage, sessionId } = usePlatformChatbot();
+  const [inputText, setInputText] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const [streamingContent, setStreamingContent] = useState('');
+  const [isStreaming, setIsStreaming] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  // Scroll to bottom when messages change
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, streamingContent]);
+
+  const handleSend = async () => {
+    const text = inputText.trim();
+    if (!text || isSending) return;
+
+    // Append user message
+    addMessage({ role: 'user', content: text, timestamp: Date.now() });
+    setInputText('');
+    setIsSending(true);
+    setStreamingContent('');
+    setIsStreaming(true);
+
+    abortControllerRef.current = new AbortController();
+    let accumulated = '';
+
+    try {
+      await apiService.streamPlatformChatbotMessage(text, sessionId, {
+        signal: abortControllerRef.current.signal,
+        onEvent: (event: StreamEvent) => {
+          if (event.type === 'token') {
+            const token = (event.data as { content?: string }).content || '';
+            accumulated += token;
+            setStreamingContent(accumulated);
+          } else if (event.type === 'done') {
+            const response = (event.data as { response?: string }).response;
+            const finalContent = response || accumulated;
+            setIsStreaming(false);
+            setStreamingContent('');
+            addMessage({ role: 'assistant', content: finalContent, timestamp: Date.now() });
+          } else if (event.type === 'error') {
+            const errMsg = (event.data as { message?: string }).message || 'Something went wrong.';
+            setIsStreaming(false);
+            setStreamingContent('');
+            addMessage({
+              role: 'assistant',
+              content: `Sorry, something went wrong. ${errMsg}`,
+              timestamp: Date.now(),
+            });
+          }
+        },
+      });
+    } catch (err: unknown) {
+      setIsStreaming(false);
+      setStreamingContent('');
+      // Don't add error message if the request was aborted intentionally
+      if (err instanceof Error && err.name !== 'AbortError') {
+        addMessage({
+          role: 'assistant',
+          content: 'Sorry, something went wrong. Please try again.',
+          timestamp: Date.now(),
+        });
+      }
+    } finally {
+      setIsSending(false);
+      setIsStreaming(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  const handleNewConversation = () => {
+    // Abort any in-progress stream
+    abortControllerRef.current?.abort();
+    setStreamingContent('');
+    setIsStreaming(false);
+    setIsSending(false);
+    onNewConversation();
+  };
+
+  return (
+    <div className="fixed bottom-20 right-4 z-50 w-96 h-[600px] flex flex-col rounded-xl shadow-2xl border bg-background overflow-hidden transition-all duration-300">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/50">
+        <span className="font-semibold text-sm truncate">
+          {agentName || 'AI Assistant'}
+        </span>
+        <div className="flex items-center gap-1 shrink-0">
+          <button
+            onClick={handleNewConversation}
+            className="text-xs px-2 py-1 rounded border hover:bg-muted transition-colors"
+            title="New conversation"
+          >
+            <RotateCcw size={12} className="inline mr-1" />
+            New
+          </button>
+          <button
+            onClick={onClose}
+            className="p-1 rounded hover:bg-muted transition-colors"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      </div>
+
+      {/* Message list */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {messages.length === 0 && !isStreaming && (
+          <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+            Hi! How can I help you today?
+          </div>
+        )}
+
+        {messages.map((msg, idx) => (
+          <div
+            key={idx}
+            className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+          >
+            <div
+              className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${
+                msg.role === 'user'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-foreground'
+              }`}
+            >
+              {msg.role === 'assistant' ? (
+                <MessageContent content={msg.content} />
+              ) : (
+                <span className="whitespace-pre-wrap">{msg.content}</span>
+              )}
+            </div>
+          </div>
+        ))}
+
+        {isStreaming && (
+          <StreamingMessage
+            content={streamingContent}
+            isStreaming={isStreaming}
+          />
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input area */}
+      <div className="flex gap-2 p-3 border-t">
+        <textarea
+          value={inputText}
+          onChange={(e) => setInputText(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Type a message..."
+          rows={1}
+          disabled={isSending}
+          className="flex-1 resize-none rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
+          style={{ minHeight: '38px', maxHeight: '120px' }}
+        />
+        <button
+          onClick={handleSend}
+          disabled={isSending || !inputText.trim()}
+          className="shrink-0 p-2 rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40 transition-opacity"
+          aria-label="Send"
+        >
+          <Send size={16} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PlatformChatbotPanel;

--- a/frontend/src/components/platform-chatbot/PlatformChatbotPanel.tsx
+++ b/frontend/src/components/platform-chatbot/PlatformChatbotPanel.tsx
@@ -44,6 +44,15 @@ function sanitizeJsonControlChars(text: string): string {
   return out;
 }
 
+function unescapeJsonString(s: string): string {
+  return s
+    .replace(/\\n/g, '\n')
+    .replace(/\\t/g, '\t')
+    .replace(/\\r/g, '\r')
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, '\\');
+}
+
 function parseAgentResponse(text: string): { content: string; follow_ups: string[] } {
   const idx = text.search(/\{\s*"/);
   if (idx === -1) return { content: text, follow_ups: [] };
@@ -68,21 +77,14 @@ function parseAgentResponse(text: string): { content: string; follow_ups: string
   const contentMatch = jsonPart.match(/"content"\s*:\s*"((?:[^"\\]|\\[\s\S])*)"/);
   if (!contentMatch) return { content: text, follow_ups: [] };
 
-  const content = contentMatch[1]
-    .replace(/\\n/g, '\n')
-    .replace(/\\t/g, '\t')
-    .replace(/\\r/g, '\r')
-    .replace(/\\"/g, '"')
-    .replace(/\\\\/g, '\\');
-
   const follow_ups: string[] = [];
   const fuMatch = jsonPart.match(/"follow_ups"\s*:\s*\[([\s\S]*?)\]/);
   if (fuMatch) {
     const fuItems = [...fuMatch[1].matchAll(/"((?:[^"\\]|\\[\s\S])*)"/g)];
-    follow_ups.push(...fuItems.map(m => m[1].replace(/\\n/g, '\n').replace(/\\"/g, '"')));
+    follow_ups.push(...fuItems.map(m => unescapeJsonString(m[1])));
   }
 
-  return { content, follow_ups };
+  return { content: unescapeJsonString(contentMatch[1]), follow_ups };
 }
 
 // ---------------------------------------------------------------------------
@@ -101,20 +103,13 @@ const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const displayStreamingContent = useMemo(() => {
-    const unescape = (s: string) => s
-      .replace(/\\n/g, '\n')
-      .replace(/\\t/g, '\t')
-      .replace(/\\r/g, '\r')
-      .replace(/\\"/g, '"')
-      .replace(/\\\\/g, '\\');
-
     // Case 1: closing quote already received — extract complete content value
     const complete = streamingContent.match(/"content"\s*:\s*"((?:[^"\\]|\\.)*)"/);
-    if (complete) return unescape(complete[1]);
+    if (complete) return unescapeJsonString(complete[1]);
 
     // Case 2: still streaming the content value — show what's arrived so far
     const partial = streamingContent.match(/"content"\s*:\s*"([\s\S]*)/);
-    if (partial) return unescape(partial[1]);
+    if (partial) return unescapeJsonString(partial[1]);
 
     // Case 3: JSON response but content key not yet arrived — show nothing
     if (streamingContent.trimStart().startsWith('{')) return '';
@@ -122,6 +117,11 @@ const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
     // Case 4: plain text response — show as-is
     return streamingContent;
   }, [streamingContent]);
+
+  // Abort any in-flight stream on unmount
+  useEffect(() => {
+    return () => { abortControllerRef.current?.abort(); };
+  }, []);
 
   // Scroll to bottom when messages change
   useEffect(() => {
@@ -167,12 +167,10 @@ const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
               ({ content, follow_ups } = parseAgentResponse(finalText));
             }
 
-            setIsStreaming(false);
             setStreamingContent('');
             addMessage({ role: 'assistant', content, follow_ups, timestamp: Date.now() });
           } else if (event.type === 'error') {
             const errMsg = (event.data as { message?: string }).message || 'Something went wrong.';
-            setIsStreaming(false);
             setStreamingContent('');
             addMessage({
               role: 'assistant',
@@ -183,7 +181,6 @@ const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
         },
       });
     } catch (err: unknown) {
-      setIsStreaming(false);
       setStreamingContent('');
       // Don't add error message if the request was aborted intentionally
       if (err instanceof Error && err.name !== 'AbortError') {
@@ -202,12 +199,8 @@ const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      handleSend(undefined);
+      handleSend();
     }
-  };
-
-  const handleFollowUp = (text: string) => {
-    if (!isSending) handleSend(text);
   };
 
   const handleNewConversation = () => {
@@ -276,7 +269,7 @@ const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
                 {msg.follow_ups.map((fu, fi) => (
                   <button
                     key={fi}
-                    onClick={() => handleFollowUp(fu)}
+                    onClick={() => handleSend(fu)}
                     disabled={isSending}
                     className="text-xs px-3 py-1.5 rounded-full border border-primary/40 text-primary hover:bg-primary/10 transition-colors text-left disabled:opacity-40"
                   >
@@ -291,7 +284,7 @@ const PlatformChatbotPanel: React.FC<PlatformChatbotPanelProps> = ({
         {isStreaming && (
           <StreamingMessage
             content={displayStreamingContent}
-            isStreaming={isStreaming}
+            isStreaming={true}
           />
         )}
 

--- a/frontend/src/components/platform-chatbot/PlatformChatbotWidget.tsx
+++ b/frontend/src/components/platform-chatbot/PlatformChatbotWidget.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { usePlatformChatbot } from '../../contexts/PlatformChatbotContext';
+import PlatformChatbotButton from './PlatformChatbotButton';
+import PlatformChatbotPanel from './PlatformChatbotPanel';
+
+const PlatformChatbotWidget: React.FC = () => {
+  const { config, isConfigLoading, isOpen, openChat, closeChat, startNewConversation } =
+    usePlatformChatbot();
+
+  // Don't render anything while loading or when chatbot is disabled
+  if (isConfigLoading || !config?.enabled) {
+    return null;
+  }
+
+  return (
+    <>
+      {isOpen && (
+        <PlatformChatbotPanel
+          agentName={config.agent_name}
+          onClose={closeChat}
+          onNewConversation={startNewConversation}
+        />
+      )}
+      <PlatformChatbotButton
+        onClick={isOpen ? closeChat : openChat}
+        isOpen={isOpen}
+      />
+    </>
+  );
+};
+
+export default PlatformChatbotWidget;

--- a/frontend/src/contexts/PlatformChatbotContext.tsx
+++ b/frontend/src/contexts/PlatformChatbotContext.tsx
@@ -17,6 +17,7 @@ export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
   timestamp: number;
+  follow_ups?: string[];
 }
 
 interface PlatformChatbotContextType {

--- a/frontend/src/contexts/PlatformChatbotContext.tsx
+++ b/frontend/src/contexts/PlatformChatbotContext.tsx
@@ -1,0 +1,179 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import type { ReactNode } from 'react';
+import { apiService } from '../services/api';
+import { useUser } from './UserContext';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PlatformChatbotConfig {
+  enabled: boolean;
+  agent_name: string | null;
+  agent_description: string | null;
+}
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: number;
+}
+
+interface PlatformChatbotContextType {
+  config: PlatformChatbotConfig | null;
+  isConfigLoading: boolean;
+  isOpen: boolean;
+  openChat: () => void;
+  closeChat: () => void;
+  sessionId: string;
+  messages: ChatMessage[];
+  addMessage: (msg: ChatMessage) => void;
+  startNewConversation: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const PlatformChatbotContext = createContext<PlatformChatbotContextType | undefined>(undefined);
+
+export const usePlatformChatbot = (): PlatformChatbotContextType => {
+  const context = useContext(PlatformChatbotContext);
+  if (context === undefined) {
+    throw new Error('usePlatformChatbot must be used within a PlatformChatbotProvider');
+  }
+  return context;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SESSION_KEY = 'platform_chatbot_session_id';
+const MAX_MESSAGES = 100;
+
+function historyKey(sessionId: string): string {
+  return `platform_chatbot_history_${sessionId}`;
+}
+
+function readHistory(sessionId: string): ChatMessage[] {
+  if (!sessionId) return [];
+  try {
+    const raw = localStorage.getItem(historyKey(sessionId));
+    return raw ? (JSON.parse(raw) as ChatMessage[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeHistory(sessionId: string, messages: ChatMessage[]): void {
+  try {
+    localStorage.setItem(historyKey(sessionId), JSON.stringify(messages));
+  } catch {
+    // localStorage may be unavailable or full — fail silently
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+interface PlatformChatbotProviderProps {
+  children: ReactNode;
+}
+
+export const PlatformChatbotProvider: React.FC<PlatformChatbotProviderProps> = ({ children }) => {
+  const { user } = useUser();
+
+  const [config, setConfig] = useState<PlatformChatbotConfig | null>(null);
+  const [isConfigLoading, setIsConfigLoading] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
+  const [sessionId, setSessionId] = useState('');
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+
+  // Fetch config on mount
+  useEffect(() => {
+    let cancelled = false;
+    apiService
+      .getPlatformChatbotConfig()
+      .then((data) => {
+        if (!cancelled) setConfig(data);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setConfig({ enabled: false, agent_name: null, agent_description: null });
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setIsConfigLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Initialize session ID once user is available
+  useEffect(() => {
+    if (!user) return;
+
+    const stored = localStorage.getItem(SESSION_KEY);
+    const defaultId = `platform_chatbot_${user.user_id}`;
+    const resolved = stored || defaultId;
+
+    if (!stored) {
+      try {
+        localStorage.setItem(SESSION_KEY, resolved);
+      } catch {
+        // ignore
+      }
+    }
+
+    setSessionId(resolved);
+    setMessages(readHistory(resolved));
+  }, [user]);
+
+  const openChat = useCallback(() => setIsOpen(true), []);
+  const closeChat = useCallback(() => setIsOpen(false), []);
+
+  const addMessage = useCallback(
+    (msg: ChatMessage) => {
+      setMessages((prev) => {
+        const next = [...prev, msg];
+        const capped = next.length > MAX_MESSAGES ? next.slice(next.length - MAX_MESSAGES) : next;
+        writeHistory(sessionId, capped);
+        return capped;
+      });
+    },
+    [sessionId]
+  );
+
+  const startNewConversation = useCallback(() => {
+    if (!user) return;
+    const newId = `platform_chatbot_${user.user_id}_${Date.now()}`;
+    try {
+      localStorage.setItem(SESSION_KEY, newId);
+    } catch {
+      // ignore
+    }
+    setSessionId(newId);
+    setMessages([]);
+  }, [user]);
+
+  return (
+    <PlatformChatbotContext.Provider
+      value={{
+        config,
+        isConfigLoading,
+        isOpen,
+        openChat,
+        closeChat,
+        sessionId,
+        messages,
+        addMessage,
+        startNewConversation,
+      }}
+    >
+      {children}
+    </PlatformChatbotContext.Provider>
+  );
+};

--- a/frontend/src/core/ExtensibleBaseApp.tsx
+++ b/frontend/src/core/ExtensibleBaseApp.tsx
@@ -56,6 +56,8 @@ import SystemAIServicesPage from '../pages/admin/SystemAIServicesPage';
 import SystemEmbeddingServicesPage from '../pages/admin/SystemEmbeddingServicesPage';
 import TierConfigPage from '../pages/admin/TierConfigPage';
 import { DeploymentModeProvider } from '../contexts/DeploymentModeContext';
+import { PlatformChatbotProvider } from '../contexts/PlatformChatbotContext';
+import PlatformChatbotWidget from '../components/platform-chatbot/PlatformChatbotWidget';
 import MCPServersPage from '../pages/MCPServersPage';
 import MCPServerFormPage from '../pages/MCPServerFormPage';
 import MCPServerDetailPage from '../pages/MCPServerDetailPage';
@@ -140,6 +142,7 @@ export const ExtensibleBaseApp: React.FC<ExtensibleBaseAppProps> = ({
         <UserProvider>
           <SettingsCacheProvider>
             <DeploymentModeProvider>
+            <PlatformChatbotProvider>
             <Router>
               <Routes>
                 {/* Public routes */}
@@ -444,7 +447,9 @@ export const ExtensibleBaseApp: React.FC<ExtensibleBaseAppProps> = ({
                 {/* Default redirect for unmatched paths */}
                 <Route path="*" element={<Navigate to="/apps" replace />} />
               </Routes>
+              <PlatformChatbotWidget />
             </Router>
+            </PlatformChatbotProvider>
             </DeploymentModeProvider>
           </SettingsCacheProvider>
         </UserProvider>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2070,6 +2070,78 @@ class ApiService {
     });
   }
 
+  // ==================== PLATFORM CHATBOT API ====================
+
+  async getPlatformChatbotConfig(): Promise<{
+    enabled: boolean;
+    agent_name: string | null;
+    agent_description: string | null;
+  }> {
+    return this.request('/internal/platform-chatbot/config');
+  }
+
+  async sendPlatformChatbotMessage(
+    message: string,
+    sessionId: string
+  ): Promise<{ response: string | Record<string, unknown>; agent_id: number; conversation_id: number | null; metadata: Record<string, unknown> }> {
+    return this.request('/internal/platform-chatbot/chat', {
+      method: 'POST',
+      body: JSON.stringify({ message, session_id: sessionId }),
+    });
+  }
+
+  async streamPlatformChatbotMessage(
+    message: string,
+    sessionId: string,
+    options: { onEvent: (event: StreamEvent) => void; signal?: AbortSignal }
+  ): Promise<void> {
+    const url = `${this.baseURL}/internal/platform-chatbot/chat/stream`;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    const token = this.getAuthToken();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ message, session_id: sessionId }),
+      signal: options.signal,
+    });
+
+    if (!response.ok) {
+      await this.handleResponseError(response);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error('ReadableStream not supported');
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Parse SSE lines: each event is "data: {json}\n\n"
+        const lines = buffer.split('\n\n');
+        // Keep the last incomplete chunk in the buffer
+        buffer = lines.pop() || '';
+
+        this.parseSSELines(lines, options.onEvent);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
   // ==================== UTILITY METHODS ====================
 }
 

--- a/tests/integration/routers/internal/test_platform_chatbot.py
+++ b/tests/integration/routers/internal/test_platform_chatbot.py
@@ -1,0 +1,107 @@
+"""
+Integration tests for the platform chatbot internal router.
+Tests run against the real test PostgreSQL DB (via conftest fixtures).
+
+Endpoints under test:
+  GET  /internal/platform-chatbot/config
+  POST /internal/platform-chatbot/chat
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# TestPlatformChatbotAuth
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformChatbotAuth:
+    def test_config_requires_auth(self, client):
+        response = client.get("/internal/platform-chatbot/config")
+        assert response.status_code == 401
+
+    def test_chat_requires_auth(self, client):
+        response = client.post(
+            "/internal/platform-chatbot/chat",
+            json={"message": "hi", "session_id": "s1"},
+        )
+        assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# TestPlatformChatbotConfig
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformChatbotConfig:
+    def test_config_returns_disabled_when_default(self, client, auth_headers):
+        """Default setting is -1 so chatbot is disabled."""
+        response = client.get(
+            "/internal/platform-chatbot/config",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is False
+
+    def test_config_returns_disabled_when_agent_id_set_but_agent_deleted(
+        self, client, auth_headers, db, monkeypatch
+    ):
+        """Non-existent agent ID leads to enabled=False."""
+        monkeypatch.setattr(
+            "services.system_settings_service.SystemSettingsService.get_setting",
+            lambda self, key: 99999 if key == "platform_chatbot_agent_id" else None,
+        )
+        response = client.get(
+            "/internal/platform-chatbot/config",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["enabled"] is False
+
+    def test_config_returns_enabled_when_agent_configured(
+        self, client, auth_headers, db, fake_agent, monkeypatch
+    ):
+        """When a real agent is configured, the endpoint returns enabled=True."""
+        monkeypatch.setattr(
+            "services.system_settings_service.SystemSettingsService.get_setting",
+            lambda self, key: fake_agent.agent_id if key == "platform_chatbot_agent_id" else None,
+        )
+        response = client.get(
+            "/internal/platform-chatbot/config",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is True
+        assert data["agent_name"] == fake_agent.name
+
+
+# ---------------------------------------------------------------------------
+# TestPlatformChatbotChat
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformChatbotChat:
+    def test_chat_returns_404_when_not_configured(self, client, auth_headers):
+        """Default setting -1 → 404."""
+        response = client.post(
+            "/internal/platform-chatbot/chat",
+            json={"message": "hi", "session_id": "s1"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 404
+
+    def test_chat_returns_404_when_agent_missing(
+        self, client, auth_headers, monkeypatch
+    ):
+        """Agent ID set to non-existent value → 404."""
+        monkeypatch.setattr(
+            "services.system_settings_service.SystemSettingsService.get_setting",
+            lambda self, key: 99999 if key == "platform_chatbot_agent_id" else None,
+        )
+        response = client.post(
+            "/internal/platform-chatbot/chat",
+            json={"message": "hi", "session_id": "s1"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 404

--- a/tests/unit/routers/test_platform_chatbot.py
+++ b/tests/unit/routers/test_platform_chatbot.py
@@ -1,0 +1,213 @@
+"""
+Unit tests for the platform chatbot internal router.
+All dependencies are mocked — no DB or LLM required.
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+
+from routers.internal import platform_chatbot as chatbot_module
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_db():
+    return MagicMock()
+
+
+def _make_user():
+    user = MagicMock()
+    user.identity.id = "42"
+    user.identity.email = "test@example.com"
+    return user
+
+
+def _mock_settings(mocker, agent_id):
+    """Patch SystemSettingsService so get_setting returns agent_id."""
+    mock_cls = mocker.patch.object(chatbot_module, "SystemSettingsService")
+    instance = mock_cls.return_value
+    instance.get_setting.return_value = agent_id
+    return instance
+
+
+def _mock_agent_service(mocker, agent=None):
+    """Patch AgentService so get_agent returns agent (or None)."""
+    mock_cls = mocker.patch.object(chatbot_module, "AgentService")
+    instance = mock_cls.return_value
+    if agent is None:
+        instance.get_agent.return_value = None
+    else:
+        instance.get_agent.return_value = agent
+    return instance
+
+
+def _make_agent(agent_id=42, name="My Bot", description="Help", app_id=1):
+    agent = MagicMock()
+    agent.agent_id = agent_id
+    agent.name = name
+    agent.description = description
+    agent.app_id = app_id
+    return agent
+
+
+def _mock_execution_service(mocker, result=None):
+    """Patch AgentExecutionService so execute_agent_chat_with_file_refs is an AsyncMock."""
+    mock_cls = mocker.patch.object(chatbot_module, "AgentExecutionService")
+    instance = mock_cls.return_value
+    if result is None:
+        result = {
+            "response": "Hello!",
+            "agent_id": 42,
+            "conversation_id": 1,
+            "metadata": {"tokens": 10},
+        }
+    instance.execute_agent_chat_with_file_refs = AsyncMock(return_value=result)
+    return instance
+
+
+def _mock_streaming_service(mocker):
+    """Patch AgentStreamingService so stream_agent_chat returns an async generator."""
+    mock_cls = mocker.patch.object(chatbot_module, "AgentStreamingService")
+    instance = mock_cls.return_value
+
+    async def _gen():
+        yield 'data: {"type":"token","content":"hi"}\n\n'
+
+    instance.stream_agent_chat.return_value = _gen()
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# TestPlatformChatbotConfig
+# ---------------------------------------------------------------------------
+
+class TestPlatformChatbotConfig:
+    @pytest.mark.asyncio
+    async def test_config_returns_disabled_when_agent_id_is_negative_one(self, mocker):
+        _mock_settings(mocker, -1)
+        response = await chatbot_module.get_platform_chatbot_config(
+            db=_make_db(),
+            current_user=_make_user(),
+        )
+        assert response.enabled is False
+        assert response.agent_name is None
+
+    @pytest.mark.asyncio
+    async def test_config_returns_disabled_when_agent_not_found(self, mocker):
+        _mock_settings(mocker, 42)
+        _mock_agent_service(mocker, agent=None)
+        response = await chatbot_module.get_platform_chatbot_config(
+            db=_make_db(),
+            current_user=_make_user(),
+        )
+        assert response.enabled is False
+        assert response.agent_name is None
+
+    @pytest.mark.asyncio
+    async def test_config_returns_enabled_with_agent_metadata(self, mocker):
+        _mock_settings(mocker, 42)
+        _mock_agent_service(mocker, agent=_make_agent(name="My Bot", description="Help"))
+        response = await chatbot_module.get_platform_chatbot_config(
+            db=_make_db(),
+            current_user=_make_user(),
+        )
+        assert response.enabled is True
+        assert response.agent_name == "My Bot"
+        assert response.agent_description == "Help"
+
+    @pytest.mark.asyncio
+    async def test_config_does_not_expose_agent_id_or_app_id(self, mocker):
+        _mock_settings(mocker, 42)
+        _mock_agent_service(mocker, agent=_make_agent(name="My Bot", description="Help"))
+        response = await chatbot_module.get_platform_chatbot_config(
+            db=_make_db(),
+            current_user=_make_user(),
+        )
+        # PlatformChatbotConfigResponse should not have agent_id or app_id fields
+        assert "agent_id" not in response.model_fields
+        assert "app_id" not in response.model_fields
+
+
+# ---------------------------------------------------------------------------
+# TestPlatformChatbotChat
+# ---------------------------------------------------------------------------
+
+class TestPlatformChatbotChat:
+    @pytest.mark.asyncio
+    async def test_chat_returns_404_when_disabled(self, mocker):
+        _mock_settings(mocker, -1)
+        body = MagicMock()
+        body.message = "hello"
+        body.session_id = "s1"
+
+        with pytest.raises(HTTPException) as exc_info:
+            await chatbot_module.platform_chatbot_chat(
+                body=body,
+                db=_make_db(),
+                current_user=_make_user(),
+            )
+        assert exc_info.value.status_code == 404
+        assert "not configured" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_chat_returns_404_when_agent_not_found(self, mocker):
+        _mock_settings(mocker, 42)
+        _mock_agent_service(mocker, agent=None)
+        body = MagicMock()
+        body.message = "hello"
+        body.session_id = "s1"
+
+        with pytest.raises(HTTPException) as exc_info:
+            await chatbot_module.platform_chatbot_chat(
+                body=body,
+                db=_make_db(),
+                current_user=_make_user(),
+            )
+        assert exc_info.value.status_code == 404
+        assert "not found" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_chat_delegates_to_execution_service(self, mocker):
+        _mock_settings(mocker, 42)
+        _mock_agent_service(mocker, agent=_make_agent(agent_id=42))
+        svc = _mock_execution_service(mocker)
+        body = MagicMock()
+        body.message = "hello"
+        body.session_id = "s1"
+
+        result = await chatbot_module.platform_chatbot_chat(
+            body=body,
+            db=_make_db(),
+            current_user=_make_user(),
+        )
+
+        call_kwargs = svc.execute_agent_chat_with_file_refs.call_args
+        assert call_kwargs.kwargs["agent_id"] == 42
+        assert call_kwargs.kwargs["message"] == "hello"
+        assert call_kwargs.kwargs["file_references"] is None
+        assert call_kwargs.kwargs["conversation_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_chat_returns_503_when_execution_raises(self, mocker):
+        _mock_settings(mocker, 42)
+        _mock_agent_service(mocker, agent=_make_agent(agent_id=42))
+        svc = _mock_execution_service(mocker)
+        svc.execute_agent_chat_with_file_refs = AsyncMock(
+            side_effect=RuntimeError("LLM timeout")
+        )
+        body = MagicMock()
+        body.message = "hello"
+        body.session_id = "s1"
+
+        with pytest.raises(HTTPException) as exc_info:
+            await chatbot_module.platform_chatbot_chat(
+                body=body,
+                db=_make_db(),
+                current_user=_make_user(),
+            )
+        assert exc_info.value.status_code == 503


### PR DESCRIPTION
## Summary

- Adds a platform-wide floating chatbot widget (bottom-right) backed by any agent, configured via a new `platform_chatbot_agent_id` system setting (default: -1, disabled)
- Adds an internal proxy endpoint `/internal/platform-chatbot/chat` so no API key is exposed to the browser; calls do not count toward quotas
- Supports structured agent responses: `{"content": "...", "follow_ups": ["q1", "q2"]}` with smart streaming extraction (shows only the `content` during streaming, renders follow-up buttons after)
- Handles both plain-text and JSON responses from agents, with `sanitizeJsonControlChars` + regex fallback for malformed LLM JSON
- Conversation history persisted per-user in localStorage; "New conversation" creates a fresh session
- Adds `.md` file upload support in Repositories (treated as plain text)
- Includes admin configuration guide and a ready-to-use knowledge base + system prompt template under `docs/guides/chat-bot/`

## Test plan

- [ ] Set `platform_chatbot_agent_id` to a valid agent ID in system settings — widget appears
- [ ] Set to -1 or invalid agent — widget does not appear
- [ ] Send a message, verify streaming shows only the content (not raw JSON)
- [ ] Agent returns `{"content": "...", "follow_ups": [...]}` — follow-up buttons render below the message
- [ ] Click a follow-up button — it sends that text as a new message
- [ ] Reload page — conversation history restored from localStorage
- [ ] Click "New conversation" — history cleared, new session ID assigned
- [ ] Upload a `.md` file to a Repository — succeeds and gets indexed
- [ ] Run unit + integration tests: `pytest tests/unit/ tests/integration/ -v`