### PR TITLE
Map unauthorized provider errors to HTTP 400

### DIFF
--- a/backend/services/provider_models_service.py
+++ b/backend/services/provider_models_service.py
@@ -58,7 +58,10 @@ _DISPATCH: Dict[str, str] = {
 
 PROVIDER_ERROR_STATUS: Dict[str, int] = {
     "invalid_request": 400,
-    "unauthorized": 401,
+    # Provider authentication failures (invalid external API keys) were being mapped to HTTP 401. 
+    # The frontend treats any 401 as a user authentication failure and clears the session. 
+    # External provider credential errors are configuration errors, not user authentication failures, so they are now mapped to HTTP 400.
+    "unauthorized": 400,
     "not_found": 404,
     "timeout": 408,
     "network": 502,


### PR DESCRIPTION
# Pull Request Template for Mattin AI Repository

## Description

This pull request changes the HTTP status code returned for provider authenticatino errors during AI model listing operations.

Previously, provider authentication failures (for example, an invalid OpenAI API key) where mapped to `401 Unauthorized`, which caused the frontend to interpret the response as a user authentication failure and automatically log the user out.

The mapping has been updated so that the provider authentication errors return `400 Bad Request` instead. This allows the frontend to display the provider-specific error message without triggering the application's logout flow.

## Related Issue(s)

No related issue was created.

This change addresses an application behviour where invalid third-party AI provider credentials caused unintended user logout events.

## Type of Change

Please check the option that best describes the purpose of this pull request:

* [X] Bug fix (a change that does not break existing functionality and fixes an issue)
* [ ] Feature (a change that does not break existing functionality and adds new functionality)
* [ ] Documentation (updates or adds documentation only)
* [ ] Refactor (code change that neither fixes a bug nor adds a feature)
* [ ] Performance improvement
* [ ] Test (adding or updating tests)
* [ ] Build or infrastructure (changes to tooling, deployment scripts, CI/CD, etc.)

## Dependencies Added

None

## Affected Components

Backend (FastAPI)

The change affects the provider error handling logic used when listing AI provider models.

## Implementation Details

The mapping of provider-specific errors was updated from:

```
PROVIDER_ERROR_STATUS = {
    "unauthorized": 401,
}
```

to:

```
PROVIDER_ERROR_STATUS = {
    "unauthorized": 400,
}
```

This mapping is only used when handling `ProviderListingError` exceptions generated by external AI providers.

User authentication and authorization flows remain unchanged and contine to return `401 Unauthorized` where appropiate.

As a result:

- Invalid AI provider credentials no longer trigger authomatic frontend logout.
- Real user authentication failures continue to behave exactly as before.

## How to Test

### Test 1 – Invalid AI Provider Credentials
1. Configure an invalid API key for an AI provider (e.g. OpenAI).
2. Call the endpoint that lists available models.
3. Verify that:
    - The API returns HTTP 400.
    - The provider error message is displayed.
    - The user session remains active.
    - No automatic logout occurs.
### Test 2 – Invalid User Authentication Token

1. Replace the application's JWT token with an invalid value.
2. Access a protected endpoint.
3. Verify that:
    - The API returns HTTP 401.
    - The frontend executes its normal authentication failure flow.
    - The user is logged out.

## Checklist
Before submitting, please confirm that you have completed the following. Replace the empty square brackets with an `x` to indicate completion.

* [ ] All commits in this pull request are signed using GPG, as required by our commit signing policy (see `.github/instructions/git-github.instructions.md`).
* [X] I have read the contributing guidelines and my change adheres to the coding standards of this project (see `docs/README.md#contributing`).
* [ ] I have added tests that prove my fix or feature works, or confirm that tests are not needed for this change.
* [ ] I have run all existing tests and they all pass locally.
* [ ] I have updated any relevant documentation, configuration files, or environment examples as needed.
* [X] I have considered backwards compatibility and ensured that my change does not break existing functionality.
* [ ] For UI changes, I have included relevant screenshots or screencasts.

## Additional Notes

This change is intentionally limited to provider-generated authentication errors handled through `ProviderListingError`.

No changes were made to user authentication, authorization, JWT validation, or frontend logout logic. The objective is solely to prevent external provider credential issues from being interpreted as application authentication failures.