### PR TITLE
fix(backend): filter PDF image artifacts from silo indexing pipeline

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -149,6 +149,7 @@ pydantic_core==2.33.2
 PyJWT==2.10.1
 PyNaCl==1.5.0
 pyparsing==3.2.3
+pymupdf>=1.23.0
 pypdf==5.9.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1

--- a/backend/services/silo_service.py
+++ b/backend/services/silo_service.py
@@ -63,6 +63,34 @@ _GARBAGE_PATTERNS = [
 # Used to distinguish OCR artifact lines from lines with actual text content.
 _WORD_RE = re.compile(r'[^\W\d_]{3,}', re.UNICODE)
 
+# Matches runs of single Unicode letters each separated by exactly one space:
+# e.g. "V I T O R I A" or "p a s a d o". Used to detect and collapse
+# spaced-out OCR output back into normal words.
+_SPACED_WORD_RE = re.compile(r'[^\W\d_](?: [^\W\d_])+', re.UNICODE)
+
+
+def _collapse_spaced_letters(line: str) -> str:
+    """Collapse spaced-out single-letter OCR output into normal words.
+
+    When > 60 % of the whitespace-delimited tokens on a line are single
+    Unicode letters, the line is treated as spaced-out text (e.g. from
+    low-resolution OCR) and consecutive single-letter runs are joined::
+
+        "V I T O R I A .  E l  p a s a d o" → "VITORIA . El pasado"
+
+    Lines that do not meet the threshold are returned unchanged.
+    """
+    tokens = line.split()
+    if len(tokens) < 3:
+        return line
+    single_alpha = sum(1 for t in tokens if len(t) == 1 and t.isalpha())
+    if single_alpha / len(tokens) < 0.6:
+        return line
+    collapsed = _SPACED_WORD_RE.sub(lambda m: m.group(0).replace(' ', ''), line)
+    # Normalize multiple spaces left after joining (e.g. between sections)
+    collapsed = re.sub(r' {2,}', ' ', collapsed)
+    return collapsed.strip()
+
 
 def _clean_chunk_text(text: str) -> str:
     """Remove known PDF extraction artifacts from *text*.
@@ -81,12 +109,16 @@ def _clean_chunk_text(text: str) -> str:
     for pattern in _GARBAGE_PATTERNS:
         text = pattern.sub(' ', text)
 
-    # 2. Line-level: drop lines that are clearly artifact/garbage
+    # 2. Per-line: collapse spaced-out single-letter OCR text BEFORE filtering
+    #    so that "V I T O R I A" → "VITORIA" survives Rule B below.
+    lines = text.split('\n')
+    lines = [_collapse_spaced_letters(line) for line in lines]
+
+    # 3. Line-level: drop lines that are clearly artifact/garbage
     #    Rule A — very short lines with minimal alpha (@@h?, @@g, ??, @@, …)
     #    Rule B — short-medium lines with no real word ≥ 3 letters; catches OCR
     #             image noise such as "r . * * * ! ? *", "^ i * * : * ;",
     #             "-'Jl", "i i ¥", etc.
-    lines = text.split('\n')
     clean_lines = []
     for line in lines:
         s = line.strip()

--- a/backend/services/silo_service.py
+++ b/backend/services/silo_service.py
@@ -1,5 +1,6 @@
 from typing import Optional, List, Dict, Any
 import os
+import re
 from models.media import Media
 from models.silo import Silo
 from models.resource import Resource
@@ -46,6 +47,77 @@ def _get_vector_store(silo: Optional[Silo] = None, vector_db_type: Optional[str]
 
     resolved_type = _resolve_vector_db_type(silo, vector_db_type)
     return VectorStoreFactory.get_vector_store(db_obj, resolved_type)
+
+
+# Patterns produced by PDF loaders when they encounter fonts with non-standard
+# encodings (e.g. Type3 fonts where codepoint 64 maps to a drawn glyph):
+#   PyPDFLoader  → outputs raw decimal codepoints:  "64/64/64/64/..."
+#   PyMuPDFLoader → decodes codepoint 64 as ASCII @: "@@@@@@@@@..."
+# Both represent the same underlying artifact and must be stripped.
+_GARBAGE_PATTERNS = [
+    re.compile(r'(\d+/){8,}'),  # raw decimal codepoint sequences
+    re.compile(r'@{5,}'),       # decoded Type3 font artifacts
+]
+
+# Detects real words: 3+ consecutive Unicode letters (isalpha-equivalent via \w without digits/_)
+# Used to distinguish OCR artifact lines from lines with actual text content.
+_WORD_RE = re.compile(r'[^\W\d_]{3,}', re.UNICODE)
+
+
+def _clean_chunk_text(text: str) -> str:
+    """Remove known PDF extraction artifacts from *text*.
+
+    Two complementary strategies are applied:
+
+    1. **Span-level:** Replace long runs of repeated glyph sequences in a single
+       span (e.g. ``@@@@@`` or ``64/64/64/...``) with a space.
+    2. **Line-level:** Drop entire lines that consist almost entirely of
+       non-alphabetic characters and are very short (≤ 6 chars, < 2 alpha).
+       This catches multi-line Type3 font artifacts such as ``@@h?``, ``@@g``,
+       ``??``, ``?``, ``@@`` — which are Unicode codepoints decoded from glyphs
+       that have no real text mapping (e.g. cp64→@, cp104→h, cp63→?).
+    """
+    # 1. Span-level: strip long repetitive sequences
+    for pattern in _GARBAGE_PATTERNS:
+        text = pattern.sub(' ', text)
+
+    # 2. Line-level: drop lines that are clearly artifact/garbage
+    #    Rule A — very short lines with minimal alpha (@@h?, @@g, ??, @@, …)
+    #    Rule B — short-medium lines with no real word ≥ 3 letters; catches OCR
+    #             image noise such as "r . * * * ! ? *", "^ i * * : * ;",
+    #             "-'Jl", "i i ¥", etc.
+    lines = text.split('\n')
+    clean_lines = []
+    for line in lines:
+        s = line.strip()
+        n = len(s)
+        alpha = sum(c.isalpha() for c in s)
+        if n <= 8 and alpha < 3:          # Rule A
+            continue
+        if n < 50 and not _WORD_RE.search(s):  # Rule B
+            continue
+        clean_lines.append(line)
+    text = '\n'.join(clean_lines)
+
+    # Collapse whitespace runs introduced by replacements
+    text = re.sub(r'[ \t]{2,}', ' ', text)
+    return text.strip()
+
+
+def _is_meaningful_chunk(text: str) -> bool:
+    """Return True if *text* (already cleaned) contains real textual content.
+
+    Rejects chunks that are too short or still dominated by non-alphabetic
+    characters after ``_clean_chunk_text`` has been applied.
+    """
+    stripped = text.strip()
+    if len(stripped) < 20:
+        return False
+    # Generic: fewer than 40 % of characters are letters or spaces → garbage
+    alpha_space = sum(1 for c in stripped if c.isalpha() or c.isspace())
+    if alpha_space / len(stripped) < 0.40:
+        return False
+    return True
 
 
 class SiloService:
@@ -451,15 +523,14 @@ class SiloService:
         """
         from langchain_core.documents import Document
         from langchain_text_splitters import CharacterTextSplitter
-        from langchain_community.document_loaders.pdf import PyPDFLoader
-        from langchain_community.document_loaders import Docx2txtLoader, TextLoader
+        from langchain_community.document_loaders import PyMuPDFLoader, Docx2txtLoader, TextLoader
 
         if base_metadata is None:
             base_metadata = {}
 
         # Determine file type and use appropriate loader
         if file_extension == '.pdf':
-            loader = PyPDFLoader(file_path, extract_images=False)
+            loader = PyMuPDFLoader(file_path)
         elif file_extension == '.docx':
             loader = Docx2txtLoader(file_path)
         elif file_extension in ('.txt', '.md'):
@@ -471,6 +542,18 @@ class SiloService:
         pages = loader.load()
         text_splitter = CharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
         docs = text_splitter.split_documents(pages)
+
+        # Clean known PDF extraction artifacts (e.g. @@@@, 64/64/64/...) from
+        # each chunk's content, then discard chunks that are empty or still
+        # dominated by non-textual characters after cleaning.
+        for doc in docs:
+            doc.page_content = _clean_chunk_text(doc.page_content)
+
+        original_count = len(docs)
+        docs = [doc for doc in docs if _is_meaningful_chunk(doc.page_content)]
+        filtered = original_count - len(docs)
+        if filtered:
+            logger.debug(f"Filtered {filtered} garbage chunk(s) from {file_path}")
 
         for doc in docs:
             doc.metadata.update(base_metadata)


### PR DESCRIPTION
## Descripción

Esta PR filtra artefactos generados por extractores de PDF al indexar documentos con imágenes en silos, evitando que contenido basura (codepoints de fuentes Type3, ruido OCR) se almacene en la base de datos vectorial.

## Cambios realizados

### Dependencias
- Añadido `pymupdf>=1.23.0` a `backend/requirements.txt`
  - Sustituye PyPDFLoader (pypdf) por PyMuPDFLoader
  - Motor de renderizado más robusto que separa mejor texto real del contenido de imágenes

### Limpieza de artefactos (`backend/services/silo_service.py`)

Implementado pipeline de limpieza en dos niveles en `_clean_chunk_text()`:

**Nivel span:**
- Elimina secuencias repetitivas de codepoints: `(\d+/){8,}` (e.g., `/64/64/104/63/...`)
- Elimina cadenas largas de `@`: `@{5,}`

**Nivel línea:**
- Regla A: descarta líneas ≤ 8 chars con < 3 letras (glifos Type3 como `@@h?`, `@@`, `?`)
- Regla B: descarta líneas < 50 chars sin ninguna palabra de ≥ 3 letras Unicode (ruido OCR como `r . * * * ! ? *`)

**Filtrado de chunks:**
- `_is_meaningful_chunk()` descarta chunks con < 20 caracteres o ratio letras+espacios < 40%

El pipeline se aplica **antes** de indexar: `clean → filter → index`

## Testing

Verificado con múltiples casos:
- Texto real preservado (palabras de 3+ letras no se filtran)
- Artefactos Type3 eliminados (`@@h?`, `@@`, `?`, `??`)
- Ruido OCR eliminado (`r . * * *`, `^ i * *`, `-Jl`)
- PDFs con 2 páginas: se indexan correctamente sin artefactos
- PDFs con imágenes: contenido real extraído, artefactos filtrados

## Impacto

- **Silos existentes:** No se ve afectado; el filtrado solo aplica a nuevos indexados
- **Búsquedas en silos:** Resultados más limpios, sin mezcla de artefactos
- **Performance:** Negligible (filtrado en memoria durante extracción)