### PR TITLE
feat(metrics): Agent Metrics Dashboard (EE plugin)

### DIFF
--- a/alembic/versions/metrics001_agent_metrics_tables.py
+++ b/alembic/versions/metrics001_agent_metrics_tables.py
@@ -1,0 +1,118 @@
+"""Add agent_execution_event and agent_tool_call tables for metrics plugin.
+
+Revision ID: metrics001
+Revises: spoint001
+Create Date: 2026-05-25
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'metrics001'
+down_revision = 'spoint001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Create PostgreSQL enum types
+    for name, values in [
+        ('agent_execution_caller_type', ['INTERNAL_PLAYGROUND', 'PUBLIC_API', 'MCP', 'AGENT_AS_TOOL']),
+        ('agent_execution_status', ['SUCCESS', 'ERROR', 'TIMEOUT']),
+        ('agent_tool_call_type', ['AGENT', 'MCP', 'RETRIEVER']),
+        ('agent_tool_call_status', ['SUCCESS', 'ERROR']),
+    ]:
+        postgresql.ENUM(*values, name=name, create_type=True).create(op.get_bind(), checkfirst=True)
+
+    # 2. Create parent table: agent_execution_event
+    op.create_table(
+        'agent_execution_event',
+        sa.Column('event_id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('app_id', sa.Integer(), nullable=False),
+        sa.Column('agent_id', sa.Integer(), nullable=False),
+        sa.Column('conversation_id', sa.Integer(), nullable=True),
+        sa.Column('user_id', sa.Integer(), nullable=True),
+        sa.Column('api_key_id', sa.Integer(), nullable=True),
+        sa.Column('caller_type', postgresql.ENUM(
+            'INTERNAL_PLAYGROUND', 'PUBLIC_API', 'MCP', 'AGENT_AS_TOOL',
+            name='agent_execution_caller_type', create_type=False,
+        ), nullable=False),
+        sa.Column('parent_execution_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('started_at', sa.DateTime(), nullable=False),
+        sa.Column('finished_at', sa.DateTime(), nullable=True),
+        sa.Column('duration_ms', sa.Integer(), nullable=True),
+        sa.Column('status', postgresql.ENUM(
+            'SUCCESS', 'ERROR', 'TIMEOUT',
+            name='agent_execution_status', create_type=False,
+        ), nullable=False),
+        sa.Column('error_code', sa.String(64), nullable=True),
+        sa.Column('error_message', sa.Text(), nullable=True),
+        sa.Column('model_name', sa.String(255), nullable=True),
+        sa.Column('ai_service_id', sa.Integer(), nullable=True),
+        sa.Column('input_tokens', sa.Integer(), nullable=True),
+        sa.Column('output_tokens', sa.Integer(), nullable=True),
+        sa.Column('total_tokens', sa.Integer(), nullable=True),
+        sa.Column('tool_calls', sa.JSON(), nullable=True),
+        sa.Column('retrieved_docs', sa.JSON(), nullable=True),
+        sa.Column('had_files', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('file_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('had_images', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('output_parser_used', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('parser_succeeded', sa.Boolean(), nullable=True),
+        sa.Column('prompt_chars', sa.Integer(), nullable=True),
+        sa.Column('response_chars', sa.Integer(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(['app_id'], ['App.app_id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['agent_id'], ['Agent.agent_id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['conversation_id'], ['Conversation.conversation_id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['user_id'], ['User.user_id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['api_key_id'], ['APIKey.key_id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['ai_service_id'], ['AIService.service_id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['parent_execution_id'], ['agent_execution_event.event_id'], ondelete='SET NULL'),
+    )
+
+    # 3. Create child table: agent_tool_call
+    op.create_table(
+        'agent_tool_call',
+        sa.Column('tool_call_id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('event_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('tool_name', sa.String(255), nullable=False),
+        sa.Column('tool_type', postgresql.ENUM(
+            'AGENT', 'MCP', 'RETRIEVER',
+            name='agent_tool_call_type', create_type=False,
+        ), nullable=False),
+        sa.Column('sub_agent_id', sa.Integer(), nullable=True),
+        sa.Column('mcp_config_id', sa.Integer(), nullable=True),
+        sa.Column('duration_ms', sa.Integer(), nullable=True),
+        sa.Column('status', postgresql.ENUM(
+            'SUCCESS', 'ERROR',
+            name='agent_tool_call_status', create_type=False,
+        ), nullable=False),
+        sa.Column('error_message', sa.Text(), nullable=True),
+        sa.Column('started_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['event_id'], ['agent_execution_event.event_id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['sub_agent_id'], ['Agent.agent_id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['mcp_config_id'], ['MCPConfig.config_id'], ondelete='SET NULL'),
+    )
+
+    # 4. Create indexes
+    op.create_index('ix_aee_app_started', 'agent_execution_event', ['app_id', sa.text('started_at DESC')])
+    op.create_index('ix_aee_agent_started', 'agent_execution_event', ['agent_id', sa.text('started_at DESC')])
+    op.create_index('ix_aee_parent', 'agent_execution_event', ['parent_execution_id'])
+    op.create_index('ix_aee_status_started', 'agent_execution_event', ['app_id', 'status', sa.text('started_at DESC')])
+    op.create_index('ix_atc_event', 'agent_tool_call', ['event_id'])
+    op.create_index('ix_atc_tool_name', 'agent_tool_call', ['tool_name'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_atc_tool_name', table_name='agent_tool_call')
+    op.drop_index('ix_atc_event', table_name='agent_tool_call')
+    op.drop_index('ix_aee_status_started', table_name='agent_execution_event')
+    op.drop_index('ix_aee_parent', table_name='agent_execution_event')
+    op.drop_index('ix_aee_agent_started', table_name='agent_execution_event')
+    op.drop_index('ix_aee_app_started', table_name='agent_execution_event')
+    op.drop_table('agent_tool_call')
+    op.drop_table('agent_execution_event')
+    for name in ['agent_tool_call_status', 'agent_tool_call_type', 'agent_execution_status', 'agent_execution_caller_type']:
+        postgresql.ENUM(name=name).drop(op.get_bind(), checkfirst=True)

--- a/alembic/versions/metrics001_agent_metrics_tables.py
+++ b/alembic/versions/metrics001_agent_metrics_tables.py
@@ -10,7 +10,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = 'metrics001'
-down_revision = 'spoint001'
+down_revision = 'ragcfg001'
 branch_labels = None
 depends_on = None
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -27,6 +27,8 @@ from .crawl_policy import CrawlPolicy
 from .crawl_job import CrawlJob
 from .sharepoint_source import SharePointSource
 from .sharepoint_file import SharePointFile
+from .agent_execution_event import AgentExecutionEvent
+from .agent_tool_call import AgentToolCall
 from .media import Media
 from .mcp_server import MCPServer, MCPServerAgent
 from .system_setting import SystemSetting
@@ -52,4 +54,6 @@ __all__ = [
     'TierConfig',
     'UsageRecord',
     'UserCredential',
+    'AgentExecutionEvent',
+    'AgentToolCall',
 ]

--- a/backend/models/agent_execution_event.py
+++ b/backend/models/agent_execution_event.py
@@ -1,0 +1,99 @@
+import uuid
+import enum
+from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, JSON, ForeignKey, Enum
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from db.database import Base
+from models.enums.agent_execution_caller_type import AgentExecutionCallerType
+from models.enums.agent_execution_status import AgentExecutionStatus
+
+
+class AgentExecutionEvent(Base):
+    """Records a single agent execution (one LLM invocation via _execute_agent_async)."""
+    __tablename__ = 'agent_execution_event'
+
+    event_id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        nullable=False,
+    )
+    app_id = Column(
+        Integer,
+        ForeignKey('App.app_id', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
+    )
+    agent_id = Column(
+        Integer,
+        ForeignKey('Agent.agent_id', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
+    )
+    conversation_id = Column(
+        Integer,
+        ForeignKey('Conversation.conversation_id', ondelete='SET NULL'),
+        nullable=True,
+    )
+    user_id = Column(
+        Integer,
+        ForeignKey('User.user_id', ondelete='SET NULL'),
+        nullable=True,
+    )
+    api_key_id = Column(
+        Integer,
+        ForeignKey('APIKey.key_id', ondelete='SET NULL'),
+        nullable=True,
+    )
+    caller_type = Column(
+        Enum(AgentExecutionCallerType, name='agent_execution_caller_type', create_type=False),
+        nullable=False,
+    )
+    parent_execution_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey('agent_execution_event.event_id', ondelete='SET NULL'),
+        nullable=True,
+        index=True,
+    )
+    started_at = Column(DateTime, nullable=False)
+    finished_at = Column(DateTime, nullable=True)
+    duration_ms = Column(Integer, nullable=True)
+    status = Column(
+        Enum(AgentExecutionStatus, name='agent_execution_status', create_type=False),
+        nullable=False,
+    )
+    error_code = Column(String(64), nullable=True)
+    error_message = Column(Text, nullable=True)
+    model_name = Column(String(255), nullable=True)
+    ai_service_id = Column(
+        Integer,
+        ForeignKey('AIService.service_id', ondelete='SET NULL'),
+        nullable=True,
+    )
+    input_tokens = Column(Integer, nullable=True)
+    output_tokens = Column(Integer, nullable=True)
+    total_tokens = Column(Integer, nullable=True)
+    tool_calls = Column(JSON, nullable=True)
+    retrieved_docs = Column(JSON, nullable=True)
+    had_files = Column(Boolean, nullable=False, server_default='false')
+    file_count = Column(Integer, nullable=False, server_default='0')
+    had_images = Column(Boolean, nullable=False, server_default='false')
+    output_parser_used = Column(Boolean, nullable=False, server_default='false')
+    parser_succeeded = Column(Boolean, nullable=True)
+    prompt_chars = Column(Integer, nullable=True)
+    response_chars = Column(Integer, nullable=True)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    # Relationships
+    tool_call_rows = relationship(
+        'AgentToolCall',
+        back_populates='event',
+        cascade='all, delete-orphan',
+    )
+    children = relationship(
+        'AgentExecutionEvent',
+        foreign_keys=[parent_execution_id],
+        backref='parent_event',
+        remote_side='AgentExecutionEvent.event_id',
+    )

--- a/backend/models/agent_tool_call.py
+++ b/backend/models/agent_tool_call.py
@@ -1,0 +1,50 @@
+import uuid
+from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, Enum
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from db.database import Base
+from models.enums.agent_tool_call_type import AgentToolCallType
+from models.enums.agent_tool_call_status import AgentToolCallStatus
+
+
+class AgentToolCall(Base):
+    """Records a single tool call made during an agent execution."""
+    __tablename__ = 'agent_tool_call'
+
+    tool_call_id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        nullable=False,
+    )
+    event_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey('agent_execution_event.event_id', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
+    )
+    tool_name = Column(String(255), nullable=False)
+    tool_type = Column(
+        Enum(AgentToolCallType, name='agent_tool_call_type', create_type=False),
+        nullable=False,
+    )
+    sub_agent_id = Column(
+        Integer,
+        ForeignKey('Agent.agent_id', ondelete='SET NULL'),
+        nullable=True,
+    )
+    mcp_config_id = Column(
+        Integer,
+        ForeignKey('MCPConfig.config_id', ondelete='SET NULL'),
+        nullable=True,
+    )
+    duration_ms = Column(Integer, nullable=True)
+    status = Column(
+        Enum(AgentToolCallStatus, name='agent_tool_call_status', create_type=False),
+        nullable=False,
+    )
+    error_message = Column(Text, nullable=True)
+    started_at = Column(DateTime, nullable=False)
+
+    # Relationships
+    event = relationship('AgentExecutionEvent', back_populates='tool_call_rows')

--- a/backend/models/enums/agent_execution_caller_type.py
+++ b/backend/models/enums/agent_execution_caller_type.py
@@ -1,0 +1,8 @@
+import enum
+
+
+class AgentExecutionCallerType(str, enum.Enum):
+    INTERNAL_PLAYGROUND = "INTERNAL_PLAYGROUND"
+    PUBLIC_API = "PUBLIC_API"
+    MCP = "MCP"
+    AGENT_AS_TOOL = "AGENT_AS_TOOL"

--- a/backend/models/enums/agent_execution_status.py
+++ b/backend/models/enums/agent_execution_status.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class AgentExecutionStatus(str, enum.Enum):
+    SUCCESS = "SUCCESS"
+    ERROR = "ERROR"
+    TIMEOUT = "TIMEOUT"

--- a/backend/models/enums/agent_tool_call_status.py
+++ b/backend/models/enums/agent_tool_call_status.py
@@ -1,0 +1,6 @@
+import enum
+
+
+class AgentToolCallStatus(str, enum.Enum):
+    SUCCESS = "SUCCESS"
+    ERROR = "ERROR"

--- a/backend/models/enums/agent_tool_call_type.py
+++ b/backend/models/enums/agent_tool_call_type.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class AgentToolCallType(str, enum.Enum):
+    AGENT = "AGENT"
+    MCP = "MCP"
+    RETRIEVER = "RETRIEVER"

--- a/backend/services/agent_execution_service.py
+++ b/backend/services/agent_execution_service.py
@@ -2,6 +2,8 @@ import os
 import asyncio
 import ast
 import json
+import uuid as _uuid
+from datetime import datetime as _dt
 from typing import List, Dict, Any, Optional
 from concurrent.futures import ThreadPoolExecutor
 from fastapi import UploadFile, HTTPException
@@ -984,6 +986,14 @@ class AgentExecutionService:
         )
 
         mcp_client = None
+        # Metrics: generate event_id and propagate to sub-agent calls
+        event_id = str(_uuid.uuid4())
+        started_at = _dt.utcnow()
+        if user_context is not None:
+            user_context = {**user_context, 'current_event_id': event_id}
+        else:
+            user_context = {'current_event_id': event_id}
+
         try:
             # Create the agent chain with all tools and capabilities
             agent_chain, mcp_client = await create_agent(
@@ -1023,7 +1033,39 @@ class AgentExecutionService:
                     ls_settings.source,
                 )
 
-            result = await agent_chain.ainvoke({"messages": [message_payload]}, config=config)
+            _status = "SUCCESS"
+            _error_code = None
+            _error_message = None
+            result = None
+            try:
+                result = await agent_chain.ainvoke({"messages": [message_payload]}, config=config)
+            except asyncio.TimeoutError:
+                _status = "TIMEOUT"
+                _error_code = "TIMEOUT"
+                _error_message = "Execution timed out"
+                raise
+            except Exception as _exc:
+                _status = "ERROR"
+                _error_code = type(_exc).__name__
+                _error_message = str(_exc)[:2000]
+                raise
+            finally:
+                finished_at = _dt.utcnow()
+                duration_ms = int((finished_at - started_at).total_seconds() * 1000)
+                _fire_metrics_hook(
+                    event_id=event_id,
+                    fresh_agent=fresh_agent,
+                    user_context=user_context or {},
+                    started_at=started_at,
+                    finished_at=finished_at,
+                    duration_ms=duration_ms,
+                    status=_status,
+                    error_code=_error_code,
+                    error_message=_error_message,
+                    result=result if _status == "SUCCESS" else None,
+                    image_files=image_files or [],
+                    message=message,
+                )
 
             # LangChain v1: structured output is in 'structured_response' key
             # when create_agent is called with response_format=pydantic_model
@@ -1086,4 +1128,138 @@ class AgentExecutionService:
     
     def _update_request_count(self, agent: Agent, db: Session):
         """Update agent request count"""
-        self.agent_execution_repo.update_agent_request_count(db, agent.agent_id) 
+        self.agent_execution_repo.update_agent_request_count(db, agent.agent_id)
+
+
+# ── Module-level helpers for metrics instrumentation ──────────────────────────
+
+def _fire_metrics_hook(*, event_id, fresh_agent, user_context, started_at,
+                        finished_at, duration_ms, status, error_code,
+                        error_message, result, image_files, message):
+    """Build the metrics payload and fire the hook as a background task.
+    Never raises — all errors are logged and swallowed."""
+    try:
+        from services.metrics_hooks import get_execution_hook
+        hook = get_execution_hook()
+        if hook is None:
+            return
+        payload = _build_metrics_payload(
+            event_id=event_id,
+            fresh_agent=fresh_agent,
+            user_context=user_context,
+            started_at=started_at,
+            finished_at=finished_at,
+            duration_ms=duration_ms,
+            status=status,
+            error_code=error_code,
+            error_message=error_message,
+            result=result,
+            image_files=image_files,
+            message=message,
+        )
+        asyncio.create_task(hook(payload))
+    except Exception:
+        logger.exception("_fire_metrics_hook failed — metrics dropped, execution unaffected")
+
+
+def _build_metrics_payload(*, event_id, fresh_agent, user_context, started_at,
+                             finished_at, duration_ms, status, error_code,
+                             error_message, result, image_files, message):
+    """Build a MetricsHookPayload dict from the available execution context."""
+    # 1. Detect caller_type
+    ctx = user_context or {}
+    caller_type_override = ctx.get('caller_type_override')
+    if caller_type_override:
+        caller_type = caller_type_override
+    elif ctx.get('api_key_id') is not None:
+        caller_type = "PUBLIC_API"
+    elif ctx.get('mcp_caller', False):
+        caller_type = "MCP"
+    elif ctx.get('parent_execution_id') is not None:
+        caller_type = "AGENT_AS_TOOL"
+    else:
+        caller_type = "INTERNAL_PLAYGROUND"
+
+    # 2. Extract token counts from result messages
+    input_tokens = None
+    output_tokens = None
+    total_tokens = None
+    tool_calls_summary = None
+    response_chars = None
+
+    if result is not None and isinstance(result, dict):
+        messages = result.get("messages") or []
+        # Walk in reverse to find the last message with usage_metadata
+        for msg in reversed(messages):
+            usage = getattr(msg, 'usage_metadata', None)
+            if usage is not None:
+                input_tokens = (
+                    usage.get('input_tokens')
+                    or usage.get('prompt_tokens')
+                )
+                output_tokens = (
+                    usage.get('output_tokens')
+                    or usage.get('completion_tokens')
+                )
+                total_tokens = usage.get('total_tokens')
+                break
+
+        # 3. Collect tool call summary from AIMessage.tool_calls (up to 20)
+        tool_calls_list = []
+        for msg in messages:
+            tc_list = getattr(msg, 'tool_calls', None)
+            if tc_list:
+                for tc in tc_list:
+                    if len(tool_calls_list) >= 20:
+                        break
+                    if isinstance(tc, dict):
+                        tool_calls_list.append({
+                            "tool_name": tc.get("name", ""),
+                            "tool_type": "MCP",
+                            "status": "SUCCESS",
+                        })
+        tool_calls_summary = tool_calls_list if tool_calls_list else None
+
+        # Extract response chars from last message
+        for msg in reversed(messages):
+            content = getattr(msg, 'content', None)
+            if content and isinstance(content, str):
+                response_chars = len(content)
+                break
+
+    # 4. Build event payload
+    event_payload = {
+        "event_id": event_id,
+        "app_id": getattr(fresh_agent, 'app_id', None),
+        "agent_id": getattr(fresh_agent, 'agent_id', None),
+        "conversation_id": ctx.get('conversation_id'),
+        "user_id": ctx.get('user_id'),
+        "api_key_id": ctx.get('api_key_id'),
+        "caller_type": caller_type,
+        "parent_execution_id": ctx.get('parent_execution_id'),
+        "started_at": started_at.isoformat(),
+        "finished_at": finished_at.isoformat() if finished_at else None,
+        "duration_ms": duration_ms,
+        "status": status,
+        "error_code": error_code,
+        "error_message": error_message,
+        "model_name": getattr(getattr(fresh_agent, 'ai_service', None), 'description', None),
+        "ai_service_id": getattr(fresh_agent, 'ai_service_id', None),
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+        "tool_calls": tool_calls_summary,
+        "retrieved_docs": None,
+        "had_files": len(image_files) > 0,
+        "file_count": len(image_files),
+        "had_images": len(image_files) > 0,
+        "output_parser_used": getattr(fresh_agent, 'output_parser_id', None) is not None,
+        "parser_succeeded": None,
+        "prompt_chars": len(message) if isinstance(message, str) else None,
+        "response_chars": response_chars,
+    }
+
+    return {
+        "event": event_payload,
+        "tool_calls": [],
+    }

--- a/backend/services/agent_streaming_service.py
+++ b/backend/services/agent_streaming_service.py
@@ -8,6 +8,8 @@ and tool events to the client.
 """
 
 from typing import AsyncGenerator, Dict, List, Any
+from datetime import datetime as _dt
+import uuid as _uuid
 
 import psycopg.errors
 from sqlalchemy.orm import Session
@@ -23,7 +25,7 @@ from tools.streaming_utils import (
     map_stream_event,
     SSE_TOKEN,
 )
-from services.agent_execution_service import AgentExecutionService
+from services.agent_execution_service import AgentExecutionService, _fire_metrics_hook
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -88,6 +90,14 @@ class AgentStreamingService:
         """
         effective_db = db or self.db
         mcp_client = None
+
+        # Metrics instrumentation
+        event_id = str(_uuid.uuid4())
+        started_at = _dt.utcnow()
+        _status = "SUCCESS"
+        _error_code = None
+        _error_message = None
+        _stream_messages = []  # collect last update messages for token extraction
 
         try:
             # ----------------------------------------------------------------
@@ -180,6 +190,11 @@ class AgentStreamingService:
                 config=config,
                 stream_mode=["messages", "updates"],
             ):
+                # Collect messages from updates for token extraction in metrics
+                if mode == "updates" and isinstance(chunk, dict):
+                    for node_output in chunk.values():
+                        if isinstance(node_output, dict) and "messages" in node_output:
+                            _stream_messages = node_output["messages"]
                 events = map_stream_event(mode, chunk)
                 if events:
                     for event in events:
@@ -219,14 +234,42 @@ class AgentStreamingService:
                 type(exc).__name__,
                 str(exc),
             )
+            _status = "ERROR"
+            _error_code = type(exc).__name__
+            _error_message = "Connection error, please retry."
             yield format_sse_event("error", {"message": "Connection error, please retry."})
         except Exception as exc:
             logger.error("Error in streaming agent chat: %s", str(exc), exc_info=True)
+            _status = "ERROR"
+            _error_code = type(exc).__name__
+            _error_message = str(exc)[:2000]
             yield format_sse_event("error", {"message": str(exc)})
 
         finally:
             if mcp_client:
                 logger.info("MCP client will be cleaned up automatically")
+            # Fire metrics hook — same pattern as _execute_agent_async
+            try:
+                _ctx = locals().get('ctx')
+                if _ctx is not None:
+                    finished_at = _dt.utcnow()
+                    duration_ms = int((finished_at - started_at).total_seconds() * 1000)
+                    _fire_metrics_hook(
+                        event_id=event_id,
+                        fresh_agent=_ctx.fresh_agent,
+                        user_context=_ctx.user_context,
+                        started_at=started_at,
+                        finished_at=finished_at,
+                        duration_ms=duration_ms,
+                        status=_status,
+                        error_code=_error_code,
+                        error_message=_error_message,
+                        result={"messages": _stream_messages} if _stream_messages else None,
+                        image_files=_ctx.image_files or [],
+                        message=message,
+                    )
+            except Exception:
+                logger.exception("stream metrics hook dispatch failed")
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/backend/services/metrics_hooks.py
+++ b/backend/services/metrics_hooks.py
@@ -1,0 +1,71 @@
+"""Metrics instrumentation hook contract for Mattin AI core.
+
+This module defines the payload types and the registration mechanism used by
+the mattin-metrics plugin. The core never imports the plugin directly; instead
+the plugin calls register_execution_hook() during register() to replace the
+no-op with its own implementation.
+"""
+from typing import Optional, Callable, Awaitable, TypedDict
+import uuid as _uuid
+
+
+class AgentToolCallPayload(TypedDict):
+    tool_name: str
+    tool_type: str          # AgentToolCallType value
+    sub_agent_id: Optional[int]
+    mcp_config_id: Optional[int]
+    duration_ms: Optional[int]
+    status: str             # AgentToolCallStatus value
+    error_message: Optional[str]
+    started_at: str         # ISO-8601 UTC
+
+
+class AgentExecutionEventPayload(TypedDict):
+    event_id: str           # UUID str
+    app_id: int
+    agent_id: int
+    conversation_id: Optional[int]
+    user_id: Optional[int]
+    api_key_id: Optional[int]
+    caller_type: str        # AgentExecutionCallerType value
+    parent_execution_id: Optional[str]
+    started_at: str         # ISO-8601 UTC
+    finished_at: Optional[str]
+    duration_ms: Optional[int]
+    status: str             # AgentExecutionStatus value
+    error_code: Optional[str]
+    error_message: Optional[str]
+    model_name: Optional[str]
+    ai_service_id: Optional[int]
+    input_tokens: Optional[int]
+    output_tokens: Optional[int]
+    total_tokens: Optional[int]
+    tool_calls: Optional[list]       # capped JSON summary
+    retrieved_docs: Optional[list]
+    had_files: bool
+    file_count: int
+    had_images: bool
+    output_parser_used: bool
+    parser_succeeded: Optional[bool]
+    prompt_chars: Optional[int]
+    response_chars: Optional[int]
+
+
+class MetricsHookPayload(TypedDict):
+    event: AgentExecutionEventPayload
+    tool_calls: list  # list[AgentToolCallPayload]
+
+
+# Module-level hook slot. None = no-op (OSS default).
+_execution_hook: Optional[Callable[[MetricsHookPayload], Awaitable[None]]] = None
+
+
+def register_execution_hook(fn: Callable[[MetricsHookPayload], Awaitable[None]]) -> None:
+    """Replace the no-op hook with the provided async callable."""
+    global _execution_hook
+    _execution_hook = fn
+
+
+def get_execution_hook() -> Optional[Callable[[MetricsHookPayload], Awaitable[None]]]:
+    """Return the current hook (None if not registered)."""
+    return _execution_hook

--- a/backend/tools/agentTools.py
+++ b/backend/tools/agentTools.py
@@ -506,6 +506,7 @@ class IACTTool(BaseTool):
     react_agent: Any = None
     mcp_client: Any = None
     llm: Any = None
+    _parent_event_id: Optional[str] = None
 
     def __init__(self, agent: Agent, user_context: Optional[Dict] = None) -> None:
         super().__init__(agent=agent, user_context=user_context)
@@ -519,6 +520,8 @@ class IACTTool(BaseTool):
             raise ValueError("No LLM found for agent")
         self.react_agent = None
         self.mcp_client = None
+        # Store parent event_id for metrics propagation (set by create())
+        object.__setattr__(self, '_parent_event_id', (user_context or {}).get('current_event_id'))
 
     @classmethod
     async def create(cls, agent: Agent, user_context: Optional[Dict] = None) -> "IACTTool":
@@ -595,6 +598,14 @@ class IACTTool(BaseTool):
             raise RuntimeError(
                 "IACTTool must be built via 'await IACTTool.create(...)' before use."
             )
+        import uuid as _uuid
+        from datetime import datetime as _dt
+        sub_event_id = str(_uuid.uuid4())
+        sub_started_at = _dt.utcnow()
+        _sub_status = "SUCCESS"
+        _sub_error_code = None
+        _sub_error = None
+        result_str = None
         try:
             # Format the message using prompt_template if available, otherwise use query directly
             if self.agent.prompt_template:
@@ -610,28 +621,61 @@ class IACTTool(BaseTool):
                         formatted_prompt = query
             else:
                 formatted_prompt = query
-            
+
             messages = [HumanMessage(content=formatted_prompt)]
             result = self.react_agent.invoke({"messages": messages})
-            
+
             # Extract the content from the last AI message
             if isinstance(result, dict) and "messages" in result:
                 messages_list = result["messages"]
                 # Find the last AI message with content
                 for msg in reversed(messages_list):
                     if hasattr(msg, 'content') and msg.content:
-                        return str(msg.content)
+                        result_str = str(msg.content)
+                        return result_str
                 # Fallback: return the last message content
                 if messages_list:
                     last_msg = messages_list[-1]
-                    return str(last_msg.content) if hasattr(last_msg, 'content') else str(last_msg)
-            
+                    result_str = str(last_msg.content) if hasattr(last_msg, 'content') else str(last_msg)
+                    return result_str
+
             # If result is a string, return it directly
-            return str(result)
-            
-        except Exception as e:
-            logger.error(f"Error executing agent tool {self.name}: {str(e)}")
-            return f"Error executing agent tool: {str(e)}"
+            result_str = str(result)
+            return result_str
+
+        except Exception as _exc:
+            _sub_status = "ERROR"
+            _sub_error_code = type(_exc).__name__
+            _sub_error = str(_exc)
+            logger.error(f"Error executing agent tool {self.name}: {str(_exc)}")
+            result_str = f"Error executing agent tool: {str(_exc)}"
+            return result_str
+        finally:
+            sub_finished_at = _dt.utcnow()
+            sub_duration_ms = int((sub_finished_at - sub_started_at).total_seconds() * 1000)
+            try:
+                from services.agent_execution_service import _fire_metrics_hook
+                parent_event_id = object.__getattribute__(self, '_parent_event_id')
+                _fire_metrics_hook(
+                    event_id=sub_event_id,
+                    fresh_agent=self.agent,
+                    user_context={
+                        **(self.user_context or {}),
+                        'parent_execution_id': parent_event_id,
+                        'caller_type_override': 'AGENT_AS_TOOL',
+                    },
+                    started_at=sub_started_at,
+                    finished_at=sub_finished_at,
+                    duration_ms=sub_duration_ms,
+                    status=_sub_status,
+                    error_code=_sub_error_code,
+                    error_message=_sub_error,
+                    result=None,
+                    image_files=[],
+                    message=query,
+                )
+            except Exception:
+                pass  # Metrics never break execution
     
     async def _arun(self, query: str, *args, **kwargs) -> str:
         """Asynchronous execution of the agent tool"""

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "ogl": "^1.0.11",
         "oidc-client-ts": "^3.3.0",
         "react-markdown": "^10.1.0",
+        "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7"
       },
@@ -991,6 +992,42 @@
         "node": ">=14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -1000,6 +1037,18 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1041,6 +1090,69 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -1119,6 +1231,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.38.0",
@@ -1784,6 +1902,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1874,6 +2001,127 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -1889,6 +2137,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
@@ -2019,6 +2273,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.18.20",
@@ -2254,6 +2518,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2689,6 +2959,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2718,6 +2998,15 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
       "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -4414,6 +4703,13 @@
         "react": "^19.2.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-markdown": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
@@ -4438,6 +4734,29 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -4504,6 +4823,51 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -4567,6 +4931,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -5010,6 +5380,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5231,6 +5607,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -5261,6 +5646,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "ogl": "^1.0.11",
     "oidc-client-ts": "^3.3.0",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7"
   },

--- a/frontend/src/components/metrics/AgentMetricsTab.tsx
+++ b/frontend/src/components/metrics/AgentMetricsTab.tsx
@@ -1,0 +1,168 @@
+import { useState, useEffect } from 'react';
+import { Lock, Mail } from 'lucide-react';
+import { useCapability } from '../../contexts/CapabilitiesContext';
+import { metricsApi } from '../../services/metrics';
+import type {
+  TimeRange,
+  AgentSummaryResponse,
+  AgentExecutionsResponse,
+  AgentTokensResponse,
+  AgentErrorsResponse,
+  AgentLatencyResponse,
+  AgentToolsResponse,
+  AgentUsersResponse,
+} from '../../types/metrics';
+import { MetricRangeSelector } from './MetricRangeSelector';
+import { KpiCard } from './KpiCard';
+import { ExecutionsLineChart } from './ExecutionsLineChart';
+import { TokenStackedAreaChart } from './TokenStackedAreaChart';
+import { LatencyChart } from './LatencyChart';
+import { ErrorsChart } from './ErrorsChart';
+import { ToolsBarChart } from './ToolsBarChart';
+import { TopUsersTable } from './TopUsersTable';
+
+interface AgentMetricsTabProps {
+  appId: number;
+  agentId: number;
+}
+
+function MetricsUpsell() {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-xl border border-amber-200 bg-amber-50 p-6 text-center">
+      <Lock className="w-6 h-6 text-amber-500" />
+      <p className="text-sm text-gray-700 font-medium">
+        Agent Metrics is an Enterprise Edition feature.
+      </p>
+      <a
+        href="mailto:info@lksnext.com?subject=Mattin AI Enterprise Edition — Agent Metrics"
+        className="inline-flex items-center gap-2 px-3 py-1.5 bg-blue-600 text-white text-xs font-medium rounded-lg hover:bg-blue-700 transition-colors"
+      >
+        <Mail className="w-3 h-3" />
+        Contact us
+      </a>
+    </div>
+  );
+}
+
+export function AgentMetricsTab({ appId, agentId }: AgentMetricsTabProps) {
+  const metricsEnabled = useCapability('metrics');
+
+  const [range, setRange] = useState<TimeRange>('7d');
+  const [summary, setSummary] = useState<AgentSummaryResponse | null>(null);
+  const [executions, setExecutions] = useState<AgentExecutionsResponse | null>(null);
+  const [tokens, setTokens] = useState<AgentTokensResponse | null>(null);
+  const [errors, setErrors] = useState<AgentErrorsResponse | null>(null);
+  const [latency, setLatency] = useState<AgentLatencyResponse | null>(null);
+  const [tools, setTools] = useState<AgentToolsResponse | null>(null);
+  const [users, setUsers] = useState<AgentUsersResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!metricsEnabled) return;
+
+    setLoading(true);
+    setLoadError(null);
+
+    Promise.all([
+      metricsApi.agentSummary(appId, agentId, range),
+      metricsApi.agentExecutions(appId, agentId, range),
+      metricsApi.agentTokens(appId, agentId, range),
+      metricsApi.agentErrors(appId, agentId, range),
+      metricsApi.agentLatency(appId, agentId, range),
+      metricsApi.agentTools(appId, agentId, range),
+      metricsApi.agentUsers(appId, agentId, range),
+    ])
+      .then(([s, e, t, err, l, tl, u]) => {
+        setSummary(s);
+        setExecutions(e);
+        setTokens(t);
+        setErrors(err);
+        setLatency(l);
+        setTools(tl);
+        setUsers(u);
+      })
+      .catch((err) => {
+        console.error('Failed to load agent metrics:', err);
+        setLoadError('Failed to load metrics. Please try again.');
+      })
+      .finally(() => setLoading(false));
+  }, [appId, agentId, range, metricsEnabled]);
+
+  if (!metricsEnabled) {
+    return <MetricsUpsell />;
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Range selector */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-base font-semibold text-gray-800">Agent Metrics</h3>
+        <MetricRangeSelector value={range} onChange={setRange} />
+      </div>
+
+      {loadError && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {loadError}
+        </div>
+      )}
+
+      {loading && !summary && (
+        <div className="text-sm text-gray-400">Loading metrics…</div>
+      )}
+
+      {/* KPI row */}
+      {summary && (
+        <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3">
+          <KpiCard
+            label="Executions"
+            value={summary.executions.toLocaleString()}
+          />
+          <KpiCard
+            label="As Tool"
+            value={(summary.executions_incl_subcalls - summary.executions).toLocaleString()}
+          />
+          <KpiCard
+            label="Error Rate"
+            value={`${(summary.error_rate * 100).toFixed(1)}%`}
+            trend={summary.error_rate > 0.1 ? 'down' : 'neutral'}
+          />
+          <KpiCard
+            label="P50 Latency"
+            value={summary.latency_p50_ms != null ? `${Math.round(summary.latency_p50_ms)}ms` : '—'}
+          />
+          <KpiCard
+            label="P95 Latency"
+            value={summary.latency_p95_ms != null ? `${Math.round(summary.latency_p95_ms)}ms` : '—'}
+          />
+          <KpiCard
+            label="Total Tokens"
+            value={summary.total_tokens.toLocaleString()}
+          />
+        </div>
+      )}
+
+      {/* Charts row 1 */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {executions && (
+          <ExecutionsLineChart series={executions.series} agentView />
+        )}
+        {tokens && (
+          <TokenStackedAreaChart series={tokens.series} />
+        )}
+      </div>
+
+      {/* Charts row 2 */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {latency && <LatencyChart series={latency.series} />}
+        {errors && <ErrorsChart series={errors.series} />}
+      </div>
+
+      {/* Tools breakdown */}
+      {tools && <ToolsBarChart tools={tools.tools} />}
+
+      {/* Top users */}
+      {users && <TopUsersTable users={users.users} />}
+    </div>
+  );
+}

--- a/frontend/src/components/metrics/ErrorsChart.tsx
+++ b/frontend/src/components/metrics/ErrorsChart.tsx
@@ -1,0 +1,72 @@
+import {
+  ComposedChart,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import type { ErrorBucket } from '../../types/metrics';
+
+interface Props {
+  series: ErrorBucket[];
+}
+
+function formatTs(ts: string): string {
+  try {
+    const d = new Date(ts);
+    const h = d.getUTCHours().toString().padStart(2, '0');
+    const m = d.getUTCMinutes().toString().padStart(2, '0');
+    if (h === '00' && m === '00') {
+      return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+    }
+    return `${h}:${m}`;
+  } catch {
+    return ts;
+  }
+}
+
+export function ErrorsChart({ series }: Props) {
+  if (!series || series.length === 0) {
+    return (
+      <div className="flex h-40 items-center justify-center rounded-xl border border-gray-200 bg-white text-sm text-gray-400">
+        No error data available for this period.
+      </div>
+    );
+  }
+
+  const data = series.map((b) => ({
+    ts: formatTs(b.ts),
+    errors: b.errors,
+    rate: parseFloat((b.rate * 100).toFixed(1)),
+  }));
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      <h3 className="mb-3 text-sm font-semibold text-gray-700">Errors</h3>
+      <ResponsiveContainer width="100%" height={200}>
+        <ComposedChart data={data} margin={{ top: 4, right: 16, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis dataKey="ts" tick={{ fontSize: 11 }} />
+          <YAxis yAxisId="left" tick={{ fontSize: 11 }} />
+          <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 11 }} unit="%" />
+          <Tooltip />
+          <Legend />
+          <Bar yAxisId="left" dataKey="errors" name="Error count" fill="#fca5a5" />
+          <Line
+            yAxisId="right"
+            type="monotone"
+            dataKey="rate"
+            name="Error rate %"
+            stroke="#ef4444"
+            strokeWidth={2}
+            dot={false}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/metrics/ExecutionsLineChart.tsx
+++ b/frontend/src/components/metrics/ExecutionsLineChart.tsx
@@ -1,0 +1,90 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import type { ExecutionBucket, AgentExecutionBucket } from '../../types/metrics';
+
+type Bucket = ExecutionBucket | AgentExecutionBucket;
+
+interface Props {
+  series: Bucket[];
+  /** When true, the second line is "as_tool" (agent view) instead of "sub" (app view) */
+  agentView?: boolean;
+}
+
+function formatTs(ts: string): string {
+  try {
+    const d = new Date(ts);
+    const h = d.getUTCHours().toString().padStart(2, '0');
+    const m = d.getUTCMinutes().toString().padStart(2, '0');
+    if (h === '00' && m === '00') {
+      return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+    }
+    return `${h}:${m}`;
+  } catch {
+    return ts;
+  }
+}
+
+export function ExecutionsLineChart({ series, agentView = false }: Props) {
+  if (!series || series.length === 0) {
+    return (
+      <div className="flex h-40 items-center justify-center rounded-xl border border-gray-200 bg-white text-sm text-gray-400">
+        No execution data available for this period.
+      </div>
+    );
+  }
+
+  const subKey = agentView ? 'as_tool' : 'sub';
+  const subLabel = agentView ? 'As Tool' : 'Sub-calls';
+
+  const data = series.map((b) => {
+    const sub = agentView
+      ? (b as AgentExecutionBucket).as_tool
+      : (b as ExecutionBucket).sub;
+    const errors = 'errors' in b ? (b as ExecutionBucket).errors : 0;
+    return {
+      ts: formatTs(b.ts),
+      root: b.root,
+      [subKey]: sub ?? 0,
+      errors,
+    };
+  });
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      <h3 className="mb-3 text-sm font-semibold text-gray-700">Executions Over Time</h3>
+      <ResponsiveContainer width="100%" height={200}>
+        <LineChart data={data} margin={{ top: 4, right: 16, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis dataKey="ts" tick={{ fontSize: 11 }} />
+          <YAxis tick={{ fontSize: 11 }} />
+          <Tooltip />
+          <Legend />
+          <Line
+            type="monotone"
+            dataKey="root"
+            name="Root calls"
+            stroke="#3b82f6"
+            strokeWidth={2}
+            dot={false}
+          />
+          <Line
+            type="monotone"
+            dataKey={subKey}
+            name={subLabel}
+            stroke="#9ca3af"
+            strokeWidth={2}
+            dot={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/metrics/KpiCard.tsx
+++ b/frontend/src/components/metrics/KpiCard.tsx
@@ -1,0 +1,26 @@
+interface Props {
+  label: string;
+  value: string | number;
+  subLine?: string;
+  trend?: 'up' | 'down' | 'neutral';
+}
+
+const trendColors = {
+  up: 'text-green-600',
+  down: 'text-red-500',
+  neutral: 'text-gray-500',
+};
+
+export function KpiCard({ label, value, subLine, trend }: Props) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      <p className="text-xs font-medium uppercase tracking-wide text-gray-500">{label}</p>
+      <p className={`mt-1 text-2xl font-bold text-gray-900 ${trend ? trendColors[trend] : ''}`}>
+        {value}
+      </p>
+      {subLine && (
+        <p className="mt-0.5 text-xs text-gray-400">{subLine}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/metrics/LatencyChart.tsx
+++ b/frontend/src/components/metrics/LatencyChart.tsx
@@ -1,0 +1,85 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import type { LatencyBucket } from '../../types/metrics';
+
+interface Props {
+  series: LatencyBucket[];
+}
+
+function formatTs(ts: string): string {
+  try {
+    const d = new Date(ts);
+    const h = d.getUTCHours().toString().padStart(2, '0');
+    const m = d.getUTCMinutes().toString().padStart(2, '0');
+    if (h === '00' && m === '00') {
+      return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+    }
+    return `${h}:${m}`;
+  } catch {
+    return ts;
+  }
+}
+
+export function LatencyChart({ series }: Props) {
+  if (!series || series.length === 0) {
+    return (
+      <div className="flex h-40 items-center justify-center rounded-xl border border-gray-200 bg-white text-sm text-gray-400">
+        No latency data available for this period.
+      </div>
+    );
+  }
+
+  const data = series.map((b) => ({
+    ts: formatTs(b.ts),
+    p50: b.p50,
+    p95: b.p95,
+    p99: b.p99,
+  }));
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      <h3 className="mb-3 text-sm font-semibold text-gray-700">Latency (ms)</h3>
+      <ResponsiveContainer width="100%" height={200}>
+        <LineChart data={data} margin={{ top: 4, right: 16, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis dataKey="ts" tick={{ fontSize: 11 }} />
+          <YAxis tick={{ fontSize: 11 }} />
+          <Tooltip />
+          <Legend />
+          <Line
+            type="monotone"
+            dataKey="p50"
+            name="P50"
+            stroke="#22c55e"
+            strokeWidth={2}
+            dot={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="p95"
+            name="P95"
+            stroke="#f59e0b"
+            strokeWidth={2}
+            dot={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="p99"
+            name="P99"
+            stroke="#ef4444"
+            strokeWidth={2}
+            dot={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/metrics/MetricRangeSelector.tsx
+++ b/frontend/src/components/metrics/MetricRangeSelector.tsx
@@ -1,0 +1,32 @@
+import type { TimeRange } from '../../types/metrics';
+
+interface Props {
+  value: TimeRange;
+  onChange: (v: TimeRange) => void;
+}
+
+const RANGES: { label: string; value: TimeRange }[] = [
+  { label: '24h', value: '24h' },
+  { label: '7d', value: '7d' },
+  { label: '30d', value: '30d' },
+];
+
+export function MetricRangeSelector({ value, onChange }: Props) {
+  return (
+    <div className="flex items-center gap-1 rounded-lg border border-gray-200 bg-gray-50 p-1">
+      {RANGES.map((r) => (
+        <button
+          key={r.value}
+          onClick={() => onChange(r.value)}
+          className={`rounded-md px-3 py-1 text-sm font-medium transition-colors ${
+            value === r.value
+              ? 'bg-blue-600 text-white shadow-sm'
+              : 'text-gray-600 hover:bg-gray-200'
+          }`}
+        >
+          {r.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/metrics/TokenStackedAreaChart.tsx
+++ b/frontend/src/components/metrics/TokenStackedAreaChart.tsx
@@ -1,0 +1,76 @@
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import type { TokenBucket } from '../../types/metrics';
+
+interface Props {
+  series: TokenBucket[];
+}
+
+function formatTs(ts: string): string {
+  try {
+    const d = new Date(ts);
+    const h = d.getUTCHours().toString().padStart(2, '0');
+    const m = d.getUTCMinutes().toString().padStart(2, '0');
+    if (h === '00' && m === '00') {
+      return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+    }
+    return `${h}:${m}`;
+  } catch {
+    return ts;
+  }
+}
+
+export function TokenStackedAreaChart({ series }: Props) {
+  if (!series || series.length === 0) {
+    return (
+      <div className="flex h-40 items-center justify-center rounded-xl border border-gray-200 bg-white text-sm text-gray-400">
+        No token data available for this period.
+      </div>
+    );
+  }
+
+  const data = series.map((b) => ({
+    ts: formatTs(b.ts),
+    input: b.input,
+    output: b.output,
+  }));
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      <h3 className="mb-3 text-sm font-semibold text-gray-700">Token Usage</h3>
+      <ResponsiveContainer width="100%" height={200}>
+        <AreaChart data={data} margin={{ top: 4, right: 16, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis dataKey="ts" tick={{ fontSize: 11 }} />
+          <YAxis tick={{ fontSize: 11 }} />
+          <Tooltip />
+          <Legend />
+          <Area
+            type="monotone"
+            dataKey="input"
+            name="Input tokens"
+            stackId="1"
+            stroke="#3b82f6"
+            fill="#bfdbfe"
+          />
+          <Area
+            type="monotone"
+            dataKey="output"
+            name="Output tokens"
+            stackId="1"
+            stroke="#6366f1"
+            fill="#c7d2fe"
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/metrics/ToolsBarChart.tsx
+++ b/frontend/src/components/metrics/ToolsBarChart.tsx
@@ -1,0 +1,48 @@
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import type { ToolBreakdown } from '../../types/metrics';
+
+interface Props {
+  tools: ToolBreakdown[];
+}
+
+export function ToolsBarChart({ tools }: Props) {
+  if (!tools || tools.length === 0) {
+    return (
+      <div className="flex h-40 items-center justify-center rounded-xl border border-gray-200 bg-white text-sm text-gray-400">
+        No tool usage data available for this period.
+      </div>
+    );
+  }
+
+  const data = tools.map((t) => ({
+    name: t.tool_name,
+    calls: t.calls,
+  }));
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      <h3 className="mb-3 text-sm font-semibold text-gray-700">Top Tools by Calls</h3>
+      <ResponsiveContainer width="100%" height={Math.max(160, data.length * 36)}>
+        <BarChart
+          data={data}
+          layout="vertical"
+          margin={{ top: 4, right: 16, left: 8, bottom: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" horizontal={false} />
+          <XAxis type="number" tick={{ fontSize: 11 }} />
+          <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={120} />
+          <Tooltip />
+          <Bar dataKey="calls" name="Calls" fill="#3b82f6" radius={[0, 4, 4, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/metrics/TopUsersTable.tsx
+++ b/frontend/src/components/metrics/TopUsersTable.tsx
@@ -1,0 +1,45 @@
+import type { UserBreakdown } from '../../types/metrics';
+
+interface Props {
+  users: UserBreakdown[];
+}
+
+export function TopUsersTable({ users }: Props) {
+  if (!users || users.length === 0) {
+    return (
+      <div className="flex h-24 items-center justify-center rounded-xl border border-gray-200 bg-white text-sm text-gray-400">
+        No user data available.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      <h3 className="mb-3 text-sm font-semibold text-gray-700">Top Users</h3>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-100 text-left text-xs text-gray-500">
+            <th className="pb-2 font-medium">User</th>
+            <th className="pb-2 font-medium text-right">Executions</th>
+            <th className="pb-2 font-medium text-right">Total Tokens</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-50">
+          {users.map((u, idx) => (
+            <tr key={u.user_id ?? idx} className="hover:bg-gray-50">
+              <td className="py-2 text-gray-700">
+                {u.user_name ?? <span className="italic text-gray-400">(deleted)</span>}
+              </td>
+              <td className="py-2 text-right tabular-nums text-gray-700">
+                {u.executions.toLocaleString()}
+              </td>
+              <td className="py-2 text-right tabular-nums text-gray-700">
+                {u.total_tokens.toLocaleString()}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/core/ExtensibleBaseApp.tsx
+++ b/frontend/src/core/ExtensibleBaseApp.tsx
@@ -71,6 +71,7 @@ import MarketplaceHomePage from '../pages/MarketplaceHomePage';
 import SharePointSourcesPage from '../pages/SharePointSourcesPage';
 import SharePointWizardPage from '../pages/SharePointWizardPage';
 import SharePointSourceDetailPage from '../pages/SharePointSourceDetailPage';
+import AppMetricsPage from '../pages/AppMetricsPage';
 import EnterpriseFeaturePage from '../pages/EnterpriseFeaturePage';
 
 interface ExtensibleBaseAppProps {
@@ -311,6 +312,14 @@ export const ExtensibleBaseApp: React.FC<ExtensibleBaseAppProps> = ({
                   </EditorLayoutRoute>
                 } />
 
+                {/* Metrics route */}
+                <Route path="/apps/:appId/metrics" element={
+                  <ProtectedLayoutRoute {...commonLayoutProps}>
+                    <AppMetricsPage />
+                  </ProtectedLayoutRoute>
+                } />
+
+                {/* MCP Servers routes */}
                 <Route path="/apps/:appId/mcp-servers" element={
                   <EditorLayoutRoute {...commonLayoutProps}>
                       <MCPServersPage />

--- a/frontend/src/core/defaultNavigation.tsx
+++ b/frontend/src/core/defaultNavigation.tsx
@@ -107,6 +107,13 @@ export const defaultNavigation: NavigationConfig = {
       section: 'appNavigation'
     },
     {
+      path: '/apps/:appId/metrics',
+      name: 'Metrics',
+      icon: <BarChart2 size={16} />,
+      section: 'appNavigation',
+      enterpriseFeature: 'metrics'
+    },
+    {
       path: '/apps/:appId/skills',
       name: 'Skills',
       icon: <Zap size={16} />,

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -15,6 +15,8 @@ import type { SearchFilterMetadataField } from '../components/playground/SearchF
 import type { AgentMCPUsage } from '../core/types';
 import type { MarketplaceVisibility, MarketplaceProfileUpdate } from '../types/marketplace';
 import { MARKETPLACE_CATEGORIES } from '../types/marketplace';
+import { AgentMetricsTab } from '../components/metrics/AgentMetricsTab';
+import { useCapability } from '../contexts/CapabilitiesContext';
 
 // Define the Agent types
 interface Agent {
@@ -533,6 +535,7 @@ function AgentFormPage() {
   };
 
   const isNewAgent = Number.parseInt(agentId || '0') === 0;
+  const metricsEnabled = useCapability('metrics');
 
   if (loading) {
     return (
@@ -553,7 +556,8 @@ function AgentFormPage() {
     { id: 'prompts', label: 'Prompts' },
     { id: 'configuration', label: 'Configuration' },
     { id: 'advanced', label: 'Advanced' },
-    { id: 'marketplace', label: 'Marketplace' }
+    { id: 'marketplace', label: 'Marketplace' },
+    ...(!isNewAgent ? [{ id: 'metrics', label: metricsEnabled ? 'Metrics' : 'Metrics [EE]' }] : []),
   ];
 
   return (
@@ -1579,6 +1583,16 @@ function AgentFormPage() {
               )}
               </>
               )}
+            </div>
+          )}
+
+          {/* Metrics tab */}
+          {activeTab === 'metrics' && !isNewAgent && (
+            <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-6 mb-8">
+              <AgentMetricsTab
+                appId={Number(appId)}
+                agentId={Number(agentId)}
+              />
             </div>
           )}
 

--- a/frontend/src/pages/AppMetricsPage.tsx
+++ b/frontend/src/pages/AppMetricsPage.tsx
@@ -1,0 +1,228 @@
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { Lock, Mail } from 'lucide-react';
+import { useCapability } from '../contexts/CapabilitiesContext';
+import { metricsApi } from '../services/metrics';
+import type {
+  TimeRange,
+  AppSummaryResponse,
+  AppExecutionsResponse,
+  AppAgentsResponse,
+  AppModelsResponse,
+  AppUsersResponse,
+} from '../types/metrics';
+import { MetricRangeSelector } from '../components/metrics/MetricRangeSelector';
+import { KpiCard } from '../components/metrics/KpiCard';
+import { ExecutionsLineChart } from '../components/metrics/ExecutionsLineChart';
+import { TopUsersTable } from '../components/metrics/TopUsersTable';
+
+// ── Inline upsell (shown when capability is absent) ───────────────────────
+
+function MetricsUpsell() {
+  return (
+    <div className="max-w-lg mx-auto mt-16 rounded-xl border border-amber-200 bg-amber-50 p-8 text-center">
+      <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-amber-100 border border-amber-300 mb-4">
+        <Lock className="w-6 h-6 text-amber-500" />
+      </div>
+      <h2 className="text-lg font-bold text-gray-900 mb-2">Agent Metrics — Enterprise Edition</h2>
+      <p className="text-gray-500 text-sm mb-6">
+        Token usage, latency, error and tool-usage dashboards at App and Agent level
+        are part of the Mattin AI Enterprise Edition.
+      </p>
+      <a
+        href="mailto:info@lksnext.com?subject=Mattin AI Enterprise Edition — Agent Metrics"
+        className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
+      >
+        <Mail className="w-4 h-4" />
+        Contact us to purchase
+      </a>
+    </div>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────
+
+function AppMetricsPage() {
+  const { appId } = useParams<{ appId: string }>();
+  const metricsEnabled = useCapability('metrics');
+
+  const [range, setRange] = useState<TimeRange>('7d');
+  const [summary, setSummary] = useState<AppSummaryResponse | null>(null);
+  const [executions, setExecutions] = useState<AppExecutionsResponse | null>(null);
+  const [agents, setAgents] = useState<AppAgentsResponse | null>(null);
+  const [models, setModels] = useState<AppModelsResponse | null>(null);
+  const [users, setUsers] = useState<AppUsersResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!metricsEnabled || !appId) return;
+
+    const id = Number(appId);
+    setLoading(true);
+    setError(null);
+
+    Promise.all([
+      metricsApi.appSummary(id, range),
+      metricsApi.appExecutions(id, range),
+      metricsApi.appAgents(id, range),
+      metricsApi.appModels(id, range),
+      metricsApi.appUsers(id, range),
+    ])
+      .then(([s, e, a, m, u]) => {
+        setSummary(s);
+        setExecutions(e);
+        setAgents(a);
+        setModels(m);
+        setUsers(u);
+      })
+      .catch((err) => {
+        console.error('Failed to load metrics:', err);
+        setError('Failed to load metrics data. Please try again.');
+      })
+      .finally(() => setLoading(false));
+  }, [appId, range, metricsEnabled]);
+
+  if (!metricsEnabled) {
+    return <MetricsUpsell />;
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Metrics</h1>
+        <MetricRangeSelector value={range} onChange={setRange} />
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {loading && !summary && (
+        <div className="text-sm text-gray-400">Loading metrics…</div>
+      )}
+
+      {/* KPI row */}
+      {summary && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <KpiCard
+            label="Total Executions"
+            value={summary.total_executions.toLocaleString()}
+          />
+          <KpiCard
+            label="Error Rate"
+            value={`${(summary.error_rate * 100).toFixed(1)}%`}
+            trend={summary.error_rate > 0.1 ? 'down' : 'neutral'}
+          />
+          <KpiCard
+            label="P50 Latency"
+            value={
+              summary.avg_latency_ms_p50 != null
+                ? `${Math.round(summary.avg_latency_ms_p50)}ms`
+                : '—'
+            }
+          />
+          <KpiCard
+            label="Active Agents"
+            value={summary.active_agents}
+          />
+        </div>
+      )}
+
+      {/* Executions chart */}
+      {executions && (
+        <ExecutionsLineChart series={executions.series} />
+      )}
+
+      {/* Agents breakdown table */}
+      {agents && agents.agents.length > 0 && (
+        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+          <h2 className="mb-3 text-sm font-semibold text-gray-700">Agents</h2>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 text-left text-xs text-gray-500">
+                <th className="pb-2 font-medium">Name</th>
+                <th className="pb-2 font-medium text-right">Executions</th>
+                <th className="pb-2 font-medium text-right">Total Tokens</th>
+                <th className="pb-2 font-medium text-right">Error Rate</th>
+                <th className="pb-2 font-medium text-right">Avg Latency</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {agents.agents.map((a) => (
+                <tr key={a.agent_id} className="hover:bg-gray-50">
+                  <td className="py-2 font-medium text-gray-800">{a.agent_name}</td>
+                  <td className="py-2 text-right tabular-nums text-gray-700">
+                    {a.executions.toLocaleString()}
+                  </td>
+                  <td className="py-2 text-right tabular-nums text-gray-700">
+                    {a.total_tokens.toLocaleString()}
+                  </td>
+                  <td className="py-2 text-right tabular-nums text-gray-700">
+                    {(a.error_rate * 100).toFixed(1)}%
+                  </td>
+                  <td className="py-2 text-right tabular-nums text-gray-700">
+                    {a.avg_latency_ms != null ? `${Math.round(a.avg_latency_ms)}ms` : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Models breakdown table */}
+      {models && models.models.length > 0 && (
+        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+          <h2 className="mb-3 text-sm font-semibold text-gray-700">By Model</h2>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 text-left text-xs text-gray-500">
+                <th className="pb-2 font-medium">Model</th>
+                <th className="pb-2 font-medium text-right">Executions</th>
+                <th className="pb-2 font-medium text-right">Input Tokens</th>
+                <th className="pb-2 font-medium text-right">Output Tokens</th>
+                <th className="pb-2 font-medium text-right">Total Tokens</th>
+                <th className="pb-2 font-medium text-right">Error Rate</th>
+                <th className="pb-2 font-medium text-right">Avg Latency</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {models.models.map((m) => (
+                <tr key={m.model_name} className="hover:bg-gray-50">
+                  <td className="py-2 font-medium text-gray-800 font-mono text-xs">{m.model_name}</td>
+                  <td className="py-2 text-right tabular-nums text-gray-700">
+                    {m.executions.toLocaleString()}
+                  </td>
+                  <td className="py-2 text-right tabular-nums text-gray-700">
+                    {m.input_tokens.toLocaleString()}
+                  </td>
+                  <td className="py-2 text-right tabular-nums text-gray-700">
+                    {m.output_tokens.toLocaleString()}
+                  </td>
+                  <td className="py-2 text-right tabular-nums text-gray-700 font-medium">
+                    {m.total_tokens.toLocaleString()}
+                  </td>
+                  <td className="py-2 text-right tabular-nums text-gray-700">
+                    {(m.error_rate * 100).toFixed(1)}%
+                  </td>
+                  <td className="py-2 text-right tabular-nums text-gray-700">
+                    {m.avg_latency_ms != null ? `${Math.round(m.avg_latency_ms)}ms` : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Top users */}
+      {users && <TopUsersTable users={users.users} />}
+    </div>
+  );
+}
+
+export default AppMetricsPage;

--- a/frontend/src/pages/EnterpriseFeaturePage.tsx
+++ b/frontend/src/pages/EnterpriseFeaturePage.tsx
@@ -34,6 +34,13 @@ function EnterpriseFeaturePage() {
             <span><strong>SharePoint Sync</strong> — Index Microsoft SharePoint and OneDrive drives directly into your silos with incremental delta sync</span>
           </li>
           <li className="flex items-start gap-2">
+            <span className="mt-0.5 text-green-500 font-bold">✓</span>
+            <span>
+              <strong>Agent Metrics</strong> — Token, latency, error and tool-usage
+              dashboards at App and Agent level
+            </span>
+          </li>
+          <li className="flex items-start gap-2">
             <span className="mt-0.5 text-gray-300 font-bold">+</span>
             <span className="text-gray-400">More Enterprise connectors and integrations coming soon</span>
           </li>

--- a/frontend/src/services/metrics.ts
+++ b/frontend/src/services/metrics.ts
@@ -1,0 +1,96 @@
+import { apiService } from './api';
+import type {
+  TimeRange,
+  AppSummaryResponse,
+  AppExecutionsResponse,
+  AppAgentsResponse,
+  AppModelsResponse,
+  AppUsersResponse,
+  AgentSummaryResponse,
+  AgentExecutionsResponse,
+  AgentTokensResponse,
+  AgentErrorsResponse,
+  AgentLatencyResponse,
+  AgentToolsResponse,
+  AgentUsersResponse,
+} from '../types/metrics';
+
+const appBase = (appId: number) => `/internal/apps/${appId}/metrics`;
+const agentBase = (appId: number, agentId: number) =>
+  `/internal/apps/${appId}/agents/${agentId}/metrics`;
+
+export const metricsApi = {
+  // App-level
+  appSummary: (appId: number, range: TimeRange): Promise<AppSummaryResponse> =>
+    apiService.request(`${appBase(appId)}/summary?range=${range}`),
+
+  appExecutions: (
+    appId: number,
+    range: TimeRange,
+    callerType?: string,
+  ): Promise<AppExecutionsResponse> => {
+    const qs = callerType
+      ? `?range=${range}&caller_type=${callerType}`
+      : `?range=${range}`;
+    return apiService.request(`${appBase(appId)}/executions${qs}`);
+  },
+
+  appAgents: (appId: number, range: TimeRange): Promise<AppAgentsResponse> =>
+    apiService.request(`${appBase(appId)}/agents?range=${range}`),
+
+  appModels: (appId: number, range: TimeRange): Promise<AppModelsResponse> =>
+    apiService.request(`${appBase(appId)}/models?range=${range}`),
+
+  appUsers: (appId: number, range: TimeRange): Promise<AppUsersResponse> =>
+    apiService.request(`${appBase(appId)}/users?range=${range}`),
+
+  // Per-agent
+  agentSummary: (
+    appId: number,
+    agentId: number,
+    range: TimeRange,
+  ): Promise<AgentSummaryResponse> =>
+    apiService.request(`${agentBase(appId, agentId)}/summary?range=${range}`),
+
+  agentExecutions: (
+    appId: number,
+    agentId: number,
+    range: TimeRange,
+  ): Promise<AgentExecutionsResponse> =>
+    apiService.request(`${agentBase(appId, agentId)}/executions?range=${range}`),
+
+  agentTokens: (
+    appId: number,
+    agentId: number,
+    range: TimeRange,
+  ): Promise<AgentTokensResponse> =>
+    apiService.request(`${agentBase(appId, agentId)}/tokens?range=${range}`),
+
+  agentErrors: (
+    appId: number,
+    agentId: number,
+    range: TimeRange,
+  ): Promise<AgentErrorsResponse> =>
+    apiService.request(`${agentBase(appId, agentId)}/errors?range=${range}`),
+
+  agentLatency: (
+    appId: number,
+    agentId: number,
+    range: TimeRange,
+  ): Promise<AgentLatencyResponse> =>
+    apiService.request(`${agentBase(appId, agentId)}/latency?range=${range}`),
+
+  agentTools: (
+    appId: number,
+    agentId: number,
+    range: TimeRange,
+  ): Promise<AgentToolsResponse> =>
+    apiService.request(`${agentBase(appId, agentId)}/tools?range=${range}`),
+
+  agentUsers: (
+    appId: number,
+    agentId: number,
+    range: TimeRange,
+  ): Promise<AgentUsersResponse> =>
+    apiService.request(`${agentBase(appId, agentId)}/users?range=${range}`),
+};

--- a/frontend/src/types/metrics.ts
+++ b/frontend/src/types/metrics.ts
@@ -1,0 +1,171 @@
+/**
+ * TypeScript interfaces for the Agent Metrics plugin API responses.
+ * Field names match the Python snake_case JSON keys from mattin_metrics/schemas.py.
+ */
+
+export type TimeRange = '24h' | '7d' | '30d';
+
+// ── App-level ──────────────────────────────────────────────────────────────
+
+export interface AppSummaryResponse {
+  range: string;
+  total_executions: number;
+  total_executions_incl_subcalls: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_tokens: number;
+  error_rate: number;
+  avg_latency_ms_p50: number | null;
+  avg_latency_ms_p95: number | null;
+  active_agents: number;
+  active_users: number;
+}
+
+export interface ExecutionBucket {
+  ts: string;
+  root: number;
+  sub: number;
+  errors: number;
+}
+
+export interface AppExecutionsResponse {
+  range: string;
+  bucket_size: string;
+  series: ExecutionBucket[];
+}
+
+export interface AgentBreakdown {
+  agent_id: number;
+  agent_name: string;
+  executions: number;
+  total_tokens: number;
+  error_rate: number;
+  avg_latency_ms: number | null;
+  last_execution_at: string | null;
+}
+
+export interface AppAgentsResponse {
+  range: string;
+  agents: AgentBreakdown[];
+}
+
+export interface ModelBreakdown {
+  model_name: string;
+  executions: number;
+  total_tokens: number;
+  input_tokens: number;
+  output_tokens: number;
+  error_rate: number;
+  avg_latency_ms: number | null;
+  last_execution_at: string | null;
+}
+
+export interface AppModelsResponse {
+  range: string;
+  models: ModelBreakdown[];
+}
+
+export interface UserBreakdown {
+  user_id: number | null;
+  user_name: string | null;
+  executions: number;
+  total_tokens: number;
+}
+
+export interface AppUsersResponse {
+  range: string;
+  users: UserBreakdown[];
+  limit: number;
+}
+
+// ── Per-agent ──────────────────────────────────────────────────────────────
+
+export interface AgentSummaryResponse {
+  range: string;
+  executions: number;
+  executions_incl_subcalls: number;
+  total_tokens: number;
+  input_tokens: number;
+  output_tokens: number;
+  error_rate: number;
+  latency_p50_ms: number | null;
+  latency_p95_ms: number | null;
+  latency_p99_ms: number | null;
+  active_users: number;
+}
+
+export interface AgentExecutionBucket {
+  ts: string;
+  root: number;
+  as_tool: number;
+}
+
+export interface AgentExecutionsResponse {
+  range: string;
+  bucket_size: string;
+  series: AgentExecutionBucket[];
+}
+
+export interface TokenBucket {
+  ts: string;
+  input: number;
+  output: number;
+}
+
+export interface AgentTokensResponse {
+  range: string;
+  bucket_size: string;
+  series: TokenBucket[];
+}
+
+export interface ErrorBucket {
+  ts: string;
+  errors: number;
+  total: number;
+  rate: number;
+}
+
+export interface ErrorByCode {
+  error_code: string;
+  count: number;
+}
+
+export interface AgentErrorsResponse {
+  range: string;
+  bucket_size: string;
+  series: ErrorBucket[];
+  by_code: ErrorByCode[];
+}
+
+export interface LatencyBucket {
+  ts: string;
+  p50: number | null;
+  p95: number | null;
+  p99: number | null;
+}
+
+export interface AgentLatencyResponse {
+  range: string;
+  bucket_size: string;
+  series: LatencyBucket[];
+}
+
+export interface ToolBreakdown {
+  tool_name: string;
+  tool_type: string;
+  sub_agent_id: number | null;
+  calls: number;
+  error_rate: number;
+  avg_duration_ms: number | null;
+}
+
+export interface AgentToolsResponse {
+  range: string;
+  tools: ToolBreakdown[];
+}
+
+export interface AgentUsersResponse {
+  range: string;
+  users: UserBreakdown[];
+  limit: number;
+}

--- a/tests/integration/test_app_delete_cascades_metrics.py
+++ b/tests/integration/test_app_delete_cascades_metrics.py
@@ -1,0 +1,81 @@
+"""
+Integration test: AgentExecutionEvent rows are cascade-deleted when their App
+(and Agent) is deleted.
+
+Verifies that the ON DELETE CASCADE FK constraint on agent_execution_event.app_id
+(and agent_execution_event.agent_id) works correctly so that metric rows do not
+become orphaned when apps or agents are removed.
+"""
+import uuid
+import pytest
+from datetime import datetime, timedelta
+from sqlalchemy import text
+
+from models.agent_execution_event import AgentExecutionEvent
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _insert_events(db, app_id, agent_id, user_id, count=5):
+    """Insert `count` AgentExecutionEvent rows for the given app/agent."""
+    now = datetime.utcnow()
+    for i in range(count):
+        evt = AgentExecutionEvent(
+            event_id=uuid.uuid4(),
+            app_id=app_id,
+            agent_id=agent_id,
+            user_id=user_id,
+            caller_type="INTERNAL_PLAYGROUND",
+            parent_execution_id=None,
+            started_at=now - timedelta(hours=i),
+            finished_at=now - timedelta(hours=i) + timedelta(seconds=1),
+            duration_ms=1000,
+            status="SUCCESS",
+        )
+        db.add(evt)
+    db.flush()
+
+
+def _count_events(db, app_id):
+    """Count AgentExecutionEvent rows for the given app_id."""
+    result = db.execute(
+        text("SELECT count(*) FROM agent_execution_event WHERE app_id = :app_id"),
+        {"app_id": app_id},
+    )
+    return result.scalar()
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+
+class TestAppDeleteCascadeMetrics:
+    def test_cascade_on_agent_delete(self, db, fake_app, fake_agent, fake_user):
+        """Deleting an Agent cascades to its AgentExecutionEvent rows."""
+        _insert_events(db, fake_app.app_id, fake_agent.agent_id, fake_user.user_id, count=5)
+
+        # Verify they were inserted
+        assert _count_events(db, fake_app.app_id) == 5
+
+        # Delete the agent directly — ON DELETE CASCADE should remove metrics rows
+        db.delete(fake_agent)
+        db.flush()
+
+        assert _count_events(db, fake_app.app_id) == 0, \
+            "Metrics rows must be cascade-deleted when the Agent is deleted"
+
+    def test_cascade_on_app_delete(self, db, fake_app, fake_agent, fake_user):
+        """Deleting an App cascades to its AgentExecutionEvent rows."""
+        _insert_events(db, fake_app.app_id, fake_agent.agent_id, fake_user.user_id, count=5)
+
+        assert _count_events(db, fake_app.app_id) == 5
+
+        # Delete via AppService (which deletes agents first, then app)
+        # Agents cascade metrics rows; the app deletion cascades any remaining ones.
+        from services.app_service import AppService
+        svc = AppService(db)
+        result = svc.delete_app(fake_app.app_id)
+
+        assert result is True, "AppService.delete_app should return True on success"
+        assert _count_events(db, fake_app.app_id) == 0, \
+            "Metrics rows must be gone after the App is deleted"

--- a/tests/integration/test_metrics_agent_endpoints.py
+++ b/tests/integration/test_metrics_agent_endpoints.py
@@ -1,0 +1,271 @@
+"""
+Integration tests for per-agent metrics endpoints.
+
+Tests:
+  1. EDITOR can access per-agent metrics (200)
+  2. VIEWER is forbidden (403)
+  3. Cross-app agent lookup returns 404
+  4-10. Response structure checks for each per-agent endpoint
+  10. Invalid range returns 400
+"""
+import uuid
+import pytest
+from datetime import datetime, timedelta
+from models.app_collaborator import AppCollaborator, CollaborationRole, CollaborationStatus
+from models.agent_execution_event import AgentExecutionEvent
+from tests.factories import configure_factories, UserFactory, AppFactory, AIServiceFactory, AgentFactory
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _make_collab(db, app_id, user_id, role: CollaborationRole, invited_by):
+    collab = AppCollaborator(
+        app_id=app_id,
+        user_id=user_id,
+        role=role,
+        status=CollaborationStatus.ACCEPTED,
+        invited_by=invited_by,
+        invited_at=datetime.utcnow(),
+        accepted_at=datetime.utcnow(),
+    )
+    db.add(collab)
+    db.flush()
+    return collab
+
+
+def _login(client, email):
+    resp = client.post("/internal/auth/dev-login", json={"email": email})
+    assert resp.status_code == 200, f"Login failed: {resp.text}"
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _seed_events(db, app_id, agent_id, user_id, count=6):
+    """Insert AgentExecutionEvent rows for the given app/agent."""
+    now = datetime.utcnow()
+    statuses = ["SUCCESS", "SUCCESS", "ERROR", "SUCCESS", "SUCCESS", "ERROR"]
+    parent_id = uuid.uuid4()
+    parent = AgentExecutionEvent(
+        event_id=parent_id,
+        app_id=app_id,
+        agent_id=agent_id,
+        user_id=user_id,
+        caller_type="INTERNAL_PLAYGROUND",
+        parent_execution_id=None,
+        started_at=now - timedelta(hours=count + 1),
+        finished_at=now - timedelta(hours=count + 1) + timedelta(seconds=2),
+        duration_ms=2000,
+        status="SUCCESS",
+        input_tokens=200,
+        output_tokens=100,
+        total_tokens=300,
+    )
+    db.add(parent)
+    db.flush()
+
+    for i in range(count):
+        caller = "AGENT_AS_TOOL" if i % 3 == 0 else "INTERNAL_PLAYGROUND"
+        parent_ref = parent_id if caller == "AGENT_AS_TOOL" else None
+        evt = AgentExecutionEvent(
+            event_id=uuid.uuid4(),
+            app_id=app_id,
+            agent_id=agent_id,
+            user_id=user_id,
+            caller_type=caller,
+            parent_execution_id=parent_ref,
+            started_at=now - timedelta(hours=i),
+            finished_at=now - timedelta(hours=i) + timedelta(seconds=1 + i),
+            duration_ms=1000 + i * 200,
+            status=statuses[i % len(statuses)],
+            error_code="ValueError" if statuses[i % len(statuses)] == "ERROR" else None,
+            input_tokens=100 + i * 10,
+            output_tokens=50 + i * 5,
+            total_tokens=150 + i * 15,
+        )
+        db.add(evt)
+    db.flush()
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def editor_user(db, fake_app, fake_user):
+    configure_factories(db)
+    user = UserFactory(email="editor-agent-metrics@mattin-test.com", name="Editor User")
+    _make_collab(db, fake_app.app_id, user.user_id,
+                 CollaborationRole.EDITOR, fake_user.user_id)
+    return user
+
+
+@pytest.fixture
+def editor_headers(db, client, fake_app, fake_user):
+    configure_factories(db)
+    user = UserFactory(email="editor-agent-metrics2@mattin-test.com", name="Editor User 2")
+    _make_collab(db, fake_app.app_id, user.user_id,
+                 CollaborationRole.EDITOR, fake_user.user_id)
+    return _login(client, user.email)
+
+
+@pytest.fixture
+def viewer_headers(db, client, fake_app, fake_user):
+    configure_factories(db)
+    user = UserFactory(email="viewer-agent-metrics@mattin-test.com", name="Viewer User")
+    _make_collab(db, fake_app.app_id, user.user_id,
+                 CollaborationRole.VIEWER, fake_user.user_id)
+    return _login(client, user.email)
+
+
+@pytest.fixture
+def seeded_events(db, fake_app, fake_agent, fake_user):
+    _seed_events(db, fake_app.app_id, fake_agent.agent_id, fake_user.user_id)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+
+
+class TestAgentSummaryEndpoint:
+    def test_editor_ok(self, client, fake_app, fake_agent, seeded_events, editor_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/agents/{fake_agent.agent_id}/metrics/summary?range=7d",
+            headers=editor_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "executions" in data
+        assert isinstance(data["error_rate"], float)
+        assert "total_tokens" in data
+
+    def test_viewer_forbidden(self, client, fake_app, fake_agent, viewer_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/agents/{fake_agent.agent_id}/metrics/summary?range=7d",
+            headers=viewer_headers,
+        )
+        assert resp.status_code == 403
+
+    def test_cross_app_404(self, client, db, fake_app, fake_agent, fake_user):
+        """An agent belonging to App A queried via App B's URL returns 404."""
+        configure_factories(db)
+        # Create a second app with a different owner
+        other_user = UserFactory(email="other-owner-metrics@mattin-test.com", name="Other Owner")
+        other_app = AppFactory(owner=other_user, owner_id=other_user.user_id)
+        # Create a cross-app editor: a user who is an EDITOR in both apps
+        cross_user = UserFactory(email="cross-editor-metrics@mattin-test.com", name="Cross Editor")
+        _make_collab(db, fake_app.app_id, cross_user.user_id,
+                     CollaborationRole.EDITOR, fake_user.user_id)
+        _make_collab(db, other_app.app_id, cross_user.user_id,
+                     CollaborationRole.EDITOR, other_user.user_id)
+        # Log in as cross_user (who has EDITOR access to other_app)
+        cross_headers = _login(client, cross_user.email)
+        # Query fake_agent (which belongs to fake_app) via other_app's URL
+        # The service should return 404 since fake_agent.app_id != other_app.app_id
+        resp = client.get(
+            f"/internal/apps/{other_app.app_id}/agents/{fake_agent.agent_id}/metrics/summary?range=7d",
+            headers=cross_headers,
+        )
+        assert resp.status_code == 404
+
+
+class TestAgentExecutionsEndpoint:
+    def test_series_structure(self, client, fake_app, fake_agent, seeded_events, editor_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/agents/{fake_agent.agent_id}/metrics/executions?range=7d",
+            headers=editor_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "series" in data
+        assert isinstance(data["series"], list)
+        if data["series"]:
+            item = data["series"][0]
+            assert "ts" in item
+            assert "root" in item
+            assert "as_tool" in item
+
+
+class TestAgentTokensEndpoint:
+    def test_series_structure(self, client, fake_app, fake_agent, seeded_events, editor_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/agents/{fake_agent.agent_id}/metrics/tokens?range=7d",
+            headers=editor_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "series" in data
+        assert isinstance(data["series"], list)
+        if data["series"]:
+            item = data["series"][0]
+            assert "ts" in item
+            assert "input" in item
+            assert "output" in item
+
+
+class TestAgentErrorsEndpoint:
+    def test_structure(self, client, fake_app, fake_agent, seeded_events, editor_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/agents/{fake_agent.agent_id}/metrics/errors?range=7d",
+            headers=editor_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "series" in data
+        assert "by_code" in data
+        assert isinstance(data["series"], list)
+        assert isinstance(data["by_code"], list)
+
+
+class TestAgentLatencyEndpoint:
+    def test_structure(self, client, fake_app, fake_agent, seeded_events, editor_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/agents/{fake_agent.agent_id}/metrics/latency?range=7d",
+            headers=editor_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "series" in data
+        assert isinstance(data["series"], list)
+        if data["series"]:
+            item = data["series"][0]
+            assert "ts" in item
+            assert "p50" in item
+            assert "p95" in item
+            assert "p99" in item
+
+
+class TestAgentToolsEndpoint:
+    def test_structure(self, client, fake_app, fake_agent, seeded_events, editor_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/agents/{fake_agent.agent_id}/metrics/tools?range=7d",
+            headers=editor_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "tools" in data
+        assert isinstance(data["tools"], list)
+        # If tools are present, verify structure
+        for tool in data["tools"]:
+            assert "tool_name" in tool
+            assert "tool_type" in tool
+            assert "calls" in tool
+
+
+class TestAgentUsersEndpoint:
+    def test_structure(self, client, fake_app, fake_agent, seeded_events, editor_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/agents/{fake_agent.agent_id}/metrics/users?range=7d",
+            headers=editor_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "users" in data
+        assert isinstance(data["users"], list)
+
+
+class TestInvalidRangePerAgent:
+    def test_invalid_range(self, client, fake_app, fake_agent, editor_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/agents/{fake_agent.agent_id}/metrics/summary?range=invalid",
+            headers=editor_headers,
+        )
+        assert resp.status_code == 400
+        assert "Invalid range" in resp.json().get("detail", "")

--- a/tests/integration/test_metrics_app_endpoints.py
+++ b/tests/integration/test_metrics_app_endpoints.py
@@ -1,0 +1,211 @@
+"""
+Integration tests for the App-level metrics endpoints.
+
+These tests require the test DB (port 5433) and the metrics plugin router
+to be mounted (it is loaded automatically via entry-point in the test env).
+"""
+import uuid
+import pytest
+from datetime import datetime, timedelta
+from models.app_collaborator import AppCollaborator, CollaborationRole, CollaborationStatus
+from models.agent_execution_event import AgentExecutionEvent
+from tests.factories import configure_factories, UserFactory
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _make_collab(db, app_id, user_id, role: CollaborationRole, invited_by):
+    from datetime import datetime
+    collab = AppCollaborator(
+        app_id=app_id,
+        user_id=user_id,
+        role=role,
+        status=CollaborationStatus.ACCEPTED,
+        invited_by=invited_by,
+        invited_at=datetime.utcnow(),
+        accepted_at=datetime.utcnow(),
+    )
+    db.add(collab)
+    db.flush()
+    return collab
+
+
+def _login(client, email):
+    resp = client.post("/internal/auth/dev-login", json={"email": email})
+    assert resp.status_code == 200, f"Login failed: {resp.text}"
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _seed_events(db, app_id, agent_id, user_id, count=7):
+    """Insert a handful of AgentExecutionEvent rows for the given app/agent."""
+    now = datetime.utcnow()
+    events = []
+    statuses = ["SUCCESS", "SUCCESS", "SUCCESS", "SUCCESS", "ERROR", "SUCCESS", "ERROR"]
+    # First insert a parent event so sub-calls can reference it
+    parent_id = uuid.uuid4()
+    parent = AgentExecutionEvent(
+        event_id=parent_id,
+        app_id=app_id,
+        agent_id=agent_id,
+        user_id=user_id,
+        caller_type="INTERNAL_PLAYGROUND",
+        parent_execution_id=None,
+        started_at=now - timedelta(hours=count + 1),
+        finished_at=now - timedelta(hours=count + 1) + timedelta(seconds=3),
+        duration_ms=3000,
+        status="SUCCESS",
+        input_tokens=200,
+        output_tokens=100,
+        total_tokens=300,
+    )
+    db.add(parent)
+    db.flush()
+
+    for i in range(count):
+        caller = "INTERNAL_PLAYGROUND" if i % 3 != 0 else "AGENT_AS_TOOL"
+        parent_ref = parent_id if caller == "AGENT_AS_TOOL" else None
+        evt = AgentExecutionEvent(
+            event_id=uuid.uuid4(),
+            app_id=app_id,
+            agent_id=agent_id,
+            user_id=user_id,
+            caller_type=caller,
+            parent_execution_id=parent_ref,
+            started_at=now - timedelta(hours=i),
+            finished_at=now - timedelta(hours=i) + timedelta(seconds=2),
+            duration_ms=2000 + i * 100,
+            status=statuses[i % len(statuses)],
+            error_code="ValueError" if statuses[i % len(statuses)] == "ERROR" else None,
+            input_tokens=100 + i * 10,
+            output_tokens=50 + i * 5,
+            total_tokens=150 + i * 15,
+        )
+        db.add(evt)
+        events.append(evt)
+    db.flush()
+    return events
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def admin_headers(db, client, fake_app, fake_user):
+    configure_factories(db)
+    admin_user = UserFactory(email="admin-metrics@mattin-test.com", name="Admin User")
+    _make_collab(db, fake_app.app_id, admin_user.user_id,
+                 CollaborationRole.ADMINISTRATOR, fake_user.user_id)
+    return _login(client, admin_user.email)
+
+
+@pytest.fixture
+def viewer_headers(db, client, fake_app, fake_user):
+    configure_factories(db)
+    viewer_user = UserFactory(email="viewer-metrics@mattin-test.com", name="Viewer User")
+    _make_collab(db, fake_app.app_id, viewer_user.user_id,
+                 CollaborationRole.VIEWER, fake_user.user_id)
+    return _login(client, viewer_user.email)
+
+
+@pytest.fixture
+def editor_headers(db, client, fake_app, fake_user):
+    configure_factories(db)
+    editor_user = UserFactory(email="editor-metrics@mattin-test.com", name="Editor User")
+    _make_collab(db, fake_app.app_id, editor_user.user_id,
+                 CollaborationRole.EDITOR, fake_user.user_id)
+    return _login(client, editor_user.email)
+
+
+@pytest.fixture
+def seeded_events(db, fake_app, fake_agent, fake_user):
+    return _seed_events(db, fake_app.app_id, fake_agent.agent_id, fake_user.user_id)
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+
+class TestAppSummaryEndpoint:
+    def test_ok_administrator(self, client, fake_app, seeded_events, admin_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/metrics/summary?range=7d",
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["total_executions"] > 0
+        assert isinstance(data["error_rate"], float)
+
+    def test_viewer_forbidden(self, client, fake_app, seeded_events, viewer_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/metrics/summary?range=7d",
+            headers=viewer_headers,
+        )
+        assert resp.status_code == 403
+
+    def test_editor_forbidden(self, client, fake_app, seeded_events, editor_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/metrics/summary?range=7d",
+            headers=editor_headers,
+        )
+        assert resp.status_code == 403
+
+    def test_owner_ok(self, client, fake_app, seeded_events, owner_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/metrics/summary?range=7d",
+            headers=owner_headers,
+        )
+        assert resp.status_code == 200
+
+    def test_invalid_range(self, client, fake_app, admin_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/metrics/summary?range=bad",
+            headers=admin_headers,
+        )
+        assert resp.status_code == 400
+        assert "Invalid range" in resp.json().get("detail", "")
+
+
+class TestAppExecutionsEndpoint:
+    def test_ok(self, client, fake_app, seeded_events, admin_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/metrics/executions?range=7d",
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "series" in data
+        assert isinstance(data["series"], list)
+        if data["series"]:
+            item = data["series"][0]
+            assert "ts" in item
+            assert "root" in item
+            assert "sub" in item
+            assert "errors" in item
+
+
+class TestAppAgentsEndpoint:
+    def test_sorted_by_executions(self, client, fake_app, seeded_events, admin_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/metrics/agents?range=7d",
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        agents = data["agents"]
+        # If there are multiple agents, verify descending sort
+        if len(agents) > 1:
+            for i in range(len(agents) - 1):
+                assert agents[i]["executions"] >= agents[i + 1]["executions"]
+
+
+class TestAppUsersEndpoint:
+    def test_limit(self, client, fake_app, seeded_events, admin_headers):
+        resp = client.get(
+            f"/internal/apps/{fake_app.app_id}/metrics/users?range=7d",
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "users" in data
+        assert len(data["users"]) <= 20

--- a/tests/integration/test_metrics_capability.py
+++ b/tests/integration/test_metrics_capability.py
@@ -1,0 +1,62 @@
+"""
+Integration tests for the metrics plugin capabilities endpoint.
+
+Tests whether the /internal/capabilities endpoint reports the metrics plugin
+when registered, and whether the metrics routes are absent when not registered.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+
+class TestCapabilityWithoutPlugin:
+    """Without plugin registration, metrics key should be absent and routes 404."""
+
+    def test_capabilities_excludes_metrics(self, client, auth_headers):
+        """GET /internal/capabilities must NOT include a 'metrics' key."""
+        from plugins.registry import plugin_registry
+        # Ensure metrics not in registry for this test
+        original = plugin_registry._plugins.pop("metrics", None)
+        try:
+            response = client.get("/internal/capabilities", headers=auth_headers)
+            assert response.status_code == 200
+            data = response.json()
+            assert "metrics" not in data, f"Unexpected 'metrics' key found: {data}"
+        finally:
+            if original is not None:
+                plugin_registry._plugins["metrics"] = original
+
+    def test_metrics_router_absent(self, client, auth_headers):
+        """Without plugin, GET /internal/apps/1/metrics/summary returns 404."""
+        from plugins.registry import plugin_registry
+        original = plugin_registry._plugins.pop("metrics", None)
+        try:
+            response = client.get("/internal/apps/1/metrics/summary", headers=auth_headers)
+            # The route does not exist without the plugin, so expect 404
+            assert response.status_code == 404, (
+                f"Expected 404 without plugin, got {response.status_code}"
+            )
+        finally:
+            if original is not None:
+                plugin_registry._plugins["metrics"] = original
+
+
+class TestCapabilityWithPlugin:
+    """With plugin registration, metrics key should appear in capabilities."""
+
+    def test_capabilities_includes_metrics(self, client, auth_headers):
+        """After registering metrics plugin, GET /internal/capabilities returns metrics.enabled == True."""
+        from plugins.registry import plugin_registry
+        # Manually register the metrics descriptor (simulates plugin.register())
+        original = plugin_registry._plugins.get("metrics")
+        plugin_registry.register("metrics", {"enabled": True, "version": "test"})
+        try:
+            response = client.get("/internal/capabilities", headers=auth_headers)
+            assert response.status_code == 200
+            data = response.json()
+            assert "metrics" in data, f"'metrics' not in capabilities: {data}"
+            assert data["metrics"]["enabled"] is True
+        finally:
+            if original is not None:
+                plugin_registry._plugins["metrics"] = original
+            else:
+                plugin_registry._plugins.pop("metrics", None)

--- a/tests/integration/test_metrics_writepath.py
+++ b/tests/integration/test_metrics_writepath.py
@@ -1,0 +1,237 @@
+"""
+Integration test: write-path instrumentation for agent metrics.
+
+Tests that AgentExecutionService._execute_agent_async fires the metrics hook
+with the correct payload on success, on error, and is a no-op when no plugin
+is registered.
+
+LangGraph / LLM calls are mocked to avoid real API calls.
+"""
+import asyncio
+import uuid
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from langchain_core.messages import AIMessage
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _make_fake_agent(app_id: int, agent_id: int) -> MagicMock:
+    """Build a minimal Agent mock that _execute_agent_async can use."""
+    agent = MagicMock()
+    agent.agent_id = agent_id
+    agent.app_id = app_id
+    agent.name = "Fake Agent"
+    agent.type = "agent"
+    agent.has_memory = False
+    agent.silo_id = None
+    agent.output_parser_id = None
+    agent.ai_service = None
+    agent.ai_service_id = None
+    agent.is_frozen = False
+    agent.request_count = 0
+    agent.app = MagicMock()
+    agent.app.langsmith_api_key = None
+    return agent
+
+
+def _make_fake_result() -> dict:
+    """Return a plausible LangGraph result dict with usage metadata."""
+    ai_msg = AIMessage(content="Hello from mock LLM!")
+    ai_msg.usage_metadata = {
+        "input_tokens": 50,
+        "output_tokens": 25,
+        "total_tokens": 75,
+    }
+    return {"messages": [ai_msg]}
+
+
+async def _drain_tasks():
+    """Yield control to the event loop to let pending tasks run."""
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+class TestWritePathSuccess:
+    """Hook is called with SUCCESS payload after a mocked successful invocation."""
+
+    @pytest.mark.asyncio
+    async def test_hook_called_with_success_payload(self, fake_app, fake_agent):
+        """After a successful invocation, the hook receives a SUCCESS payload."""
+        from services.agent_execution_service import AgentExecutionService
+        import services.metrics_hooks as _hooks
+
+        captured_payload = []
+
+        async def _capture_hook(payload):
+            captured_payload.append(payload)
+
+        # Register our capture hook
+        original_hook = _hooks.get_execution_hook()
+        _hooks.register_execution_hook(_capture_hook)
+
+        fake_result = _make_fake_result()
+        fake_chain = MagicMock()
+        fake_chain.ainvoke = AsyncMock(return_value=fake_result)
+
+        try:
+            with patch("tools.agentTools.create_agent", new=AsyncMock(return_value=(fake_chain, None))), \
+                 patch("tools.agentTools.prepare_agent_config", return_value={"configurable": {}}), \
+                 patch("tools.agentTools.build_human_message", return_value=MagicMock()):
+
+                svc = AgentExecutionService.__new__(AgentExecutionService)
+                agent = _make_fake_agent(fake_app.app_id, fake_agent.agent_id)
+
+                await svc._execute_agent_async(
+                    fresh_agent=agent,
+                    message="Hello",
+                    user_context={},
+                )
+
+                # Drain tasks so the create_task in _fire_metrics_hook runs
+                await _drain_tasks()
+
+        finally:
+            # Restore original hook (None in OSS mode)
+            _hooks.register_execution_hook(original_hook)
+
+        assert len(captured_payload) == 1, "Hook should be called exactly once"
+        event = captured_payload[0]["event"]
+        assert event["status"] == "SUCCESS"
+        assert event["caller_type"] == "INTERNAL_PLAYGROUND"
+        assert event["duration_ms"] is not None
+        assert event["agent_id"] == fake_agent.agent_id
+        assert event["app_id"] == fake_app.app_id
+        assert event["input_tokens"] == 50
+        assert event["output_tokens"] == 25
+        assert event["total_tokens"] == 75
+
+    @pytest.mark.asyncio
+    async def test_hook_called_with_public_api_caller(self, fake_app, fake_agent):
+        """When api_key_id is in user_context, caller_type is PUBLIC_API."""
+        from services.agent_execution_service import AgentExecutionService
+        import services.metrics_hooks as _hooks
+
+        captured_payload = []
+
+        async def _capture_hook(payload):
+            captured_payload.append(payload)
+
+        original_hook = _hooks.get_execution_hook()
+        _hooks.register_execution_hook(_capture_hook)
+
+        fake_chain = MagicMock()
+        fake_chain.ainvoke = AsyncMock(return_value=_make_fake_result())
+
+        try:
+            with patch("tools.agentTools.create_agent", new=AsyncMock(return_value=(fake_chain, None))), \
+                 patch("tools.agentTools.prepare_agent_config", return_value={"configurable": {}}), \
+                 patch("tools.agentTools.build_human_message", return_value=MagicMock()):
+
+                svc = AgentExecutionService.__new__(AgentExecutionService)
+                agent = _make_fake_agent(fake_app.app_id, fake_agent.agent_id)
+
+                await svc._execute_agent_async(
+                    fresh_agent=agent,
+                    message="API call",
+                    user_context={"api_key_id": 42},
+                )
+                await _drain_tasks()
+        finally:
+            _hooks.register_execution_hook(original_hook)
+
+        assert len(captured_payload) == 1
+        assert captured_payload[0]["event"]["caller_type"] == "PUBLIC_API"
+
+
+class TestWritePathError:
+    """Hook is called with ERROR payload when ainvoke raises."""
+
+    @pytest.mark.asyncio
+    async def test_hook_called_with_error_payload(self, fake_app, fake_agent):
+        """When ainvoke raises, the hook receives an ERROR payload."""
+        from services.agent_execution_service import AgentExecutionService
+        import services.metrics_hooks as _hooks
+
+        captured_payload = []
+
+        async def _capture_hook(payload):
+            captured_payload.append(payload)
+
+        original_hook = _hooks.get_execution_hook()
+        _hooks.register_execution_hook(_capture_hook)
+
+        fake_chain = MagicMock()
+        fake_chain.ainvoke = AsyncMock(side_effect=ValueError("provider down"))
+
+        try:
+            with patch("tools.agentTools.create_agent", new=AsyncMock(return_value=(fake_chain, None))), \
+                 patch("tools.agentTools.prepare_agent_config", return_value={"configurable": {}}), \
+                 patch("tools.agentTools.build_human_message", return_value=MagicMock()):
+
+                svc = AgentExecutionService.__new__(AgentExecutionService)
+                agent = _make_fake_agent(fake_app.app_id, fake_agent.agent_id)
+
+                with pytest.raises(ValueError, match="provider down"):
+                    await svc._execute_agent_async(
+                        fresh_agent=agent,
+                        message="Hello",
+                        user_context={},
+                    )
+
+                await _drain_tasks()
+        finally:
+            _hooks.register_execution_hook(original_hook)
+
+        assert len(captured_payload) == 1, "Hook must be called even on error"
+        event = captured_payload[0]["event"]
+        assert event["status"] == "ERROR"
+        assert event["error_code"] == "ValueError"
+        assert event["duration_ms"] is not None
+
+
+class TestWritePathNoPlugin:
+    """When no hook is registered, execution succeeds and no hook is called."""
+
+    @pytest.mark.asyncio
+    async def test_no_hook_no_side_effects(self, fake_app, fake_agent):
+        """Without plugin, invocation succeeds and no hook is fired."""
+        from services.agent_execution_service import AgentExecutionService
+        import services.metrics_hooks as _hooks
+
+        # Ensure no hook is registered
+        original_hook = _hooks.get_execution_hook()
+        _hooks.register_execution_hook(None)
+
+        call_count = {"n": 0}
+
+        async def _should_not_be_called(payload):
+            call_count["n"] += 1
+
+        # We do NOT register the above; hook remains None
+        fake_chain = MagicMock()
+        fake_chain.ainvoke = AsyncMock(return_value=_make_fake_result())
+
+        try:
+            with patch("tools.agentTools.create_agent", new=AsyncMock(return_value=(fake_chain, None))), \
+                 patch("tools.agentTools.prepare_agent_config", return_value={"configurable": {}}), \
+                 patch("tools.agentTools.build_human_message", return_value=MagicMock()):
+
+                svc = AgentExecutionService.__new__(AgentExecutionService)
+                agent = _make_fake_agent(fake_app.app_id, fake_agent.agent_id)
+
+                # Should not raise
+                await svc._execute_agent_async(
+                    fresh_agent=agent,
+                    message="Hello",
+                    user_context={},
+                )
+                await _drain_tasks()
+        finally:
+            _hooks.register_execution_hook(original_hook)
+
+        assert call_count["n"] == 0, "No hook should be called when none is registered"

--- a/tests/integration/test_migration_metrics001.py
+++ b/tests/integration/test_migration_metrics001.py
@@ -1,0 +1,73 @@
+"""
+Integration tests for the metrics001 migration schema state.
+
+Verifies that the agent_execution_event and agent_tool_call tables exist
+with all expected columns, indexes, and enum types.
+
+These tests use the session-scoped test_engine fixture (schema created via
+Base.metadata.create_all which reflects all registered ORM models including
+the new AgentExecutionEvent and AgentToolCall models).
+"""
+import pytest
+from sqlalchemy import inspect, text
+
+
+class TestMetricsMigrationSchema:
+    """Verify the metrics001 migration produced the expected schema."""
+
+    def test_agent_execution_event_table_exists(self, test_engine):
+        inspector = inspect(test_engine)
+        assert "agent_execution_event" in inspector.get_table_names(), \
+            "agent_execution_event table not found"
+
+    def test_agent_tool_call_table_exists(self, test_engine):
+        inspector = inspect(test_engine)
+        assert "agent_tool_call" in inspector.get_table_names(), \
+            "agent_tool_call table not found"
+
+    def test_agent_execution_event_columns(self, test_engine):
+        inspector = inspect(test_engine)
+        columns = {col["name"] for col in inspector.get_columns("agent_execution_event")}
+        expected = {
+            "event_id", "app_id", "agent_id", "conversation_id", "user_id",
+            "api_key_id", "caller_type", "parent_execution_id", "started_at",
+            "finished_at", "duration_ms", "status", "error_code", "error_message",
+            "model_name", "ai_service_id", "input_tokens", "output_tokens",
+            "total_tokens", "tool_calls", "retrieved_docs", "had_files", "file_count",
+            "had_images", "output_parser_used", "parser_succeeded",
+            "prompt_chars", "response_chars", "created_at",
+        }
+        missing = expected - columns
+        assert not missing, f"agent_execution_event missing columns: {missing}"
+
+    def test_agent_tool_call_columns(self, test_engine):
+        inspector = inspect(test_engine)
+        columns = {col["name"] for col in inspector.get_columns("agent_tool_call")}
+        expected = {
+            "tool_call_id", "event_id", "tool_name", "tool_type",
+            "sub_agent_id", "mcp_config_id", "duration_ms", "status",
+            "error_message", "started_at",
+        }
+        missing = expected - columns
+        assert not missing, f"agent_tool_call missing columns: {missing}"
+
+    def test_enum_types_exist(self, test_engine):
+        """The four PostgreSQL enum types must exist."""
+        with test_engine.connect() as conn:
+            result = conn.execute(text(
+                "SELECT typname FROM pg_type WHERE typtype = 'e' "
+                "AND typname IN ("
+                "  'agent_execution_caller_type', 'agent_execution_status',"
+                "  'agent_tool_call_type', 'agent_tool_call_status'"
+                ")"
+            ))
+            found = {row[0] for row in result}
+
+        expected = {
+            "agent_execution_caller_type",
+            "agent_execution_status",
+            "agent_tool_call_type",
+            "agent_tool_call_status",
+        }
+        missing = expected - found
+        assert not missing, f"Missing enum types: {missing}"

--- a/tests/unit/services/test_metrics_hook_payload_builder.py
+++ b/tests/unit/services/test_metrics_hook_payload_builder.py
@@ -1,0 +1,116 @@
+"""Unit tests for the metrics payload builder and caller-type detection logic.
+
+These tests do NOT require a database connection or plugin installation.
+"""
+import sys
+import os
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure backend is on sys.path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', 'backend'))
+
+from services.agent_execution_service import _build_metrics_payload
+
+
+def _fake_agent(agent_id=1, app_id=2, ai_service_id=None, ai_service=None,
+                output_parser_id=None):
+    agent = MagicMock()
+    agent.agent_id = agent_id
+    agent.app_id = app_id
+    agent.ai_service_id = ai_service_id
+    agent.ai_service = ai_service
+    agent.output_parser_id = output_parser_id
+    return agent
+
+
+def _make_payload(**kwargs):
+    defaults = dict(
+        event_id="test-event-id",
+        fresh_agent=_fake_agent(),
+        user_context={},
+        started_at=datetime(2026, 1, 1, 12, 0, 0),
+        finished_at=datetime(2026, 1, 1, 12, 0, 5),
+        duration_ms=5000,
+        status="SUCCESS",
+        error_code=None,
+        error_message=None,
+        result=None,
+        image_files=[],
+        message="Hello agent",
+    )
+    defaults.update(kwargs)
+    return _build_metrics_payload(**defaults)
+
+
+# ── Token extraction ──────────────────────────────────────────────────────────
+
+class TestTokenExtraction:
+    def _make_message_with_usage(self, input_tokens, output_tokens, total_tokens):
+        msg = MagicMock()
+        msg.usage_metadata = {
+            'input_tokens': input_tokens,
+            'output_tokens': output_tokens,
+            'total_tokens': total_tokens,
+        }
+        msg.content = "response text"
+        msg.tool_calls = None
+        return msg
+
+    def test_happy_path_tokens(self):
+        msg = self._make_message_with_usage(100, 50, 150)
+        result = {'messages': [msg]}
+        payload = _make_payload(result=result)
+        event = payload['event']
+        assert event['input_tokens'] == 100
+        assert event['output_tokens'] == 50
+        assert event['total_tokens'] == 150
+
+    def test_missing_usage_metadata(self):
+        msg = MagicMock()
+        msg.usage_metadata = None
+        msg.content = "text"
+        msg.tool_calls = None
+        result = {'messages': [msg]}
+        payload = _make_payload(result=result)
+        event = payload['event']
+        assert event['input_tokens'] is None
+        assert event['output_tokens'] is None
+        assert event['total_tokens'] is None
+
+    def test_empty_messages_list(self):
+        result = {'messages': []}
+        payload = _make_payload(result=result)
+        event = payload['event']
+        assert event['input_tokens'] is None
+        assert event['output_tokens'] is None
+        assert event['total_tokens'] is None
+
+
+# ── Caller type detection ─────────────────────────────────────────────────────
+
+class TestCallerTypeDetection:
+    def test_playground_default(self):
+        payload = _make_payload(user_context={})
+        assert payload['event']['caller_type'] == "INTERNAL_PLAYGROUND"
+
+    def test_public_api(self):
+        payload = _make_payload(user_context={'api_key_id': 5})
+        assert payload['event']['caller_type'] == "PUBLIC_API"
+
+    def test_mcp(self):
+        payload = _make_payload(user_context={'mcp_caller': True})
+        assert payload['event']['caller_type'] == "MCP"
+
+    def test_agent_as_tool(self):
+        payload = _make_payload(user_context={'parent_execution_id': 'some-uuid'})
+        assert payload['event']['caller_type'] == "AGENT_AS_TOOL"
+
+    def test_override_takes_priority(self):
+        payload = _make_payload(user_context={
+            'caller_type_override': 'AGENT_AS_TOOL',
+            'api_key_id': 5,
+        })
+        assert payload['event']['caller_type'] == "AGENT_AS_TOOL"

--- a/tests/unit/services/test_metrics_range_parser.py
+++ b/tests/unit/services/test_metrics_range_parser.py
@@ -1,0 +1,41 @@
+"""Unit tests for the _parse_range helper in mattin_metrics.service."""
+import sys
+import os
+from datetime import datetime, timedelta
+
+import pytest
+
+# Add backend to path for the indirect FastAPI import in service.py
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', 'backend'))
+
+from mattin_metrics.service import _parse_range
+
+TOLERANCE_SECONDS = 10
+
+
+class TestParseRange:
+    def test_24h(self):
+        before = datetime.utcnow() - timedelta(hours=24)
+        since, bucket_label, _ = _parse_range("24h")
+        after = datetime.utcnow() - timedelta(hours=24)
+        # since should be approximately 24h ago
+        assert abs((since - before).total_seconds()) < TOLERANCE_SECONDS
+        assert bucket_label == "1h"
+
+    def test_7d(self):
+        before = datetime.utcnow() - timedelta(days=7)
+        since, bucket_label, _ = _parse_range("7d")
+        after = datetime.utcnow() - timedelta(days=7)
+        assert abs((since - before).total_seconds()) < TOLERANCE_SECONDS
+        assert bucket_label == "6h"
+
+    def test_30d(self):
+        before = datetime.utcnow() - timedelta(days=30)
+        since, bucket_label, _ = _parse_range("30d")
+        after = datetime.utcnow() - timedelta(days=30)
+        assert abs((since - before).total_seconds()) < TOLERANCE_SECONDS
+        assert bucket_label == "1d"
+
+    def test_invalid_range(self):
+        with pytest.raises(ValueError, match="Invalid range"):
+            _parse_range("invalid")


### PR DESCRIPTION
## Summary

- Adds full agent observability as an Enterprise Edition plugin — token usage, latency, error rates, tool calls, per-user breakdown, all stored natively in PostgreSQL
- Core repo carries the DB schema, ORM models, hook registration slot, and React frontend; business logic lives in the `mattin-ai-plugins/mattin_metrics` package
- Capability-gated in the nav (`enterpriseFeature: 'metrics'`): greyed-out with EE badge when plugin is absent, fully functional dashboard when installed

## What ships

**Backend (core)**
- `alembic/versions/metrics001_agent_metrics_tables.py` — migration for `agent_execution_event` + `agent_tool_call` tables
- ORM models: `AgentExecutionEvent`, `AgentToolCall` + 4 enum types
- `backend/services/metrics_hooks.py` — no-op hook slot; plugin replaces it at startup via `register_execution_hook()`
- Instrumentation added to **both** `AgentExecutionService._execute_agent_async` (non-streaming) and `AgentStreamingService.stream_agent_chat` (streaming) — the streaming path was previously entirely bypassed
- Model name correctly sourced from `ai_service.description` (the field all LLM provider constructors actually use)

**Frontend (core)**
- `AppMetricsPage` — KPI cards, executions timeline, agents breakdown, by-model breakdown, top-users table
- 9 reusable chart/table components under `frontend/src/components/metrics/`
- EE upsell screen shown when capability absent
- `recharts` added as dependency

**Plugin (`mattin-ai-plugins`)**
- `mattin_metrics/` package with plugin entry-point, 14 REST endpoints (app-level ADMINISTRATOR, agent-level EDITOR), `MetricsQueryService`, write-path hook, and Pydantic schemas

## Test plan

- [ ] `alembic upgrade head` applies cleanly; `alembic downgrade -1` rolls back without errors
- [ ] Start server **without** the plugin — Metrics nav item shows greyed/EE badge, clicking it opens the upsell page
- [ ] Install plugin (`pip install -e mattin-ai-plugins`), restart — Metrics nav item active
- [ ] Chat with an agent (playground); row appears in `agent_execution_event` within seconds
- [ ] Chat via streaming endpoint (`/chat/stream`); row also appears (streaming path fix)
- [ ] `model_name` column is populated (not NULL) for all rows
- [ ] App Metrics page loads all 5 API calls, charts render, by-model table shows model names
- [ ] Agent-level metrics tab on AgentFormPage loads summary, executions, tokens, errors, latency, tools, users charts
- [ ] Integration tests pass: `pytest tests/integration/test_metrics_*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)