### PR TITLE
fix(backend, frontend): prevent vector_db_type from being changed after silo, repo or domain creation.

### DIFF
--- a/backend/routers/internal/domains.py
+++ b/backend/routers/internal/domains.py
@@ -34,6 +34,7 @@ from db.database import get_db
 # Import logger
 from utils.logger import get_logger
 from utils.error_handlers import ValidationError
+from utils.vector_db_immutability import assert_vector_db_type_immutable, assert_embedding_service_immutable
 from tools.vector_store_factory import VectorStoreFactory
 from fastapi import File, UploadFile
 from typing import Optional
@@ -303,9 +304,15 @@ async def update_domain(
     role: Annotated[AppRole, Depends(require_min_role("editor"))],
 ):
     """
-    Update an existing domain. Note: vector_db_type cannot be changed after creation.
+    Update an existing domain. Note: vector_db_type and embedding_service_id cannot be changed after creation.
     """
     try:
+        raw_body = await request.json()
+        existing_domain = DomainService.get_domain(domain_id, db)
+        if existing_domain and existing_domain.silo:
+            assert_vector_db_type_immutable(existing_domain.silo.vector_db_type, raw_body.get('vector_db_type'), "domain")
+            assert_embedding_service_immutable(existing_domain.silo.embedding_service_id, raw_body.get('embedding_service_id'), "domain")
+
         data = {
             'domain_id': domain_id,
             'name': domain_data.name,
@@ -317,7 +324,7 @@ async def update_domain(
             'app_id': app_id,
             'vector_db_type': None  # immutable — not accepted on update
         }
-        updated_domain_id = DomainService.create_or_update_domain(data, domain_data.embedding_service_id, db)
+        updated_domain_id = DomainService.create_or_update_domain(data, None, db)
         return await get_domain(app_id, updated_domain_id, request, db, auth_context, role)
     except HTTPException:
         raise

--- a/backend/routers/internal/domains.py
+++ b/backend/routers/internal/domains.py
@@ -17,6 +17,8 @@ from schemas.domain_url_schemas import (
     DomainListItemSchema,
     DomainDetailSchema,
     CreateUpdateDomainSchema,
+    CreateDomainSchema,
+    UpdateDomainSchema,
     URLListItemSchema,
     CreateURLSchema,
     URLActionResponseSchema
@@ -31,6 +33,7 @@ from db.database import get_db
 
 # Import logger
 from utils.logger import get_logger
+from utils.error_handlers import ValidationError
 from tools.vector_store_factory import VectorStoreFactory
 from fastapi import File, UploadFile
 from typing import Optional
@@ -247,27 +250,25 @@ async def get_domain(
     return domain_detail
 
 
-@domains_router.post("/{domain_id}",
-                     summary="Create or update domain",
+@domains_router.post("/",
+                     summary="Create domain",
                      tags=["Domains"],
-                     response_model=DomainDetailSchema)
-async def create_or_update_domain(
+                     response_model=DomainDetailSchema,
+                     status_code=status.HTTP_201_CREATED)
+async def create_domain(
     app_id: int,
-    domain_id: int,
-    domain_data: CreateUpdateDomainSchema,
+    domain_data: CreateDomainSchema,
     request: Request,
     db: Annotated[Session, Depends(get_db)],
     auth_context: Annotated[AuthContext, Depends(get_current_user_oauth)],
     role: Annotated[AppRole, Depends(require_min_role("editor"))],
 ):
     """
-    Create a new domain or update an existing one.
+    Create a new domain.
     """
-    
     try:
-        # Prepare domain data for service
         data = {
-            'domain_id': domain_id if domain_id != 0 else None,
+            'domain_id': None,
             'name': domain_data.name,
             'description': domain_data.description,
             'base_url': domain_data.base_url,
@@ -277,19 +278,54 @@ async def create_or_update_domain(
             'app_id': app_id,
             'vector_db_type': domain_data.vector_db_type
         }
-        
-        # Create or update domain using service
         created_domain_id = DomainService.create_or_update_domain(data, domain_data.embedding_service_id, db)
-        
-        # Return updated domain (reuse the GET logic)
         return await get_domain(app_id, created_domain_id, request, db, auth_context, role)
-        
+    except HTTPException:
+        raise
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
     except Exception as e:
-        logger.error(f"Error creating/updating domain: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error creating/updating domain: {str(e)}"
-        )
+        logger.error(f"Error creating domain: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+
+@domains_router.put("/{domain_id}",
+                    summary="Update domain",
+                    tags=["Domains"],
+                    response_model=DomainDetailSchema)
+async def update_domain(
+    app_id: int,
+    domain_id: int,
+    domain_data: UpdateDomainSchema,
+    request: Request,
+    db: Annotated[Session, Depends(get_db)],
+    auth_context: Annotated[AuthContext, Depends(get_current_user_oauth)],
+    role: Annotated[AppRole, Depends(require_min_role("editor"))],
+):
+    """
+    Update an existing domain. Note: vector_db_type cannot be changed after creation.
+    """
+    try:
+        data = {
+            'domain_id': domain_id,
+            'name': domain_data.name,
+            'description': domain_data.description,
+            'base_url': domain_data.base_url,
+            'content_tag': domain_data.content_tag,
+            'content_class': domain_data.content_class,
+            'content_id': domain_data.content_id,
+            'app_id': app_id,
+            'vector_db_type': None  # immutable — not accepted on update
+        }
+        updated_domain_id = DomainService.create_or_update_domain(data, domain_data.embedding_service_id, db)
+        return await get_domain(app_id, updated_domain_id, request, db, auth_context, role)
+    except HTTPException:
+        raise
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error updating domain: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 
 
 @domains_router.delete("/{domain_id}",

--- a/backend/routers/internal/repositories.py
+++ b/backend/routers/internal/repositories.py
@@ -13,7 +13,7 @@ from services.media_service import MediaService
 from services.repository_export_service import RepositoryExportService
 from services.repository_import_service import RepositoryImportService
 
-from schemas.repository_schemas import RepositoryListItemSchema, RepositoryDetailSchema, CreateUpdateRepositorySchema, RepositorySearchSchema
+from schemas.repository_schemas import RepositoryListItemSchema, RepositoryDetailSchema, CreateUpdateRepositorySchema, CreateRepositorySchema, UpdateRepositorySchema, RepositorySearchSchema
 from schemas.media_schemas import MediaResponse, MediaUploadResponse
 from schemas.import_schemas import ConflictMode, ImportResponseSchema
 from schemas.export_schemas import RepositoryExportFileSchema
@@ -21,6 +21,7 @@ from routers.internal.auth_utils import get_current_user_oauth
 from routers.controls import enforce_file_size_limit
 from routers.controls.role_authorization import require_min_role, AppRole
 from repositories.media_repository import MediaRepository
+from utils.error_handlers import ValidationError
 
 # Import database dependency
 from db.database import get_db
@@ -32,6 +33,25 @@ repositories_router = APIRouter()
 
 # Debug log when router is loaded
 logger.info("Repositories router loaded successfully")
+
+
+def _validate_repository_app_ownership(repository_id: int, app_id: int, db) -> None:
+    """Raise HTTP 404 if the repository does not exist or does not belong to app_id."""
+    from models.repository import Repository as RepositoryModel
+    repo = RepositoryService.get_repository(repository_id, db)
+    if not repo:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Repository not found",
+        )
+    if repo.app_id != app_id:
+        logger.warning(
+            f"Access violation: repository {repository_id} (app {repo.app_id}) accessed from app {app_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Repository does not belong to this app",
+        )
 
 
 # ==================== REPOSITORY MANAGEMENT ====================
@@ -144,26 +164,59 @@ async def get_repository(
     return RepositoryService.get_repository_detail(app_id, repository_id, db)
 
 
-@repositories_router.post("/{repository_id}",
-                         summary="Create or update repository",
+@repositories_router.post("/",
+                         summary="Create repository",
                          tags=["Repositories"],
-                         response_model=RepositoryDetailSchema)
-async def create_or_update_repository(
+                         response_model=RepositoryDetailSchema,
+                         status_code=status.HTTP_201_CREATED)
+async def create_repository(
     app_id: int,
-    repository_id: int,
-    repo_data: CreateUpdateRepositorySchema,
+    repo_data: CreateRepositorySchema,
     db: Annotated[Session, Depends(get_db)],
     auth_context: Annotated[AuthContext, Depends(get_current_user_oauth)],
     role: Annotated[AppRole, Depends(require_min_role("editor"))],
 ):
     """
-    Create a new repository or update an existing one.
-    """    
-    # Use RepositoryService for business logic
-    repo = RepositoryService.create_or_update_repository_router(app_id, repository_id, repo_data, db)
-    
-    # Return updated repository (reuse the GET logic)
-    return RepositoryService.get_repository_detail(app_id, repo.repository_id, db)
+    Create a new repository.
+    """
+    try:
+        repo = RepositoryService.create_repository_router(app_id, repo_data, db)
+        return RepositoryService.get_repository_detail(app_id, repo.repository_id, db)
+    except HTTPException:
+        raise
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error creating repository: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+
+@repositories_router.put("/{repository_id}",
+                         summary="Update repository",
+                         tags=["Repositories"],
+                         response_model=RepositoryDetailSchema)
+async def update_repository(
+    app_id: int,
+    repository_id: int,
+    repo_data: UpdateRepositorySchema,
+    db: Annotated[Session, Depends(get_db)],
+    auth_context: Annotated[AuthContext, Depends(get_current_user_oauth)],
+    role: Annotated[AppRole, Depends(require_min_role("editor"))],
+):
+    """
+    Update an existing repository. Note: vector_db_type cannot be changed after creation.
+    """
+    _validate_repository_app_ownership(repository_id, app_id, db)
+    try:
+        repo = RepositoryService.update_repository_router(app_id, repository_id, repo_data, db)
+        return RepositoryService.get_repository_detail(app_id, repo.repository_id, db)
+    except HTTPException:
+        raise
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error updating repository: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 
 
 @repositories_router.delete("/{repository_id}",

--- a/backend/routers/internal/silos.py
+++ b/backend/routers/internal/silos.py
@@ -11,12 +11,14 @@ from services.silo_import_service import SiloImportService
 from models.silo import Silo
 
 from schemas.silo_schemas import (
-    SiloListItemSchema, SiloDetailSchema, CreateUpdateSiloSchema, SiloSearchSchema
+    SiloListItemSchema, SiloDetailSchema, CreateUpdateSiloSchema,
+    CreateSiloSchema, UpdateSiloSchema, SiloSearchSchema
 )
 from schemas.import_schemas import ConflictMode, ImportResponseSchema
 from schemas.export_schemas import SiloExportFileSchema
 from .auth_utils import get_current_user_oauth
 from routers.controls.role_authorization import require_min_role, AppRole
+from utils.error_handlers import ValidationError
 
 from db.database import get_db
 
@@ -187,39 +189,75 @@ async def get_silo(
         )
 
 
-@silos_router.post("/{silo_id}",
-                   summary="Create or update silo",
+@silos_router.post("/",
+                   summary="Create silo",
                    tags=["Silos"],
-                   response_model=SiloDetailSchema)
-async def create_or_update_silo(
+                   response_model=SiloDetailSchema,
+                   status_code=status.HTTP_201_CREATED)
+async def create_silo(
     app_id: int,
-    silo_id: int,
-    silo_data: CreateUpdateSiloSchema,
+    silo_data: CreateSiloSchema,
     auth_context: Annotated[AuthContext, Depends(get_current_user_oauth)],
     db: Annotated[Session, Depends(get_db)],
     role: Annotated[AppRole, Depends(require_min_role("editor"))],
 ):
     """
-    Create a new silo or update an existing one.
-    """    
-    if silo_id != 0:
-        _validate_silo_app_ownership(silo_id, app_id, db)
-    
+    Create a new silo.
+    """
     try:
-        # Create or update using the service
-        silo = SiloService.create_or_update_silo_router(app_id, silo_id, silo_data, db)
-        
-        # Return updated silo (reuse the GET logic)
-        logger.info(f"Silo created/updated successfully: {silo.silo_id}, now getting details")
-        return await get_silo(app_id, silo.silo_id, auth_context, role, db)
-        
+        silo = SiloService.create_or_update_silo_router(app_id, 0, silo_data, db)
+        logger.info(f"Silo created successfully: {silo.silo_id}")
+        return await get_silo(app_id, silo.silo_id, auth_context, db, role)
+
     except HTTPException:
         raise
+    except ValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
     except Exception as e:
-        logger.error(f"Error creating/updating silo: {str(e)}", exc_info=True)
+        logger.error(f"Error creating silo: {str(e)}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error creating/updating silo: {str(e)}"
+            detail=f"Error creating silo: {str(e)}"
+        )
+
+
+@silos_router.put("/{silo_id}",
+                  summary="Update silo",
+                  tags=["Silos"],
+                  response_model=SiloDetailSchema)
+async def update_silo(
+    app_id: int,
+    silo_id: int,
+    silo_data: UpdateSiloSchema,
+    auth_context: Annotated[AuthContext, Depends(get_current_user_oauth)],
+    db: Annotated[Session, Depends(get_db)],
+    role: Annotated[AppRole, Depends(require_min_role("editor"))],
+):
+    """
+    Update an existing silo. Note: vector_db_type cannot be changed after creation.
+    """
+    _validate_silo_app_ownership(silo_id, app_id, db)
+
+    try:
+        silo = SiloService.create_or_update_silo_router(app_id, silo_id, silo_data, db)
+        logger.info(f"Silo updated successfully: {silo.silo_id}")
+        return await get_silo(app_id, silo.silo_id, auth_context, db, role)
+
+    except HTTPException:
+        raise
+    except ValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+    except Exception as e:
+        logger.error(f"Error updating silo: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error updating silo: {str(e)}"
         )
 
 

--- a/backend/routers/internal/silos.py
+++ b/backend/routers/internal/silos.py
@@ -19,6 +19,7 @@ from schemas.export_schemas import SiloExportFileSchema
 from .auth_utils import get_current_user_oauth
 from routers.controls.role_authorization import require_min_role, AppRole
 from utils.error_handlers import ValidationError
+from utils.vector_db_immutability import assert_vector_db_type_immutable, assert_embedding_service_immutable
 
 from db.database import get_db
 
@@ -229,6 +230,7 @@ async def create_silo(
                   tags=["Silos"],
                   response_model=SiloDetailSchema)
 async def update_silo(
+    request: Request,
     app_id: int,
     silo_id: int,
     silo_data: UpdateSiloSchema,
@@ -237,11 +239,17 @@ async def update_silo(
     role: Annotated[AppRole, Depends(require_min_role("editor"))],
 ):
     """
-    Update an existing silo. Note: vector_db_type cannot be changed after creation.
+    Update an existing silo. Note: vector_db_type and embedding_service_id cannot be changed after creation.
     """
     _validate_silo_app_ownership(silo_id, app_id, db)
 
     try:
+        raw_body = await request.json()
+        existing_silo = SiloService.get_silo(silo_id, db)
+        if existing_silo:
+            assert_vector_db_type_immutable(existing_silo.vector_db_type, raw_body.get('vector_db_type'), "silo")
+            assert_embedding_service_immutable(existing_silo.embedding_service_id, raw_body.get('embedding_service_id'), "silo")
+
         silo = SiloService.create_or_update_silo_router(app_id, silo_id, silo_data, db)
         logger.info(f"Silo updated successfully: {silo.silo_id}")
         return await get_silo(app_id, silo.silo_id, auth_context, db, role)

--- a/backend/routers/public/v1/silos.py
+++ b/backend/routers/public/v1/silos.py
@@ -25,7 +25,7 @@ from .schemas import (
 from .auth import get_api_key_auth, validate_api_key_for_app, validate_silo_ownership
 from db.database import get_db
 
-from schemas.silo_schemas import CreateUpdateSiloSchema, SiloSearchSchema
+from schemas.silo_schemas import CreateUpdateSiloSchema, UpdateSiloSchema, SiloSearchSchema
 
 from utils.logger import get_logger
 
@@ -153,11 +153,11 @@ async def get_silo(
 async def update_silo(
     app_id: int,
     silo_id: int,
-    silo_data: CreateUpdateSiloSchema,
+    silo_data: UpdateSiloSchema,
     api_key: Annotated[str, Depends(get_api_key_auth)],
     db: Annotated[Session, Depends(get_db)],
 ):
-    """Update silo properties."""
+    """Update silo properties. Note: vector_db_type cannot be changed after creation."""
     validate_api_key_for_app(app_id, api_key, db)
     validate_silo_ownership(db, silo_id, app_id)
 

--- a/backend/routers/public/v1/silos.py
+++ b/backend/routers/public/v1/silos.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form, status
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form, status, Request
 from typing import Optional, Annotated
 from sqlalchemy.orm import Session
 import json
@@ -26,6 +26,8 @@ from .auth import get_api_key_auth, validate_api_key_for_app, validate_silo_owne
 from db.database import get_db
 
 from schemas.silo_schemas import CreateUpdateSiloSchema, UpdateSiloSchema, SiloSearchSchema
+from utils.error_handlers import ValidationError
+from utils.vector_db_immutability import assert_vector_db_type_immutable, assert_embedding_service_immutable
 
 from utils.logger import get_logger
 
@@ -151,17 +153,24 @@ async def get_silo(
     response_model=PublicSiloResponseSchema,
 )
 async def update_silo(
+    request: Request,
     app_id: int,
     silo_id: int,
     silo_data: UpdateSiloSchema,
     api_key: Annotated[str, Depends(get_api_key_auth)],
     db: Annotated[Session, Depends(get_db)],
 ):
-    """Update silo properties. Note: vector_db_type cannot be changed after creation."""
+    """Update silo properties. Note: vector_db_type and embedding_service_id cannot be changed after creation."""
     validate_api_key_for_app(app_id, api_key, db)
     validate_silo_ownership(db, silo_id, app_id)
 
     try:
+        raw_body = await request.json()
+        existing_silo = SiloService.get_silo(silo_id, db)
+        if existing_silo:
+            assert_vector_db_type_immutable(existing_silo.vector_db_type, raw_body.get('vector_db_type'), "silo")
+            assert_embedding_service_immutable(existing_silo.embedding_service_id, raw_body.get('embedding_service_id'), "silo")
+
         silo = SiloService.create_or_update_silo_router(
             app_id=app_id,
             silo_id=silo_id,
@@ -177,6 +186,11 @@ async def update_silo(
 
     except HTTPException:
         raise
+    except ValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(e),
+        )
     except Exception as e:
         logger.error(f"Error updating silo {silo_id} for app {app_id}: {str(e)}")
         raise HTTPException(

--- a/backend/schemas/domain_url_schemas.py
+++ b/backend/schemas/domain_url_schemas.py
@@ -53,14 +53,13 @@ class CreateDomainSchema(BaseModel):
 
 
 class UpdateDomainSchema(BaseModel):
-    """Schema for updating an existing domain (vector_db_type is immutable after creation)"""
+    """Schema for updating an existing domain (vector_db_type and embedding_service_id are immutable after creation)"""
     name: str
     description: Optional[str] = ""
     base_url: str
     content_tag: Optional[str] = "body"
     content_class: Optional[str] = ""
     content_id: Optional[str] = ""
-    embedding_service_id: Optional[int] = None
 
 
 # Backward-compatible alias

--- a/backend/schemas/domain_url_schemas.py
+++ b/backend/schemas/domain_url_schemas.py
@@ -40,8 +40,8 @@ class DomainDetailSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-class CreateUpdateDomainSchema(BaseModel):
-    """Schema for creating or updating a domain"""
+class CreateDomainSchema(BaseModel):
+    """Schema for creating a new domain (vector_db_type is settable on creation only)"""
     name: str
     description: Optional[str] = ""
     base_url: str
@@ -50,6 +50,21 @@ class CreateUpdateDomainSchema(BaseModel):
     content_id: Optional[str] = ""
     embedding_service_id: Optional[int] = None
     vector_db_type: Optional[str] = None
+
+
+class UpdateDomainSchema(BaseModel):
+    """Schema for updating an existing domain (vector_db_type is immutable after creation)"""
+    name: str
+    description: Optional[str] = ""
+    base_url: str
+    content_tag: Optional[str] = "body"
+    content_class: Optional[str] = ""
+    content_id: Optional[str] = ""
+    embedding_service_id: Optional[int] = None
+
+
+# Backward-compatible alias
+CreateUpdateDomainSchema = CreateDomainSchema
 
 
 # ==================== URL SCHEMAS ====================

--- a/backend/schemas/repository_schemas.py
+++ b/backend/schemas/repository_schemas.py
@@ -45,13 +45,25 @@ class RepositoryDetailSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-class CreateUpdateRepositorySchema(BaseModel):
-    """Schema for creating or updating a repository"""
+class CreateRepositorySchema(BaseModel):
+    """Schema for creating a new repository (vector_db_type is settable on creation only)"""
     name: str
     type: Optional[str] = None
     status: Optional[str] = None
     embedding_service_id: Optional[int] = None
     vector_db_type: Optional[str] = None
+
+
+class UpdateRepositorySchema(BaseModel):
+    """Schema for updating an existing repository (vector_db_type is immutable after creation)"""
+    name: str
+    type: Optional[str] = None
+    status: Optional[str] = None
+    embedding_service_id: Optional[int] = None
+
+
+# Backward-compatible alias used by internal callers that haven't been updated yet
+CreateUpdateRepositorySchema = CreateRepositorySchema
 
 
 class RepositorySearchSchema(BaseModel):

--- a/backend/schemas/silo_schemas.py
+++ b/backend/schemas/silo_schemas.py
@@ -41,14 +41,27 @@ class SiloDetailSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-class CreateUpdateSiloSchema(BaseModel):
-    """Schema for creating or updating a silo"""
+class CreateSiloSchema(BaseModel):
+    """Schema for creating a new silo (vector_db_type is settable on creation only)"""
     name: str
     description: Optional[str] = None
     type: Optional[str] = None
     output_parser_id: Optional[int] = None
     embedding_service_id: Optional[int] = None
     vector_db_type: Optional[str] = None
+
+
+class UpdateSiloSchema(BaseModel):
+    """Schema for updating an existing silo (vector_db_type is immutable after creation)"""
+    name: str
+    description: Optional[str] = None
+    type: Optional[str] = None
+    output_parser_id: Optional[int] = None
+    embedding_service_id: Optional[int] = None
+
+
+# Kept for backward compatibility with the public API router
+CreateUpdateSiloSchema = CreateSiloSchema
 
 
 class SiloSearchSchema(BaseModel):

--- a/backend/schemas/silo_schemas.py
+++ b/backend/schemas/silo_schemas.py
@@ -52,12 +52,11 @@ class CreateSiloSchema(BaseModel):
 
 
 class UpdateSiloSchema(BaseModel):
-    """Schema for updating an existing silo (vector_db_type is immutable after creation)"""
+    """Schema for updating an existing silo (vector_db_type and embedding_service_id are immutable after creation)"""
     name: str
     description: Optional[str] = None
     type: Optional[str] = None
     output_parser_id: Optional[int] = None
-    embedding_service_id: Optional[int] = None
 
 
 # Kept for backward compatibility with the public API router

--- a/backend/services/domain_service.py
+++ b/backend/services/domain_service.py
@@ -14,6 +14,7 @@ from utils.error_handlers import (
     handle_database_errors, NotFoundError, ValidationError, 
     validate_required_fields
 )
+from utils.vector_db_immutability import assert_vector_db_type_immutable
 from tools.vector_store_factory import VectorStoreFactory
 logger = get_logger(__name__)
 
@@ -302,32 +303,26 @@ class DomainService:
         domain.content_id = domain_data.get('content_id', '').strip() or None
         
         updated_domain = DomainRepository.update(domain, db)
-        
-        # Update the associated silo's embedding service if provided
-        if domain.silo_id and embedding_service_id is not None:
-            logger.info(f"Updating embedding service for silo {domain.silo_id} to service {embedding_service_id}")
+
+        # Update the associated silo once (avoiding multiple fetches)
+        if domain.silo_id:
             silo = SiloService.get_silo(domain.silo_id, db)
             if silo:
-                silo.embedding_service_id = embedding_service_id
-                if vector_db_type:
-                    silo.vector_db_type = vector_db_type
-                elif not silo.vector_db_type:
+                # Enforce immutability before touching vector_db_type
+                assert_vector_db_type_immutable(silo.vector_db_type, vector_db_type, "domain")
+
+                if embedding_service_id is not None:
+                    silo.embedding_service_id = embedding_service_id
+                    logger.info(f"Updating embedding service for silo {domain.silo_id} to service {embedding_service_id}")
+
+                # vector_db_type is immutable — only default-fill if the stored value is empty
+                if not silo.vector_db_type:
                     silo.vector_db_type = 'PGVECTOR'
+
                 SiloRepository.update(silo, db)
-                logger.info(f"Successfully updated silo {domain.silo_id} embedding service")
+                logger.info(f"Successfully updated silo {domain.silo_id}")
             else:
                 logger.warning(f"Silo {domain.silo_id} not found for domain {domain_id}")
-
-        if domain.silo_id and vector_db_type and embedding_service_id is None:
-            silo = SiloService.get_silo(domain.silo_id, db)
-            if silo:
-                silo.vector_db_type = vector_db_type
-                SiloRepository.update(silo, db)
-        elif domain.silo_id and not vector_db_type:
-            silo = SiloService.get_silo(domain.silo_id, db)
-            if silo and not silo.vector_db_type:
-                silo.vector_db_type = 'PGVECTOR'
-                SiloRepository.update(silo, db)
         
         return updated_domain.domain_id
     

--- a/backend/services/domain_service.py
+++ b/backend/services/domain_service.py
@@ -14,7 +14,7 @@ from utils.error_handlers import (
     handle_database_errors, NotFoundError, ValidationError, 
     validate_required_fields
 )
-from utils.vector_db_immutability import assert_vector_db_type_immutable
+from utils.vector_db_immutability import assert_vector_db_type_immutable, assert_embedding_service_immutable
 from tools.vector_store_factory import VectorStoreFactory
 logger = get_logger(__name__)
 
@@ -310,10 +310,7 @@ class DomainService:
             if silo:
                 # Enforce immutability before touching vector_db_type
                 assert_vector_db_type_immutable(silo.vector_db_type, vector_db_type, "domain")
-
-                if embedding_service_id is not None:
-                    silo.embedding_service_id = embedding_service_id
-                    logger.info(f"Updating embedding service for silo {domain.silo_id} to service {embedding_service_id}")
+                assert_embedding_service_immutable(silo.embedding_service_id, embedding_service_id, "domain")
 
                 # vector_db_type is immutable — only default-fill if the stored value is empty
                 if not silo.vector_db_type:

--- a/backend/services/repository_service.py
+++ b/backend/services/repository_service.py
@@ -15,7 +15,8 @@ from services.output_parser_service import OutputParserService
 from repositories.repository_repository import RepositoryRepository
 from repositories.resource_repository import ResourceRepository
 from repositories.embedding_service_repository import EmbeddingServiceRepository
-from schemas.repository_schemas import RepositoryListItemSchema, RepositoryDetailSchema, CreateUpdateRepositorySchema
+from schemas.repository_schemas import RepositoryListItemSchema, RepositoryDetailSchema, CreateUpdateRepositorySchema, CreateRepositorySchema, UpdateRepositorySchema
+from utils.vector_db_immutability import assert_vector_db_type_immutable
 from datetime import datetime
 from utils.logger import get_logger
 from tools.vector_store_factory import VectorStoreFactory
@@ -131,6 +132,9 @@ class RepositoryService:
         if repository.silo:
             if vector_db_type is not None:
                 normalized_type = vector_db_type.upper()
+                assert_vector_db_type_immutable(
+                    repository.silo.vector_db_type, normalized_type, "repository"
+                )
                 repository.silo.vector_db_type = normalized_type
             elif not repository.silo.vector_db_type:
                 repository.silo.vector_db_type = 'PGVECTOR'
@@ -384,26 +388,13 @@ class RepositoryService:
         )
 
     @staticmethod
-    def create_or_update_repository_router(
-        app_id: int, 
-        repository_id: int, 
-        repo_data: CreateUpdateRepositorySchema, 
-        db: Session
+    def create_repository_router(
+        app_id: int,
+        repo_data: CreateRepositorySchema,
+        db: Session,
     ) -> Repository:
         """
-        Create or update a repository - business logic from router
-        
-        Args:
-            app_id: Application ID
-            repository_id: Repository ID (0 for new repository)
-            repo_data: Repository data to create/update
-            db: Database session
-            
-        Returns:
-            Created or updated Repository instance
-            
-        Raises:
-            HTTPException: If repository not found (for updates)
+        Create a new repository — business logic called by POST / router endpoint.
         """
         from fastapi import HTTPException, status
 
@@ -412,55 +403,78 @@ class RepositoryService:
             if not isinstance(repo_data.vector_db_type, str):
                 raise HTTPException(
                     status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    detail="vector_db_type must be a string"
+                    detail="vector_db_type must be a string",
                 )
             candidate_type = repo_data.vector_db_type.strip().upper()
             if candidate_type and candidate_type not in VectorStoreFactory.IMPLEMENTED_TYPES:
                 raise HTTPException(
                     status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    detail=f"Unsupported vector_db_type '{candidate_type}'"
+                    detail=f"Unsupported vector_db_type '{candidate_type}'",
                 )
             normalized_vector_db_type = candidate_type or None
-        
-        if repository_id == 0:
-            # Create new repository
-            repo = Repository()
-            repo.app_id = app_id
-            repo.name = repo_data.name
+
+        repo = Repository()
+        repo.app_id = app_id
+        repo.name = repo_data.name
+        repo.type = repo_data.type
+        repo.status = repo_data.status or "active"
+        repo.create_date = datetime.now()
+
+        return RepositoryService.create_repository(
+            repo,
+            repo_data.embedding_service_id,
+            normalized_vector_db_type,
+            db,
+        )
+
+    @staticmethod
+    def update_repository_router(
+        app_id: int,
+        repository_id: int,
+        repo_data: UpdateRepositorySchema,
+        db: Session,
+    ) -> Repository:
+        """
+        Update an existing repository — business logic called by PUT /{repository_id}.
+        vector_db_type is not accepted here; the immutability guard in update_repository()
+        will reject any attempt to change it through direct service calls.
+        """
+        from fastapi import HTTPException, status
+
+        repo = RepositoryRepository.get_by_id(db, repository_id)
+        if not repo:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Repository not found",
+            )
+
+        repo.name = repo_data.name
+        if repo_data.type is not None:
             repo.type = repo_data.type
-            repo.status = repo_data.status or 'active'
-            repo.create_date = datetime.now()
-            
-            # Use RepositoryService to create repository with silo
-            repo = RepositoryService.create_repository(
-                repo,
-                repo_data.embedding_service_id,
-                normalized_vector_db_type,
-                db
-            )
-        else:
-            # Update existing repository
-            repo = RepositoryRepository.get_by_id(db, repository_id)
-            if not repo:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="Repository not found"
-                )
-            
-            # Update repository data
-            repo.name = repo_data.name
-            if repo_data.type is not None:
-                repo.type = repo_data.type
-            if repo_data.status is not None:
-                repo.status = repo_data.status
-            repo = RepositoryService.update_repository(
-                repo,
-                repo_data.embedding_service_id,
-                normalized_vector_db_type,
-                db
-            )
-        
-        return repo
+        if repo_data.status is not None:
+            repo.status = repo_data.status
+
+        return RepositoryService.update_repository(
+            repo,
+            repo_data.embedding_service_id,
+            None,  # vector_db_type not accepted on update
+            db,
+        )
+
+    @staticmethod
+    def create_or_update_repository_router(
+        app_id: int,
+        repository_id: int,
+        repo_data: CreateUpdateRepositorySchema,
+        db: Session,
+    ) -> Repository:
+        """
+        Create or update a repository — kept for backward compatibility.
+        New callers should use create_repository_router / update_repository_router.
+        """
+        if repository_id == 0:
+            return RepositoryService.create_repository_router(app_id, repo_data, db)
+        return RepositoryService.update_repository_router(app_id, repository_id, repo_data, db)
 
     @staticmethod
     def delete_repository_router(repository_id: int, db: Session) -> bool:

--- a/backend/services/silo_service.py
+++ b/backend/services/silo_service.py
@@ -19,7 +19,7 @@ from utils.error_handlers import (
     handle_database_errors, NotFoundError, ValidationError, 
     validate_required_fields
 )
-from utils.vector_db_immutability import assert_vector_db_type_immutable
+from utils.vector_db_immutability import assert_vector_db_type_immutable, assert_embedding_service_immutable
 from schemas.silo_schemas import SiloListItemSchema, SiloDetailSchema, CreateUpdateSiloSchema
 from repositories.silo_repository import SiloRepository
 from services.folder_service import FolderService
@@ -218,6 +218,9 @@ class SiloService:
                 assert_vector_db_type_immutable(
                     silo.vector_db_type, requested_vector_db_type, "silo"
                 )
+                assert_embedding_service_immutable(
+                    silo.embedding_service_id, silo_data.get('embedding_service_id'), "silo"
+                )
             else:
                 # Enforce per-app silo limit before creation (SaaS mode only)
                 app_id = silo_data.get('app_id')
@@ -241,8 +244,8 @@ class SiloService:
                 if silo_type == SiloType.REPO:
                     silo.metadata_definition_id = 0
 
-            # Set embedding service if provided
-            if silo_data.get('embedding_service_id'):
+            # Set embedding service on creation only — immutable after creation
+            if not silo_id and silo_data.get('embedding_service_id'):
                 silo.embedding_service_id = silo_data['embedding_service_id']
             
             # Handle metadata definition (output parser) - explicitly handle None to clear it
@@ -1228,7 +1231,7 @@ class SiloService:
             'app_id': app_id,
             'type': silo_data.type,
             'output_parser_id': silo_data.output_parser_id,
-            'embedding_service_id': silo_data.embedding_service_id,
+            'embedding_service_id': getattr(silo_data, 'embedding_service_id', None),
             'vector_db_type': getattr(silo_data, 'vector_db_type', None)
         }
         

--- a/backend/services/silo_service.py
+++ b/backend/services/silo_service.py
@@ -214,6 +214,15 @@ class SiloService:
                 if not silo:
                     raise NotFoundError(f"Silo with ID {silo_id} not found", "silo")
                 logger.info(f"Updating existing silo {silo_id}")
+                if (
+                    requested_vector_db_type is not None
+                    and silo.vector_db_type is not None
+                    and requested_vector_db_type != silo.vector_db_type.upper()
+                ):
+                    raise ValidationError(
+                        "vector_db_type cannot be changed after a silo has been created. "
+                        "Delete and recreate the silo to use a different vector database."
+                    )
             else:
                 # Enforce per-app silo limit before creation (SaaS mode only)
                 app_id = silo_data.get('app_id')
@@ -1215,6 +1224,8 @@ class SiloService:
         Create or update silo using router data
         """
         # Prepare form data for the service
+        # vector_db_type uses getattr so this method works with both CreateSiloSchema
+        # (which has the field) and UpdateSiloSchema (which intentionally omits it).
         form_data = {
             'silo_id': silo_id,
             'name': silo_data.name,
@@ -1223,7 +1234,7 @@ class SiloService:
             'type': silo_data.type,
             'output_parser_id': silo_data.output_parser_id,
             'embedding_service_id': silo_data.embedding_service_id,
-            'vector_db_type': silo_data.vector_db_type
+            'vector_db_type': getattr(silo_data, 'vector_db_type', None)
         }
         
         # Create or update using the existing service

--- a/backend/services/silo_service.py
+++ b/backend/services/silo_service.py
@@ -19,6 +19,7 @@ from utils.error_handlers import (
     handle_database_errors, NotFoundError, ValidationError, 
     validate_required_fields
 )
+from utils.vector_db_immutability import assert_vector_db_type_immutable
 from schemas.silo_schemas import SiloListItemSchema, SiloDetailSchema, CreateUpdateSiloSchema
 from repositories.silo_repository import SiloRepository
 from services.folder_service import FolderService
@@ -214,15 +215,9 @@ class SiloService:
                 if not silo:
                     raise NotFoundError(f"Silo with ID {silo_id} not found", "silo")
                 logger.info(f"Updating existing silo {silo_id}")
-                if (
-                    requested_vector_db_type is not None
-                    and silo.vector_db_type is not None
-                    and requested_vector_db_type != silo.vector_db_type.upper()
-                ):
-                    raise ValidationError(
-                        "vector_db_type cannot be changed after a silo has been created. "
-                        "Delete and recreate the silo to use a different vector database."
-                    )
+                assert_vector_db_type_immutable(
+                    silo.vector_db_type, requested_vector_db_type, "silo"
+                )
             else:
                 # Enforce per-app silo limit before creation (SaaS mode only)
                 app_id = silo_data.get('app_id')

--- a/backend/utils/vector_db_immutability.py
+++ b/backend/utils/vector_db_immutability.py
@@ -1,6 +1,5 @@
 from utils.error_handlers import ValidationError
 
-
 def assert_vector_db_type_immutable(
     existing_value: str | None,
     requested_value: str | None,
@@ -20,7 +19,32 @@ def assert_vector_db_type_immutable(
         return
 
     if requested_value.upper() != existing_value.upper():
+       
         raise ValidationError(
             f"vector_db_type cannot be changed after a {entity_name} has been created. "
             f"Delete and recreate the {entity_name} to use a different vector database."
+        )
+
+
+def assert_embedding_service_immutable(
+    existing_id: int | None,
+    requested_id: int | None,
+    entity_name: str = "resource",
+) -> None:
+    """Raise ValidationError if the caller tries to change embedding_service_id on an existing resource.
+
+    Rules:
+    - If existing_id is None  → no service locked yet; pass through.
+    - If requested_id is None → caller is not touching the field; pass through.
+    - If both set and EQUAL   → idempotent; pass through.
+    - If both set and DIFFER  → raises ValidationError.
+    """
+    if existing_id is None or requested_id is None:
+        return
+
+    if int(requested_id) != int(existing_id):
+        raise ValidationError(
+            f"embedding_service_id cannot be changed after a {entity_name} has been created. "
+            f"The embedding model determines the vector dimensions of all indexed data. "
+            f"Delete and recreate the {entity_name} to use a different embedding service."
         )

--- a/backend/utils/vector_db_immutability.py
+++ b/backend/utils/vector_db_immutability.py
@@ -1,0 +1,26 @@
+from utils.error_handlers import ValidationError
+
+
+def assert_vector_db_type_immutable(
+    existing_value: str | None,
+    requested_value: str | None,
+    entity_name: str = "resource",
+) -> None:
+    """Raise ValidationError if the caller tries to change vector_db_type on an existing resource.
+
+    Rules:
+    - If existing_value is None  → no value locked yet; pass through.
+    - If requested_value is None → caller is not touching the field; pass through.
+    - If both set and EQUAL      → idempotent; pass through.
+    - If both set and DIFFER     → raises ValidationError.
+
+    Both values are compared case-insensitively after uppercasing.
+    """
+    if existing_value is None or requested_value is None:
+        return
+
+    if requested_value.upper() != existing_value.upper():
+        raise ValidationError(
+            f"vector_db_type cannot be changed after a {entity_name} has been created. "
+            f"Delete and recreate the {entity_name} to use a different vector database."
+        )

--- a/frontend/src/components/forms/SiloForm.tsx
+++ b/frontend/src/components/forms/SiloForm.tsx
@@ -112,16 +112,12 @@ function SiloForm({ silo, onSubmit, onCancel}: Readonly<SiloFormProps>) {
       setOutputParsers(parsersResponse);
       setEmbeddingServices(servicesResponse);
 
-      // Fetch vector database options only when they are not provided by the silo payload
+      // Fetch vector database options only when they have not been set
       if (vectorDbOptions.length === 0) {
         const siloOptions = await apiService.getSiloOptions(appIdNumber);
         const availableVectorDbOptions: VectorDbOption[] = siloOptions.vector_db_options ?? [];
         setVectorDbOptions(availableVectorDbOptions);
-
-        setFormData(prev => ({
-          ...prev,
-          vector_db_type: availableVectorDbOptions[0]?.code || prev.vector_db_type || 'PGVECTOR'
-        }));
+        // Do NOT set vector_db_type here — let the silo initialization effect handle it
       }
 
       // Default embedding service for new silo when only one available
@@ -165,7 +161,7 @@ function SiloForm({ silo, onSubmit, onCancel}: Readonly<SiloFormProps>) {
       return;
     }
 
-    if (!formData.vector_db_type) {
+    if (!isEditing && !formData.vector_db_type) {
       setError('Vector database selection is required');
       return;
     }
@@ -173,10 +169,10 @@ function SiloForm({ silo, onSubmit, onCancel}: Readonly<SiloFormProps>) {
     try {
       setIsSubmitting(true);
       setError(null);
-      await onSubmit({
-        ...formData,
-        vector_db_type: formData.vector_db_type.toUpperCase(),
-      });
+      const payload = isEditing
+        ? (({ vector_db_type: _ignored, ...rest }) => rest)(formData)
+        : { ...formData, vector_db_type: formData.vector_db_type!.toUpperCase() };
+      await onSubmit(payload);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save silo');
     } finally {
@@ -306,9 +302,9 @@ function SiloForm({ silo, onSubmit, onCancel}: Readonly<SiloFormProps>) {
                 name="vector_db_type"
                 value={vectorDbOptions.length === 0 ? '' : formData.vector_db_type ?? ''}
                 onChange={handleChange}
-                required
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-transparent"
-                disabled={isSubmitting || vectorDbOptions.length === 0}
+                required={!isEditing}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-transparent disabled:bg-gray-100 disabled:text-gray-500 disabled:cursor-not-allowed"
+                disabled={isSubmitting || vectorDbOptions.length === 0 || isEditing}
               >
                 {vectorDbOptions.length === 0 && <option value="">No vector databases available</option>}
                 {vectorDbOptions.map((option) => (
@@ -317,7 +313,12 @@ function SiloForm({ silo, onSubmit, onCancel}: Readonly<SiloFormProps>) {
                   </option>
                 ))}
               </select>
-              {vectorDbOptions.length === 0 ? (
+              {isEditing ? (
+                <p className="mt-1 text-sm text-gray-500 flex items-center gap-1">
+                  <Info className="w-3.5 h-3.5 shrink-0" />
+                  The vector database cannot be changed after a silo is created.
+                </p>
+              ) : vectorDbOptions.length === 0 ? (
                 <p className="mt-1 text-sm text-red-600">
                   No vector databases available. Configure a silo backend before proceeding.
                 </p>

--- a/frontend/src/components/forms/SiloForm.tsx
+++ b/frontend/src/components/forms/SiloForm.tsx
@@ -170,7 +170,7 @@ function SiloForm({ silo, onSubmit, onCancel}: Readonly<SiloFormProps>) {
       setIsSubmitting(true);
       setError(null);
       const payload = isEditing
-        ? (({ vector_db_type: _ignored, ...rest }) => rest)(formData)
+        ? (({ vector_db_type: _vdb, embedding_service_id: _esi, ...rest }) => rest)(formData)
         : { ...formData, vector_db_type: formData.vector_db_type!.toUpperCase() };
       await onSubmit(payload);
     } catch (err) {
@@ -277,8 +277,8 @@ function SiloForm({ silo, onSubmit, onCancel}: Readonly<SiloFormProps>) {
                 value={formData.embedding_service_id?.toString() || ''}
                 onChange={handleChange}
                 required
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-transparent"
-                disabled={isSubmitting}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-transparent disabled:bg-gray-100 disabled:text-gray-500 disabled:cursor-not-allowed"
+                disabled={isSubmitting || isEditing}
               >
                 <option value="">Select an embedding service</option>
                 {embeddingServices.map((service) => (
@@ -287,9 +287,15 @@ function SiloForm({ silo, onSubmit, onCancel}: Readonly<SiloFormProps>) {
                   </option>
                 ))}
               </select>
-              <p className="mt-1 text-sm text-gray-500">
-                Required: Choose the embedding service for vector generation.
-              </p>
+              {isEditing ? (
+                <p className="mt-1 text-sm text-amber-600">
+                  The embedding service cannot be changed after a silo is created.
+                </p>
+              ) : (
+                <p className="mt-1 text-sm text-gray-500">
+                  Required: Choose the embedding service for vector generation.
+                </p>
+              )}
             </div>
 
             {/* Vector Database */}

--- a/frontend/src/pages/DomainFormPage.tsx
+++ b/frontend/src/pages/DomainFormPage.tsx
@@ -128,9 +128,10 @@ function DomainFormPage() {
       const domainIdNum = isNewDomain ? 0 : Number.parseInt(domainId ?? '0', 10);
 
       if (isNewDomain) {
-        await apiService.createDomain(numericAppId, domainIdNum, formData);
+        await apiService.createDomain(numericAppId, formData);
       } else {
-        await apiService.updateDomain(numericAppId, domainIdNum, formData);
+        const { vector_db_type: _omit, ...updatePayload } = formData;
+        await apiService.updateDomain(numericAppId, domainIdNum, updatePayload);
       }
       
       // Navigate back to domains list
@@ -291,9 +292,9 @@ function DomainFormPage() {
             id="domain-vector-db"
             value={vectorDbSelectValue}
             onChange={(e) => handleInputChange('vector_db_type', e.target.value)}
-            className="w-full p-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-            required
-            disabled={vectorDbOptions.length === 0}
+            className="w-full p-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
+            required={isNewDomain}
+            disabled={vectorDbOptions.length === 0 || !isNewDomain}
           >
             {vectorDbOptions.map((option) => (
               <option key={option.code} value={option.code}>
@@ -301,9 +302,14 @@ function DomainFormPage() {
               </option>
             ))}
           </select>
-          {vectorDbOptions.length === 0 && (
+          {vectorDbOptions.length === 0 && isNewDomain && (
             <p className="text-sm text-red-600 mt-1">
               No vector databases available. Please configure a silo with vector support first.
+            </p>
+          )}
+          {!isNewDomain && (
+            <p className="text-sm text-amber-600 mt-1">
+              The vector database cannot be changed after a domain is created.
             </p>
           )}
         </div>

--- a/frontend/src/pages/DomainFormPage.tsx
+++ b/frontend/src/pages/DomainFormPage.tsx
@@ -130,7 +130,7 @@ function DomainFormPage() {
       if (isNewDomain) {
         await apiService.createDomain(numericAppId, formData);
       } else {
-        const { vector_db_type: _omit, ...updatePayload } = formData;
+        const { vector_db_type: _vdb, embedding_service_id: _esi, ...updatePayload } = formData;
         await apiService.updateDomain(numericAppId, domainIdNum, updatePayload);
       }
       
@@ -266,8 +266,9 @@ function DomainFormPage() {
               const value = e.target.value;
               handleInputChange('embedding_service_id', value ? Number.parseInt(value, 10) : undefined);
             }}
-            className="w-full p-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-            required
+            className="w-full p-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
+            required={isNewDomain}
+            disabled={!isNewDomain}
           >
             <option value="">Select an embedding service</option>
             {embeddingServices.map((service) => (
@@ -279,6 +280,11 @@ function DomainFormPage() {
           {embeddingServices.length === 0 && (
             <p className="text-sm text-red-600 mt-1">
               No embedding services available. Please create one first.
+            </p>
+          )}
+          {!isNewDomain && (
+            <p className="text-sm text-amber-600 mt-1">
+              The embedding service cannot be changed after a domain is created.
             </p>
           )}
         </div>

--- a/frontend/src/pages/RepositoryFormPage.tsx
+++ b/frontend/src/pages/RepositoryFormPage.tsx
@@ -114,7 +114,7 @@ const RepositoryFormPage: React.FC = () => {
       return;
     }
 
-    if (!formData.vector_db_type) {
+    if (isNewRepository && !formData.vector_db_type) {
       setError('Vector database selection is required');
       return;
     }
@@ -145,7 +145,6 @@ const RepositoryFormPage: React.FC = () => {
         await apiService.updateRepository(appIdNumber, repositoryIdNumber, { 
           name: trimmedName,
           embedding_service_id: formData.embedding_service_id,
-          vector_db_type: normalizedVectorDbType
         });
       }
 
@@ -228,8 +227,9 @@ const RepositoryFormPage: React.FC = () => {
                   vector_db_type: e.target.value.toUpperCase(),
                 })
               }
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              required
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed"
+              required={isNewRepository}
+              disabled={!isNewRepository}
             >
               {vectorDbOptions.length === 0
                 ? (
@@ -242,9 +242,15 @@ const RepositoryFormPage: React.FC = () => {
                   ))
                 )}
             </select>
-            <p className="text-sm text-gray-500 mt-1">
-              Select where embeddings for this repository will be stored.
-            </p>
+            {isNewRepository ? (
+              <p className="text-sm text-gray-500 mt-1">
+                Select where embeddings for this repository will be stored.
+              </p>
+            ) : (
+              <p className="text-sm text-amber-600 mt-1">
+                The vector database cannot be changed after a repository is created.
+              </p>
+            )}
           </div>
 
           {/* Embedding Service (only for new repositories) */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1081,15 +1081,15 @@ class ApiService {
   }
 
   async createRepository(appId: number, data: { name: string; embedding_service_id?: number; vector_db_type?: string }) {
-    return this.request(`/internal/apps/${appId}/repositories/0`, {
+    return this.request(`/internal/apps/${appId}/repositories/`, {
       method: 'POST',
       body: JSON.stringify(data),
     });
   }
 
-  async updateRepository(appId: number, repositoryId: number, data: { name: string; embedding_service_id?: number; vector_db_type?: string }) {
+  async updateRepository(appId: number, repositoryId: number, data: { name: string; embedding_service_id?: number }) {
     return this.request(`/internal/apps/${appId}/repositories/${repositoryId}`, {
-      method: 'POST',
+      method: 'PUT',
       body: JSON.stringify(data),
     });
   }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -976,7 +976,7 @@ class ApiService {
     });
   }
 
-  async updateSilo(appId: number, siloId: number, data: { name: string; description?: string; embedding_service_id?: number; fixed_metadata?: boolean; status?: string }) {
+  async updateSilo(appId: number, siloId: number, data: { name: string; description?: string; fixed_metadata?: boolean; status?: string }) {
     return this.request(`/internal/apps/${appId}/silos/${siloId}`, {
       method: 'PUT',
       body: JSON.stringify(data),
@@ -1399,7 +1399,6 @@ class ApiService {
       content_tag?: string;
       content_class?: string;
       content_id?: string;
-      embedding_service_id?: number;
     }
   ) {
     return this.request(`/internal/apps/${appId}/domains/${domainId}`, {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1372,7 +1372,6 @@ class ApiService {
 
   async createDomain(
     appId: number,
-    domainId: number,
     data: {
       name: string;
       description?: string;
@@ -1384,7 +1383,7 @@ class ApiService {
       vector_db_type?: string;
     }
   ) {
-    return this.request(`/internal/apps/${appId}/domains/${domainId}`, {
+    return this.request(`/internal/apps/${appId}/domains/`, {
       method: 'POST',
       body: JSON.stringify(data),
     });
@@ -1401,7 +1400,6 @@ class ApiService {
       content_class?: string;
       content_id?: string;
       embedding_service_id?: number;
-      vector_db_type?: string;
     }
   ) {
     return this.request(`/internal/apps/${appId}/domains/${domainId}`, {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -970,15 +970,15 @@ class ApiService {
   }
 
   async createSilo(appId: number, data: { name: string; description?: string; embedding_service_id?: number; vector_db_type?: string; fixed_metadata?: boolean }) {
-    return this.request(`/internal/apps/${appId}/silos/0`, {
+    return this.request(`/internal/apps/${appId}/silos/`, {
       method: 'POST',
       body: JSON.stringify(data),
     });
   }
 
-  async updateSilo(appId: number, siloId: number, data: { name: string; description?: string; embedding_service_id?: number; vector_db_type?: string; fixed_metadata?: boolean; status?: string }) {
+  async updateSilo(appId: number, siloId: number, data: { name: string; description?: string; embedding_service_id?: number; fixed_metadata?: boolean; status?: string }) {
     return this.request(`/internal/apps/${appId}/silos/${siloId}`, {
-      method: 'POST',
+      method: 'PUT',
       body: JSON.stringify(data),
     });
   }

--- a/tests/unit/services/test_domain_service_vector_db_immutability.py
+++ b/tests/unit/services/test_domain_service_vector_db_immutability.py
@@ -1,0 +1,155 @@
+"""
+Unit tests for the vector_db_type immutability guard in DomainService.
+
+The guard is enforced inside DomainService._update_existing_domain() by
+calling utils.vector_db_immutability.assert_vector_db_type_immutable().
+
+No database is needed — ORM objects and sessions are fully mocked.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+from utils.vector_db_immutability import assert_vector_db_type_immutable
+from utils.error_handlers import ValidationError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_silo_mock(vector_db_type: str | None = "PGVECTOR") -> MagicMock:
+    silo = MagicMock()
+    silo.vector_db_type = vector_db_type
+    silo.embedding_service_id = None
+    return silo
+
+
+def _make_domain_mock(silo_vector_db_type: str | None = "PGVECTOR") -> MagicMock:
+    domain = MagicMock()
+    domain.domain_id = 1
+    domain.app_id = 10
+    domain.name = "Test Domain"
+    domain.description = ""
+    domain.base_url = "https://example.com"
+    domain.content_tag = "body"
+    domain.content_class = ""
+    domain.content_id = ""
+    domain.silo_id = 5
+    domain.silo = _make_silo_mock(silo_vector_db_type)
+    return domain
+
+
+# ---------------------------------------------------------------------------
+# DomainService._update_existing_domain() — guard integration
+# ---------------------------------------------------------------------------
+
+class TestDomainServiceUpdateGuard:
+    """Immutability guard is enforced inside DomainService._update_existing_domain()."""
+
+    def _call_update(
+        self,
+        silo_vector_db_type: str | None,
+        requested_vector_db_type: str | None,
+        embedding_service_id: int | None = None,
+    ):
+        from services.domain_service import DomainService
+        from repositories.domain_repository import DomainRepository
+        from repositories.silo_repository import SiloRepository
+
+        domain = _make_domain_mock(silo_vector_db_type)
+        silo = domain.silo
+
+        mock_db = MagicMock()
+
+        with (
+            patch.object(DomainService, "get_domain", return_value=domain),
+            patch.object(DomainRepository, "update", return_value=domain),
+            patch.object(SiloService := __import__(
+                "services.silo_service", fromlist=["SiloService"]
+            ).SiloService, "get_silo", return_value=silo),
+            patch.object(SiloRepository, "update", return_value=silo),
+        ):
+            return DomainService._update_existing_domain(
+                domain_id=1,
+                domain_data={
+                    "description": "",
+                    "base_url": "https://example.com",
+                    "content_tag": "body",
+                    "content_class": "",
+                    "content_id": "",
+                },
+                embedding_service_id=embedding_service_id,
+                name="Test Domain",
+                base_url="https://example.com",
+                vector_db_type=requested_vector_db_type,
+                db=mock_db,
+            )
+
+    # Rejection cases
+
+    def test_raises_when_changing_pgvector_to_qdrant(self):
+        with pytest.raises(ValidationError) as exc:
+            self._call_update("PGVECTOR", "QDRANT")
+        assert "vector_db_type cannot be changed" in str(exc.value)
+        assert "domain" in str(exc.value)
+
+    def test_raises_when_changing_qdrant_to_pgvector(self):
+        with pytest.raises(ValidationError):
+            self._call_update("QDRANT", "PGVECTOR")
+
+    def test_raises_regardless_of_input_case(self):
+        with pytest.raises(ValidationError):
+            self._call_update("PGVECTOR", "qdrant")
+
+    # Accepted cases
+
+    def test_omitted_vector_db_type_is_accepted(self):
+        """UpdateDomainSchema doesn't send vector_db_type at all — must pass through."""
+        result = self._call_update("PGVECTOR", None)
+        assert result is not None
+
+    def test_null_stored_value_skips_guard(self):
+        """Legacy domain with no stored vector_db_type — guard must not fire."""
+        result = self._call_update(None, "QDRANT")
+        assert result is not None
+
+    def test_update_with_embedding_service_change_accepted(self):
+        """Changing only the embedding service (no vector_db_type) must succeed."""
+        result = self._call_update("PGVECTOR", None, embedding_service_id=42)
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# _update_existing_domain with no silo — guard must not fire
+# ---------------------------------------------------------------------------
+
+class TestDomainServiceUpdateNoSilo:
+    def test_no_silo_skips_guard(self):
+        """Domain without a linked silo — nothing to protect."""
+        from services.domain_service import DomainService
+        from repositories.domain_repository import DomainRepository
+        from services.silo_service import SiloService
+
+        domain = _make_domain_mock()
+        domain.silo_id = None  # no silo
+
+        mock_db = MagicMock()
+
+        with (
+            patch.object(DomainService, "get_domain", return_value=domain),
+            patch.object(DomainRepository, "update", return_value=domain),
+            patch.object(SiloService, "get_silo") as mock_get_silo,
+        ):
+            result = DomainService._update_existing_domain(
+                domain_id=1,
+                domain_data={},
+                embedding_service_id=None,
+                name="Test",
+                base_url="https://example.com",
+                vector_db_type="QDRANT",
+                db=mock_db,
+            )
+            # get_silo should never be called when there is no silo_id
+            mock_get_silo.assert_not_called()
+        assert result is not None

--- a/tests/unit/services/test_embedding_service_immutability.py
+++ b/tests/unit/services/test_embedding_service_immutability.py
@@ -1,0 +1,222 @@
+"""
+Unit tests for the embedding_service_id immutability guard.
+
+Once a silo or domain is created with a specific embedding_service_id, any
+attempt to change it via the update path must raise ValidationError.
+
+No database is needed — ORM objects and sessions are fully mocked.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from utils.vector_db_immutability import assert_embedding_service_immutable
+from utils.error_handlers import ValidationError
+
+
+# ---------------------------------------------------------------------------
+# Standalone unit tests for the guard function
+# ---------------------------------------------------------------------------
+
+class TestAssertEmbeddingServiceImmutable:
+    """Direct tests for the assert_embedding_service_immutable() helper."""
+
+    def test_raises_when_ids_differ(self):
+        with pytest.raises(ValidationError) as exc:
+            assert_embedding_service_immutable(1, 2, "silo")
+        assert "embedding_service_id cannot be changed" in str(exc.value)
+        assert "silo" in str(exc.value)
+
+    def test_raises_for_domain_entity_name(self):
+        with pytest.raises(ValidationError) as exc:
+            assert_embedding_service_immutable(3, 7, "domain")
+        assert "domain" in str(exc.value)
+
+    def test_passes_when_ids_are_equal(self):
+        """Idempotent update — same ID must pass through."""
+        assert_embedding_service_immutable(5, 5, "silo")  # must not raise
+
+    def test_passes_when_existing_is_none(self):
+        """No service set yet — guard must not fire."""
+        assert_embedding_service_immutable(None, 99, "silo")
+
+    def test_passes_when_requested_is_none(self):
+        """Caller not touching the field — pass through."""
+        assert_embedding_service_immutable(1, None, "silo")
+
+    def test_passes_when_both_none(self):
+        assert_embedding_service_immutable(None, None, "silo")
+
+    def test_int_coercion(self):
+        """IDs should be compared as ints even if one arrives as a different numeric type."""
+        assert_embedding_service_immutable(1, 1.0, "silo")  # must not raise
+
+    def test_raises_with_int_coercion_on_different_values(self):
+        with pytest.raises(ValidationError):
+            assert_embedding_service_immutable(1, 2.0, "silo")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_silo(silo_id: int = 1, embedding_service_id: int | None = 5) -> MagicMock:
+    silo = MagicMock()
+    silo.silo_id = silo_id
+    silo.app_id = 10
+    silo.vector_db_type = "PGVECTOR"
+    silo.silo_type = "CUSTOM"
+    silo.embedding_service_id = embedding_service_id
+    silo.metadata_definition_id = None
+    silo.name = "Existing Silo"
+    silo.description = ""
+    silo.status = None
+    silo.fixed_metadata = False
+    return silo
+
+
+def _make_silo_data(
+    silo_id: int = 1,
+    name: str = "Existing Silo",
+    embedding_service_id: int | None = None,
+) -> dict:
+    return {
+        "silo_id": silo_id,
+        "app_id": 10,
+        "name": name,
+        "description": "",
+        "vector_db_type": None,
+        "embedding_service_id": embedding_service_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SiloService integration tests
+# ---------------------------------------------------------------------------
+
+class TestSiloServiceEmbeddingServiceGuard:
+    """Guard is enforced inside SiloService.create_or_update_silo()."""
+
+    def _call(self, existing_silo: MagicMock, silo_data: dict):
+        mock_db = MagicMock()
+        with patch(
+            "services.silo_service.SiloService.get_silo",
+            return_value=existing_silo,
+        ):
+            from services.silo_service import SiloService
+            return SiloService.create_or_update_silo(silo_data, db=mock_db)
+
+    def test_raises_when_changing_embedding_service(self):
+        silo = _make_silo(embedding_service_id=5)
+        data = _make_silo_data(embedding_service_id=99)
+
+        with pytest.raises(ValidationError) as exc:
+            self._call(silo, data)
+
+        assert "embedding_service_id cannot be changed" in str(exc.value)
+
+    def test_raises_when_changing_to_different_service(self):
+        silo = _make_silo(embedding_service_id=10)
+        data = _make_silo_data(embedding_service_id=1)
+
+        with pytest.raises(ValidationError):
+            self._call(silo, data)
+
+    def test_same_embedding_service_is_accepted(self):
+        silo = _make_silo(embedding_service_id=5)
+        data = _make_silo_data(embedding_service_id=5)
+
+        result = self._call(silo, data)
+        assert result is not None
+
+    def test_omitted_embedding_service_is_accepted(self):
+        """UpdateSiloSchema does not send embedding_service_id — must pass through."""
+        silo = _make_silo(embedding_service_id=5)
+        data = _make_silo_data(embedding_service_id=None)
+
+        result = self._call(silo, data)
+        assert result is not None
+
+    def test_no_existing_embedding_service_skips_guard(self):
+        """Legacy silo with no embedding_service_id set — guard must not fire."""
+        silo = _make_silo(embedding_service_id=None)
+        data = _make_silo_data(embedding_service_id=42)
+
+        result = self._call(silo, data)
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# DomainService integration tests
+# ---------------------------------------------------------------------------
+
+class TestDomainServiceEmbeddingServiceGuard:
+    """Guard is enforced inside DomainService._update_existing_domain()."""
+
+    def _call_update(
+        self,
+        existing_embedding_service_id: int | None,
+        requested_embedding_service_id: int | None,
+    ):
+        from services.domain_service import DomainService
+        from repositories.domain_repository import DomainRepository
+        from repositories.silo_repository import SiloRepository
+        from services.silo_service import SiloService as SiloSvc
+
+        domain = MagicMock()
+        domain.domain_id = 1
+        domain.app_id = 10
+        domain.name = "Test Domain"
+        domain.silo_id = 5
+
+        silo = MagicMock()
+        silo.vector_db_type = "PGVECTOR"
+        silo.embedding_service_id = existing_embedding_service_id
+
+        mock_db = MagicMock()
+
+        with (
+            patch.object(DomainService, "get_domain", return_value=domain),
+            patch.object(DomainRepository, "update", return_value=domain),
+            patch.object(SiloSvc, "get_silo", return_value=silo),
+            patch.object(SiloRepository, "update", return_value=silo),
+        ):
+            return DomainService._update_existing_domain(
+                domain_id=1,
+                domain_data={
+                    "description": "",
+                    "base_url": "https://example.com",
+                    "content_tag": "body",
+                    "content_class": "",
+                    "content_id": "",
+                },
+                embedding_service_id=requested_embedding_service_id,
+                name="Test Domain",
+                base_url="https://example.com",
+                vector_db_type=None,
+                db=mock_db,
+            )
+
+    def test_raises_when_changing_embedding_service(self):
+        with pytest.raises(ValidationError) as exc:
+            self._call_update(5, 99)
+        assert "embedding_service_id cannot be changed" in str(exc.value)
+        assert "domain" in str(exc.value)
+
+    def test_raises_changing_to_another_service(self):
+        with pytest.raises(ValidationError):
+            self._call_update(10, 1)
+
+    def test_same_embedding_service_is_accepted(self):
+        result = self._call_update(5, 5)
+        assert result is not None
+
+    def test_omitted_embedding_service_is_accepted(self):
+        """Update path sends None for embedding_service_id — must pass through."""
+        result = self._call_update(5, None)
+        assert result is not None
+
+    def test_no_existing_embedding_service_skips_guard(self):
+        """Legacy domain with no embedding_service_id stored — guard must not fire."""
+        result = self._call_update(None, 42)
+        assert result is not None

--- a/tests/unit/services/test_repository_service_vector_db_immutability.py
+++ b/tests/unit/services/test_repository_service_vector_db_immutability.py
@@ -1,0 +1,159 @@
+"""
+Unit tests for the vector_db_type immutability guard in RepositoryService.
+
+Mirrors the pattern established for silos (test_silo_service_vector_db_immutability.py).
+
+The guard lives in two places:
+  1. utils/vector_db_immutability.py  — shared helper (unit-tested directly here)
+  2. RepositoryService.update_repository() — integration point (tested via the service)
+
+No database is needed — ORM objects and sessions are fully mocked.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from utils.vector_db_immutability import assert_vector_db_type_immutable
+from utils.error_handlers import ValidationError
+
+
+# ---------------------------------------------------------------------------
+# Direct tests for the shared guard utility
+# ---------------------------------------------------------------------------
+
+class TestAssertVectorDbTypeImmutable:
+    """Unit tests for utils/vector_db_immutability.assert_vector_db_type_immutable."""
+
+    # Rejection cases
+
+    def test_raises_when_changing_pgvector_to_qdrant(self):
+        with pytest.raises(ValidationError) as exc:
+            assert_vector_db_type_immutable("PGVECTOR", "QDRANT", "repository")
+        assert "vector_db_type cannot be changed" in str(exc.value)
+        assert "repository" in str(exc.value)
+
+    def test_raises_when_changing_qdrant_to_pgvector(self):
+        with pytest.raises(ValidationError):
+            assert_vector_db_type_immutable("QDRANT", "PGVECTOR", "repository")
+
+    def test_raises_regardless_of_input_case(self):
+        """Comparison is case-insensitive — lowercase requested value is still rejected."""
+        with pytest.raises(ValidationError):
+            assert_vector_db_type_immutable("PGVECTOR", "qdrant", "repository")
+
+    def test_raises_regardless_of_stored_case(self):
+        """Stored value normalised as well."""
+        with pytest.raises(ValidationError):
+            assert_vector_db_type_immutable("pgvector", "QDRANT", "repository")
+
+    # Accepted cases
+
+    def test_same_value_is_accepted(self):
+        assert_vector_db_type_immutable("PGVECTOR", "PGVECTOR", "repository")  # no raise
+
+    def test_same_value_different_case_is_accepted(self):
+        assert_vector_db_type_immutable("PGVECTOR", "pgvector", "repository")  # no raise
+
+    def test_none_requested_is_accepted(self):
+        """Caller omitted the field — nothing to enforce."""
+        assert_vector_db_type_immutable("PGVECTOR", None, "repository")  # no raise
+
+    def test_none_existing_is_accepted(self):
+        """Legacy row with no stored value — guard stays silent."""
+        assert_vector_db_type_immutable(None, "QDRANT", "repository")  # no raise
+
+    def test_both_none_is_accepted(self):
+        assert_vector_db_type_immutable(None, None, "repository")  # no raise
+
+    def test_default_entity_name_used_in_message(self):
+        """Default entity name is 'resource' when not specified."""
+        with pytest.raises(ValidationError) as exc:
+            assert_vector_db_type_immutable("PGVECTOR", "QDRANT")
+        assert "resource" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# RepositoryService.update_repository() — guard integration
+# ---------------------------------------------------------------------------
+
+def _make_silo_mock(vector_db_type: str | None = "PGVECTOR") -> MagicMock:
+    silo = MagicMock()
+    silo.vector_db_type = vector_db_type
+    silo.embedding_service_id = None
+    return silo
+
+
+def _make_repository_mock(vector_db_type: str | None = "PGVECTOR") -> MagicMock:
+    repo = MagicMock()
+    repo.repository_id = 1
+    repo.app_id = 10
+    repo.silo = _make_silo_mock(vector_db_type)
+    return repo
+
+
+class TestRepositoryServiceUpdateGuard:
+    """Guard is enforced inside RepositoryService.update_repository()."""
+
+    def _call_update(self, repository: MagicMock, vector_db_type: str | None):
+        from services.repository_service import RepositoryService
+        from repositories.repository_repository import RepositoryRepository
+
+        mock_db = MagicMock()
+
+        with patch.object(RepositoryRepository, "update", return_value=repository):
+            return RepositoryService.update_repository(
+                repository,
+                embedding_service_id=None,
+                vector_db_type=vector_db_type,
+                db=mock_db,
+            )
+
+    # Rejection cases
+
+    def test_raises_when_changing_pgvector_to_qdrant(self):
+        repo = _make_repository_mock(vector_db_type="PGVECTOR")
+        with pytest.raises(ValidationError) as exc:
+            self._call_update(repo, "QDRANT")
+        assert "vector_db_type cannot be changed" in str(exc.value)
+
+    def test_raises_when_changing_qdrant_to_pgvector(self):
+        repo = _make_repository_mock(vector_db_type="QDRANT")
+        with pytest.raises(ValidationError):
+            self._call_update(repo, "PGVECTOR")
+
+    def test_raises_regardless_of_input_case(self):
+        repo = _make_repository_mock(vector_db_type="PGVECTOR")
+        with pytest.raises(ValidationError):
+            self._call_update(repo, "qdrant")
+
+    # Accepted cases
+
+    def test_same_value_is_accepted(self):
+        repo = _make_repository_mock(vector_db_type="PGVECTOR")
+        result = self._call_update(repo, "PGVECTOR")
+        assert result is not None
+
+    def test_omitted_vector_db_type_is_accepted(self):
+        """None means the caller did not supply the field — must pass through."""
+        repo = _make_repository_mock(vector_db_type="PGVECTOR")
+        result = self._call_update(repo, None)
+        assert result is not None
+
+    def test_null_stored_value_skips_guard(self):
+        """Legacy repository with no stored vector_db_type — guard must not fire."""
+        repo = _make_repository_mock(vector_db_type=None)
+        result = self._call_update(repo, "QDRANT")
+        assert result is not None
+
+    def test_no_silo_skips_guard(self):
+        """Repository without a silo — nothing to protect."""
+        repo = _make_repository_mock()
+        repo.silo = None  # detach silo
+
+        from services.repository_service import RepositoryService
+        from repositories.repository_repository import RepositoryRepository
+
+        mock_db = MagicMock()
+        with patch.object(RepositoryRepository, "update", return_value=repo):
+            result = RepositoryService.update_repository(repo, vector_db_type="QDRANT", db=mock_db)
+        assert result is not None

--- a/tests/unit/services/test_silo_service_vector_db_immutability.py
+++ b/tests/unit/services/test_silo_service_vector_db_immutability.py
@@ -1,0 +1,184 @@
+"""
+Unit tests for the vector_db_type immutability guard in SiloService.
+
+FR-1 (issue #142): Once a silo is created with a specific vector_db_type,
+any attempt to change it via create_or_update_silo() must raise ValidationError.
+
+SiloRepository is mocked so no database is needed.
+session.add / session.commit are also replaced with no-ops.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from services.silo_service import SiloService
+from utils.error_handlers import ValidationError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_silo(silo_id: int = 1, vector_db_type: str = "PGVECTOR") -> MagicMock:
+    """Return a mock Silo ORM object with the given id and vector_db_type."""
+    silo = MagicMock()
+    silo.silo_id = silo_id
+    silo.app_id = 10
+    silo.vector_db_type = vector_db_type
+    silo.silo_type = "CUSTOM"
+    silo.metadata_definition_id = None
+    silo.embedding_service_id = None
+    silo.name = "Existing Silo"
+    silo.description = ""
+    silo.status = None
+    silo.fixed_metadata = False
+    return silo
+
+
+def _make_silo_data(
+    silo_id: int = 1,
+    name: str = "Existing Silo",
+    vector_db_type: str | None = None,
+) -> dict:
+    """Build a minimal silo_data dict as callers pass to create_or_update_silo()."""
+    return {
+        "silo_id": silo_id,
+        "app_id": 10,
+        "name": name,
+        "description": "",
+        "vector_db_type": vector_db_type,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Guard: changing vector_db_type on an existing silo raises ValidationError
+# ---------------------------------------------------------------------------
+
+class TestVectorDbTypeImmutabilityGuard:
+    """FR-1: Immutability guard in SiloService.create_or_update_silo()."""
+
+    def _call(self, existing_silo: MagicMock, silo_data: dict):
+        """
+        Invoke create_or_update_silo() with the repository mocked to return
+        existing_silo and with session side-effects replaced by no-ops.
+        """
+        mock_db = MagicMock()
+        mock_db.__bool__ = lambda self: True  # truthy so `db if db is not None` takes this branch
+
+        with patch(
+            "services.silo_service.SiloService.get_silo",
+            return_value=existing_silo,
+        ):
+            return SiloService.create_or_update_silo(silo_data, db=mock_db)
+
+    # ------------------------------------------------------------------
+    # Rejection cases — different value supplied
+    # ------------------------------------------------------------------
+
+    def test_raises_when_changing_pgvector_to_qdrant(self):
+        silo = _make_silo(vector_db_type="PGVECTOR")
+        data = _make_silo_data(vector_db_type="QDRANT")
+
+        with pytest.raises(ValidationError) as exc:
+            self._call(silo, data)
+
+        assert "vector_db_type cannot be changed" in str(exc.value)
+
+    def test_raises_when_changing_qdrant_to_pgvector(self):
+        silo = _make_silo(vector_db_type="QDRANT")
+        data = _make_silo_data(vector_db_type="PGVECTOR")
+
+        with pytest.raises(ValidationError) as exc:
+            self._call(silo, data)
+
+        assert "vector_db_type cannot be changed" in str(exc.value)
+
+    def test_raises_regardless_of_input_case(self):
+        """Guard must normalise input — lowercase 'qdrant' should also be rejected."""
+        silo = _make_silo(vector_db_type="PGVECTOR")
+        data = _make_silo_data(vector_db_type="qdrant")
+
+        with pytest.raises(ValidationError):
+            self._call(silo, data)
+
+    # ------------------------------------------------------------------
+    # Accepted cases — same value or omitted
+    # ------------------------------------------------------------------
+
+    def test_same_value_is_accepted(self):
+        """Sending the same vector_db_type as already stored must succeed silently."""
+        silo = _make_silo(vector_db_type="PGVECTOR")
+        data = _make_silo_data(vector_db_type="PGVECTOR")
+
+        # Should not raise — verifies idempotent update is allowed
+        result = self._call(silo, data)
+        assert result is not None
+
+    def test_same_value_lowercase_is_accepted(self):
+        """Same value in lowercase (normalised to uppercase) must succeed."""
+        silo = _make_silo(vector_db_type="PGVECTOR")
+        data = _make_silo_data(vector_db_type="pgvector")
+
+        result = self._call(silo, data)
+        assert result is not None
+
+    def test_omitted_vector_db_type_is_accepted(self):
+        """Omitting vector_db_type entirely (UpdateSiloSchema flow) must succeed."""
+        silo = _make_silo(vector_db_type="PGVECTOR")
+        data = _make_silo_data(vector_db_type=None)
+
+        result = self._call(silo, data)
+        assert result is not None
+
+    # ------------------------------------------------------------------
+    # Edge case — existing silo has NULL vector_db_type
+    # ------------------------------------------------------------------
+
+    def test_null_stored_value_skips_guard(self):
+        """
+        If an existing silo has no vector_db_type stored (legacy row),
+        the guard must not fire — there is no type to protect.
+        """
+        silo = _make_silo(vector_db_type=None)
+        # Even though we supply a different type, the guard should stay silent
+        # because there is no existing backend to protect.
+        data = _make_silo_data(vector_db_type="QDRANT")
+
+        result = self._call(silo, data)
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Creation flow — guard must not interfere
+# ---------------------------------------------------------------------------
+
+class TestCreationFlowUnaffected:
+    """Creating a new silo (silo_id absent/0) must be completely unaffected by the guard."""
+
+    def test_create_with_pgvector_succeeds(self):
+        mock_db = MagicMock()
+        data = {
+            "app_id": 10,
+            "name": "Brand New Silo",
+            "vector_db_type": "PGVECTOR",
+        }
+
+        with patch("services.silo_service.SiloService.get_silo") as mock_get:
+            # get_silo should never be called for new silos
+            result = SiloService.create_or_update_silo(data, db=mock_db)
+            mock_get.assert_not_called()
+
+        assert result is not None
+
+    def test_create_with_qdrant_succeeds(self):
+        mock_db = MagicMock()
+        data = {
+            "app_id": 10,
+            "name": "Brand New Silo",
+            "vector_db_type": "QDRANT",
+        }
+
+        with patch("services.silo_service.SiloService.get_silo"):
+            result = SiloService.create_or_update_silo(data, db=mock_db)
+
+        assert result is not None


### PR DESCRIPTION
Prevents the vector_db_type field of a silo, repository or domain from being changed after creation. This fixes a critical data integrity bug where switching the vector DB backend on an existing silo, repository or domain could silently corrupt or orphan data.

Key changes:

- Splits silo, repository and domain create/update schemas and endpoints (RESTful POST/PUT)
- Backend guard enforces immutability at the service layer
- Frontend disables and omits vector_db_type on edit
- Public/internal API contracts aligned