### PR TITLE
feat(backend): add curated demo workspace import JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ docker-compose up -d
 #    - API Docs: http://localhost:8000/docs/internal
 ```
 
+### Try the Demo App
+
+A pre-built demo workspace is available at `scripts/demo-app.json`. Import it to get a fully configured workspace with 8 agents, RAG, structured output, agent composition, OCR, and more — no manual setup required.
+
+From the UI: **Apps → Import App → select `demo-app.json` → provide your API keys → Import**.
+
+See [App Export and Import — Demo App](docs/guides/app-export-import.md#demo-app) for details.
+
 ### Docker Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ docker-compose up -d
 
 ### Try the Demo App
 
-A pre-built demo workspace is available at `scripts/demo-app.json`. Import it to get a fully configured workspace with 8 agents, RAG, structured output, agent composition, OCR, and more — no manual setup required.
+A pre-built demo workspace is available at `scripts/demo-app.json`. Import it to get a fully configured workspace with 6 agents, RAG, structured output, MCP integration, OCR, and more — no manual setup required.
 
 From the UI: **Apps → Import App → select `demo-app.json` → provide your API keys → Import**.
 

--- a/docs/guides/app-export-import.md
+++ b/docs/guides/app-export-import.md
@@ -162,6 +162,49 @@ api_keys_json={"GPT-4 Service":"sk-..."}
 - MCP configs are sanitized to remove auth tokens.
 - Vectors, file contents, and conversations are not exported.
 
+## Demo App
+
+A curated demo workspace JSON is available at `scripts/demo-app.json`. It can be imported to instantly set up a fully configured demo workspace showcasing all major platform features.
+
+### What's included
+
+| Entity Type | Count | Highlights |
+|-------------|-------|------------|
+| AI Services | 4 | OpenAI, Anthropic, Ollama (local), Azure OpenAI |
+| Embedding Services | 2 | OpenAI, Ollama (local) |
+| Output Parsers | 2 | Structured Summary, Q&A with Confidence |
+| MCP Configs | 1 | External tool server (placeholder) |
+| Silos | 1 | PGVector-backed knowledge base |
+| Repositories | 1 | File-based document store (empty — upload files after import) |
+| Domains | 1 | Web scraping source (placeholder URL) |
+| Agents | 8 | FAQ, RAG KB, conversational (memory), structured output, tool sub-agent, orchestrator, OCR (dual-LLM), Azure |
+
+### Import the demo
+
+Use the import endpoint or the UI import dialog:
+
+```http
+POST /internal/apps/import?conflict_mode=rename
+Cookie: session=...
+Content-Type: multipart/form-data
+
+file=@scripts/demo-app.json
+api_keys_json={"Demo OpenAI GPT-5.4":"sk-...","Demo Anthropic Claude":"sk-ant-..."}
+```
+
+Or from the frontend: **Apps → Import App → select `demo-app.json` → provide API keys → Import**.
+
+### Post-import manual steps
+
+Some features are not supported by the import schema and must be configured manually after import:
+
+| Feature | Action |
+|---------|--------|
+| **Skills** | Create skills via the UI and link them to agents |
+| **`is_tool` flag** | Edit the "Demo Intent Classifier (Tool)" agent and enable `is_tool` |
+| **MCP Server** | Create an MCP server and attach the desired agents |
+| **API keys** | Supply real provider API keys (via `api_keys_json` during import or edit each service after import) |
+
 ## See Also
 
 - [Internal API](../api/internal-api.md)

--- a/docs/guides/app-export-import.md
+++ b/docs/guides/app-export-import.md
@@ -170,14 +170,14 @@ A curated demo workspace JSON is available at `scripts/demo-app.json`. It can be
 
 | Entity Type | Count | Highlights |
 |-------------|-------|------------|
-| AI Services | 4 | OpenAI, Anthropic, Ollama (local), Azure OpenAI |
+| AI Services | 2 | OpenAI, Ollama (local) |
 | Embedding Services | 2 | OpenAI, Ollama (local) |
 | Output Parsers | 2 | Structured Summary, Q&A with Confidence |
-| MCP Configs | 1 | External tool server (placeholder) |
+| MCP Configs | 1 | AWS Docs Search (placeholder) |
 | Silos | 1 | PGVector-backed knowledge base |
 | Repositories | 1 | File-based document store (empty — upload files after import) |
 | Domains | 1 | Web scraping source (placeholder URL) |
-| Agents | 8 | FAQ, RAG KB, conversational (memory), structured output, tool sub-agent, orchestrator, OCR (dual-LLM), Azure |
+| Agents | 6 | RAG KB, conversational (memory), structured output, tool sub-agent, MCP integration, OCR (dual-LLM) |
 
 ### Import the demo
 
@@ -189,7 +189,7 @@ Cookie: session=...
 Content-Type: multipart/form-data
 
 file=@scripts/demo-app.json
-api_keys_json={"Demo OpenAI GPT-5.4":"sk-...","Demo Anthropic Claude":"sk-ant-..."}
+api_keys_json={"Demo OpenAI GPT-5.4":"sk-..."}
 ```
 
 Or from the frontend: **Apps → Import App → select `demo-app.json` → provide API keys → Import**.

--- a/scripts/demo-app.json
+++ b/scripts/demo-app.json
@@ -1,0 +1,302 @@
+{
+  "metadata": {
+    "export_version": "1.0.0",
+    "export_date": "2026-04-20T00:00:00Z",
+    "exported_by": null,
+    "source_app_id": null
+  },
+  "app": {
+    "name": "MattinAI Demo App",
+    "agent_rate_limit": null,
+    "enable_langsmith": false
+  },
+  "ai_services": [
+    {
+      "name": "Demo OpenAI GPT-5.4",
+      "api_key": null,
+      "provider": "OpenAI",
+      "model_name": "gpt-5.4",
+      "endpoint": "https://api.openai.com/v1",
+      "description": "Primary LLM for most demo agents",
+      "api_version": null
+    },
+    {
+      "name": "Demo Ollama Local",
+      "api_key": null,
+      "provider": "CUSTOM",
+      "model_name": "llama3.2",
+      "endpoint": "http://localhost:11434",
+      "description": "Local/self-hosted model showcase (Ollama)",
+      "api_version": null
+    }
+  ],
+  "embedding_services": [
+    {
+      "name": "text-embedding-3-small",
+      "api_key": null,
+      "provider": "OpenAI",
+      "model_name": "text-embedding-3-small",
+      "endpoint": "https://api.openai.com/v1",
+      "description": "Vector embeddings for the demo Silo",
+      "api_version": null
+    },
+    {
+      "name": "nomic-embed-text",
+      "api_key": null,
+      "provider": "CUSTOM",
+      "model_name": "nomic-embed-text",
+      "endpoint": "http://localhost:11434",
+      "description": "Local embedding showcase",
+      "api_version": null
+    }
+  ],
+  "output_parsers": [
+    {
+      "name": "Structured_Summary",
+      "description": "Extracts structured summaries from text",
+      "fields": [
+        {
+          "name": "title",
+          "type": "str",
+          "description": "Title of the summarized content",
+          "parser_name": null,
+          "list_item_type": null,
+          "list_item_parser_name": null
+        },
+        {
+          "name": "summary",
+          "type": "str",
+          "description": "Concise summary of the content",
+          "parser_name": null,
+          "list_item_type": null,
+          "list_item_parser_name": null
+        },
+        {
+          "name": "key_points",
+          "type": "list",
+          "description": "Key points extracted from the content",
+          "parser_name": null,
+          "list_item_type": "str",
+          "list_item_parser_name": null
+        },
+        {
+          "name": "sentiment",
+          "type": "str",
+          "description": "Overall sentiment of the content",
+          "parser_name": null,
+          "list_item_type": null,
+          "list_item_parser_name": null
+        },
+        {
+          "name": "word_count",
+          "type": "int",
+          "description": "Approximate word count of the original content",
+          "parser_name": null,
+          "list_item_type": null,
+          "list_item_parser_name": null
+        }
+      ]
+    },
+    {
+      "name": "Q&A_with_Confidence",
+      "description": "Confidence-scored answers with source attribution",
+      "fields": [
+        {
+          "name": "question",
+          "type": "str",
+          "description": "The user's question",
+          "parser_name": null,
+          "list_item_type": null,
+          "list_item_parser_name": null
+        },
+        {
+          "name": "answer",
+          "type": "str",
+          "description": "The generated answer",
+          "parser_name": null,
+          "list_item_type": null,
+          "list_item_parser_name": null
+        },
+        {
+          "name": "confidence",
+          "type": "float",
+          "description": "Confidence score between 0 and 1",
+          "parser_name": null,
+          "list_item_type": null,
+          "list_item_parser_name": null
+        },
+        {
+          "name": "sources",
+          "type": "list",
+          "description": "Source references supporting the answer",
+          "parser_name": null,
+          "list_item_type": "str",
+          "list_item_parser_name": null
+        },
+        {
+          "name": "caveats",
+          "type": "str",
+          "description": "Caveats or limitations of the answer",
+          "parser_name": null,
+          "list_item_type": null,
+          "list_item_parser_name": null
+        }
+      ]
+    }
+  ],
+  "mcp_configs": [
+     {
+        "name": "AWS Doc Search MCP",
+        "description": "Example external MCP server connection — URL is a placeholder",
+        "config": "{\"aws-knowledge-mcp-server\": {\"url\": \"https://knowledge-mcp.global.api.aws\", \"transport\": \"http\"}}"
+    }
+  ],
+  "silos": [
+    {
+      "name": "Demo Knowledge Base",
+      "type": "CUSTOM",
+      "vector_db_type": "PGVECTOR",
+      "embedding_service_name": "text-embedding-3-small",
+      "metadata_definition_name": null,
+      "fixed_metadata": false,
+      "description": "Central vector store for all RAG demo agents"
+    }
+  ],
+  "repositories": [
+    {
+      "name": "Demo Documentation Repository",
+      "type": "files",
+      "silo_name": "Demo Knowledge Base"
+    }
+  ],
+  "domains": [
+    {
+      "name": "MattinAI Docs Website",
+      "description": "Web scraping source for documentation — URL is a placeholder",
+      "base_url": "https://github.com/lksnext-ai-lab/ai-core-tools",
+      "content_tag": "article",
+      "content_class": "main-content",
+      "content_id": null,
+      "silo_name": "Demo Knowledge Base",
+      "urls": []
+    }
+  ],
+  "agents": [
+    {
+      "name": "Demo Knowledge Base Agent",
+      "description": "RAG retrieval agent — uses vector silo for grounded answers",
+      "system_prompt": "You are a knowledge base assistant. Use only the provided context documents to answer questions. If the answer is not in the context, say so explicitly. Always cite the source document name when referencing information.",
+      "prompt_template": "{question}",
+      "service_name": "Demo OpenAI GPT-5.4",
+      "silo_name": "Demo Knowledge Base",
+      "output_parser_name": null,
+      "agent_tool_refs": [],
+      "agent_mcp_refs": [],
+      "has_memory": false,
+      "memory_max_messages": 20,
+      "memory_max_tokens": null,
+      "memory_summarize_threshold": 10,
+      "temperature": 0.3,
+      "vision_service_name": null,
+      "vision_system_prompt": null,
+      "text_system_prompt": null
+    },
+    {
+      "name": "Demo Conversational Assistant",
+      "description": "Memory-enabled conversational agent — demonstrates multi-turn context retention",
+      "system_prompt": "You are a helpful conversational assistant. Maintain context across the conversation and refer back to earlier messages when relevant. Be friendly and adaptive to the user's communication style.",
+      "prompt_template": "{question}",
+      "service_name": "Demo OpenAI GPT-5.4",
+      "silo_name": null,
+      "output_parser_name": null,
+      "agent_tool_refs": [],
+      "agent_mcp_refs": [],
+      "has_memory": true,
+      "memory_max_messages": 20,
+      "memory_max_tokens": 4000,
+      "memory_summarize_threshold": 10,
+      "temperature": 0.7,
+      "vision_service_name": null,
+      "vision_system_prompt": null,
+      "text_system_prompt": null
+    },
+    {
+      "name": "Demo Document Summarizer (Structured)",
+      "description": "Structured output agent — demonstrates OutputParser for JSON responses",
+      "system_prompt": "You are a document analysis agent. Given a document or passage, extract a structured summary following the output schema precisely. Be thorough but concise.",
+      "prompt_template": "{question}",
+      "service_name": "Demo OpenAI GPT-5.4",
+      "silo_name": "Demo Knowledge Base",
+      "output_parser_name": "Structured Summary",
+      "agent_tool_refs": [],
+      "agent_mcp_refs": [],
+      "has_memory": false,
+      "memory_max_messages": 20,
+      "memory_max_tokens": null,
+      "memory_summarize_threshold": 10,
+      "temperature": 0.2,
+      "vision_service_name": null,
+      "vision_system_prompt": null,
+      "text_system_prompt": null
+    },
+    {
+      "name": "Demo Intent Classifier (Tool)",
+      "description": "Tool sub-agent — used by the orchestrator via agent_tool_refs. Set is_tool=true after import.",
+      "system_prompt": "You are an intent classifier. Given a user message, classify its intent into one of: question, request, complaint, feedback, greeting, or other. Return a structured answer with your confidence score and reasoning.",
+      "prompt_template": "{question}",
+      "service_name": "Demo OpenAI GPT-5.4",
+      "silo_name": null,
+      "output_parser_name": "Q&A with Confidence",
+      "agent_tool_refs": [],
+      "agent_mcp_refs": [],
+      "has_memory": false,
+      "memory_max_messages": 20,
+      "memory_max_tokens": null,
+      "memory_summarize_threshold": 10,
+      "temperature": 0.1,
+      "vision_service_name": null,
+      "vision_system_prompt": null,
+      "text_system_prompt": null
+    },
+    {
+      "name": "AWS Doc Search Agent (MCP)",
+      "description": "AWS Doc Search agent — demonstrates external MCP tool usage. The MCP server is expected to handle the search logic and return relevant document excerpts.",
+      "system_prompt": "You are an AWS Doc Search agent. When given a query, use the connected AWS Docs Search MCP to retrieve relevant document excerpts. Use the retrieved information to answer the user's question. Always cite the source document name when referencing information.",
+      "prompt_template": "{question}",
+      "service_name": "Demo OpenAI GPT-5.4",
+      "output_parser_name": null,
+      "agent_mcp_refs": [
+        {
+          "mcp_name": "AWS Doc Search MCP"
+        }
+      ],
+      "has_memory": true,
+      "memory_max_messages": 30,
+      "memory_max_tokens": 6000,
+      "memory_summarize_threshold": 15,
+      "temperature": 0.5,
+      "vision_service_name": null,
+      "vision_system_prompt": null,
+      "text_system_prompt": null
+    },
+    {
+      "name": "Demo OCR Document Processor",
+      "description": "OCR agent — demonstrates dual-LLM pattern (vision + text) with structured output",
+      "system_prompt": null,
+      "prompt_template": null,
+      "service_name": "Demo OpenAI GPT-5.4",
+      "silo_name": null,
+      "output_parser_name": "Structured Summary",
+      "agent_tool_refs": [],
+      "agent_mcp_refs": [],
+      "has_memory": false,
+      "memory_max_messages": 20,
+      "memory_max_tokens": null,
+      "memory_summarize_threshold": 10,
+      "temperature": 0.2,
+      "vision_service_name": "Demo OpenAI GPT-5.4",
+      "vision_system_prompt": "Extract all visible text from each scanned page. Include headers, footers, captions, and table content. Preserve the reading order and paragraph structure.",
+      "text_system_prompt": "You are an OCR post-processor. Take the raw extracted text and structure it according to the output schema. Clean up OCR artifacts and normalize formatting."
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adds a curated demo workspace JSON file (`scripts/demo-app.json`) that can be imported via the existing `POST /internal/apps/import` endpoint to instantly set up a fully configured MattinAI workspace. This provides a canonical demo environment for onboarding, evaluations, and showcases — eliminating the need to manually create entities one by one.

The demo workspace covers all major importable entity types: 2 AI services (OpenAI, Ollama), 2 embedding services, 2 output parsers, 1 MCP config (AWS Docs Search), 1 silo (PGVector), 1 repository, 1 domain, and 6 agents showcasing RAG, conversational memory, structured output, tool sub-agent, MCP integration, and OCR dual-LLM patterns.

Documentation has been updated in the README (Quick Start section) and in `docs/guides/app-export-import.md` (new "Demo App" section) to describe the demo, how to import it, and post-import manual steps.

**Plan**: demo-showcase-app
**Steps**: 001 + docs
**FR**: FR-1, FR-2, FR-3, FR-4, FR-5, FR-6, FR-7

## Related Issue(s)

No existing issue — this originated from a feature plan (`plans/demo-showcase-app/spec.md`) to address the onboarding and demo gap identified during project review.

## Type of Change

* [ ] Bug fix (a change that does not break existing functionality and fixes an issue)
* [x] Feature (a change that does not break existing functionality and adds new functionality)
* [x] Documentation (updates or adds documentation only)
* [ ] Refactor (code change that neither fixes a bug nor adds a feature)
* [ ] Performance improvement
* [ ] Test (adding or updating tests)
* [ ] Build or infrastructure (changes to tooling, deployment scripts, CI/CD, etc.)

## Checklist

* [ ] All commits in this pull request are signed using GPG, as required by our commit signing policy (see `.github/instructions/.gh-commit.instructions.md`).
* [x] I have read the contributing guidelines and my change adheres to the coding standards of this project (see `docs/README.md#contributing`).
* [ ] I have added tests that prove my fix or feature works, or confirm that tests are not needed for this change.
* [x] I have run all existing tests and they all pass locally.
* [x] I have updated any relevant documentation, configuration files, or environment examples as needed.
* [x] I have considered backwards compatibility and ensured that my change does not break existing functionality.
* [ ] For UI changes, I have included relevant screenshots or screencasts.

## Additional Notes

- **Post-import manual steps**: The current import schema does not support Skills, MCPServer, `is_tool` flag, or Agent-Skill associations. These must be configured manually after import. This is documented in the guide and in the plan spec. A future plan could extend the import schema to support these.
- **API keys**: All `api_key` fields in the JSON are `null`. Users must supply real provider keys during import (via `api_keys_json`) or configure them afterwards.
- **No backend code changes**: This PR adds only a static JSON file and documentation. No migrations, no service changes, no new endpoints.
- **Output parser name references**: Parser names in the JSON use underscores (`Structured_Summary`, `Q&A_with_Confidence`). Agent `output_parser_name` references must match exactly.
