### PR TITLE
fix(backend): scope app name conflict checks to importing user (issue #159)

### DIFF
--- a/backend/routers/internal/apps.py
+++ b/backend/routers/internal/apps.py
@@ -88,7 +88,8 @@ async def preview_import_app(
         export_data = AppExportFileSchema(**export_dict)
 
         import_service = FullAppImportService(db)
-        return import_service.preview_import(export_data)
+        user_id = int(auth_context.identity.id)
+        return import_service.preview_import(export_data, user_id)
     except (json.JSONDecodeError, ValidationError) as e:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,

--- a/backend/services/full_app_import_service.py
+++ b/backend/services/full_app_import_service.py
@@ -77,6 +77,7 @@ class FullAppImportService:
     def preview_import(
         self,
         export_data: AppExportFileSchema,
+        user_id: int,
     ) -> AppImportPreviewSchema:
         """Preview full app import without importing.
 
@@ -100,15 +101,15 @@ class FullAppImportService:
         global_warnings = []
         dependencies = []
 
-        # Check app name conflict
+        # Check app name conflict (scope to importing user)
         existing_app = (
             self.session.query(App)
-            .filter(App.name == export_data.app.name)
+            .filter(App.name == export_data.app.name, App.owner_id == user_id)
             .first()
         )
         if existing_app:
             global_warnings.append(
-                f"App '{export_data.app.name}' already exists. "
+                f"App '{export_data.app.name}' already exists for the importing user. "
                 f"Use rename mode to auto-generate a new name."
             )
 
@@ -521,9 +522,11 @@ class FullAppImportService:
         base_name = export_data.app.name
         final_name = new_name if new_name else base_name
 
-        # Check for name conflict
+        # Check for name conflict (scope to importing user)
         existing_app = (
-            self.session.query(App).filter(App.name == final_name).first()
+            self.session.query(App)
+            .filter(App.name == final_name, App.owner_id == user_id)
+            .first()
         )
         
         if existing_app:
@@ -535,7 +538,8 @@ class FullAppImportService:
                     timestamp = datetime.now().strftime("%Y-%m-%d")
                     final_name = f"{base_name} (imported {timestamp})"
                     counter = 1
-                    while self.session.query(App).filter(App.name == final_name).first():
+                    # Deduplicate only against apps owned by the importing user
+                    while self.session.query(App).filter(App.name == final_name, App.owner_id == user_id).first():
                         final_name = f"{base_name} (imported {timestamp} {counter})"
                         counter += 1
             elif conflict_mode == ConflictMode.OVERRIDE:


### PR DESCRIPTION
﻿## Description

App name conflict checks during full app import were scoped globally (all users on the platform) instead of per-user. This caused false errors when another user already had an app with the same name — even though the importing user had no conflict.

Fixed by scoping all name lookups to `App.owner_id == user_id` in both `FullAppImportService.preview_import` and `FullAppImportService._create_new_app`, and by passing `user_id` from the router into the preview flow.

## Related Issue(s)

Fixes #159

## Type of Change

* [x] Bug fix (a change that does not break existing functionality and fixes an issue)

## Dependencies Added

None.

## Affected Components

Backend (FastAPI) only — `backend/services/full_app_import_service.py` and `backend/routers/internal/apps.py`.

## Implementation Details

- `preview_import` now accepts `user_id: int` and scopes the app name conflict check to the importing user.
- `_create_new_app` scopes the initial lookup and the RENAME deduplication `while` loop to `App.owner_id == user_id`.
- The `/preview-import` router endpoint extracts `user_id = int(auth_context.identity.id)` and passes it through.
- OVERRIDE mode behaviour is unchanged (still raises ValueError as before).
- Component import services (AIService, Silo, Agent, etc.) were already correctly scoped and are not affected.

## How to Test

1. Create two users (User A and User B) on a local instance.
2. Have User A create an app named `MyApp`.
3. As User B, export any of their apps and import it with the name `MyApp` using `conflict_mode=FAIL`.
4. Before this fix: import would fail with a conflict error. After this fix: import succeeds.
5. Repeat with `conflict_mode=RENAME` — before the fix a timestamp suffix was added unnecessarily; after the fix the name is used as-is.

## Checklist

* [ ] All commits in this pull request are signed using GPG, as required by our commit signing policy (see `.github/instructions/git-github.instructions.md`).
* [x] I have read the contributing guidelines and my change adheres to the coding standards of this project (see `docs/README.md#contributing`).
* [ ] I have added tests that prove my fix or feature works, or confirm that tests are not needed for this change.
* [x] I have run all existing tests and they all pass locally.
* [x] I have updated any relevant documentation, configuration files, or environment examples as needed.
* [x] I have considered backwards compatibility and ensured that my change does not break existing functionality.
* [ ] For UI changes, I have included relevant screenshots or screencasts.

## Additional Notes

No breaking changes. No DB migration required (`App.name` has no UNIQUE constraint at the DB level — uniqueness is enforced per user at the application layer).
