### PR TITLE
feat(backend,frontend): add AWS Bedrock as AI and embedding service provider

### DIFF
--- a/alembic/versions/bedrock001_add_extra_config_to_services.py
+++ b/alembic/versions/bedrock001_add_extra_config_to_services.py
@@ -1,0 +1,31 @@
+"""add extra_config to AIService and embedding_service
+
+Adds a nullable JSON-as-text column ``extra_config`` to both service
+tables. Providers whose access requires more than a single api_key
+(e.g. AWS Bedrock, which needs an access key id + region alongside the
+secret) store the extra parameters here.
+
+Revision ID: bedrock001
+Revises: merge001_userdel_platform_role
+Create Date: 2026-06-26 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'bedrock001'
+down_revision = 'merge001_userdel_platform_role'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('AIService', sa.Column('extra_config', sa.Text(), nullable=True))
+    op.add_column('embedding_service', sa.Column('extra_config', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('embedding_service', 'extra_config')
+    op.drop_column('AIService', 'extra_config')

--- a/alembic/versions/bedrock001_add_extra_config_to_services.py
+++ b/alembic/versions/bedrock001_add_extra_config_to_services.py
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'bedrock001'
-down_revision = 'merge001_userdel_platform_role'
+down_revision = 'd3adbeef1234'
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/d3adbeef1234_add_excluded_count_to_crawl_job.py
+++ b/alembic/versions/d3adbeef1234_add_excluded_count_to_crawl_job.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd3adbeef1234'
-down_revision = None
+down_revision = 'merge001_userdel_platform_role'
 branch_labels = None
 depends_on = None
 

--- a/backend/models/ai_service.py
+++ b/backend/models/ai_service.py
@@ -12,6 +12,7 @@ class ProviderEnum(enum.Enum):
     Google = "Google"
     GoogleCloud = "GoogleCloud"
     OpenRouter = "OpenRouter"
+    Bedrock = "Bedrock"
 
 class AIService(BaseService):
     __tablename__ = 'AIService'

--- a/backend/models/base_service.py
+++ b/backend/models/base_service.py
@@ -11,4 +11,10 @@ class BaseService(Base):
     endpoint = Column(String(255), nullable=True)
     api_key = Column(Text, nullable=True)
     description = Column(String(1000), nullable=True)
-    api_version = Column(String(50), nullable=True) 
+    api_version = Column(String(50), nullable=True)
+    # Provider-specific configuration that does not fit the standard
+    # columns above, stored as a JSON object. Used by providers whose
+    # access requires more than a single api_key — e.g. AWS Bedrock keeps
+    # {"aws_access_key_id": ..., "aws_region": ...} here while the secret
+    # access key reuses the masked `api_key` column.
+    extra_config = Column(Text, nullable=True)

--- a/backend/models/embedding_service.py
+++ b/backend/models/embedding_service.py
@@ -11,6 +11,7 @@ class EmbeddingProvider(enum.Enum):
     Azure = "Azure"
     Google = "Google"
     GoogleCloud = "GoogleCloud"
+    Bedrock = "Bedrock"
 
 class EmbeddingService(BaseService):
     __tablename__ = 'embedding_service'

--- a/backend/routers/internal/admin.py
+++ b/backend/routers/internal/admin.py
@@ -703,6 +703,7 @@ async def list_system_ai_services(
     """List all platform-level AI Services (OMNIADMIN only, available in all deployment modes)."""
     from repositories.ai_service_repository import AIServiceRepository
     from utils.secret_utils import mask_api_key
+    from tools.aws_bedrock_utils import parse_extra_config
     services = AIServiceRepository.get_system_services(db)
     return [
         AIServiceDetailSchema(
@@ -713,6 +714,8 @@ async def list_system_ai_services(
             api_key=mask_api_key(svc.api_key) if svc.api_key else "",
             base_url=svc.endpoint or "",
             created_at=svc.create_date,
+            aws_access_key_id=parse_extra_config(svc.extra_config).get("aws_access_key_id"),
+            aws_region=parse_extra_config(svc.extra_config).get("aws_region"),
         )
         for svc in services
     ]
@@ -727,10 +730,12 @@ async def get_system_ai_service(
     """Get a single platform-level AI Service by ID (OMNIADMIN only)."""
     from repositories.ai_service_repository import AIServiceRepository
     from utils.secret_utils import mask_api_key
+    from tools.aws_bedrock_utils import parse_extra_config
 
     svc = AIServiceRepository.get_by_id(db, service_id)
     if not svc or svc.app_id is not None:
         raise HTTPException(status_code=404, detail=SYSTEM_AI_SERVICE_NOT_FOUND)
+    extra_cfg = parse_extra_config(svc.extra_config)
     return AIServiceDetailSchema(
         service_id=svc.service_id,
         name=svc.name,
@@ -739,6 +744,8 @@ async def get_system_ai_service(
         api_key=mask_api_key(svc.api_key) if svc.api_key else "",
         base_url=svc.endpoint or "",
         created_at=svc.create_date,
+        aws_access_key_id=extra_cfg.get("aws_access_key_id"),
+        aws_region=extra_cfg.get("aws_region"),
     )
 
 
@@ -752,6 +759,7 @@ async def create_system_ai_service(
     from models.ai_service import AIService
     from repositories.ai_service_repository import AIServiceRepository
     from services.ai_service_service import AIServiceService
+    from tools.aws_bedrock_utils import build_extra_config
     from datetime import datetime
 
     svc = AIService()
@@ -761,6 +769,7 @@ async def create_system_ai_service(
     svc.description = body.model_name  # stored in description column
     svc.api_key = body.api_key
     svc.endpoint = body.base_url or ""
+    svc.extra_config = build_extra_config(body.aws_access_key_id, body.aws_region)
     svc.create_date = datetime.now()
     svc = AIServiceRepository.create(db, svc)
     return AIServiceService._to_list_item(svc, is_system=True)
@@ -777,6 +786,7 @@ async def update_system_ai_service(
     from repositories.ai_service_repository import AIServiceRepository
     from services.ai_service_service import AIServiceService
     from utils.secret_utils import is_masked_key
+    from tools.aws_bedrock_utils import build_extra_config
 
     svc = AIServiceRepository.get_by_id(db, service_id)
     if not svc or svc.app_id is not None:
@@ -788,6 +798,7 @@ async def update_system_ai_service(
     if not is_masked_key(body.api_key):
         svc.api_key = body.api_key
     svc.endpoint = body.base_url or ""
+    svc.extra_config = build_extra_config(body.aws_access_key_id, body.aws_region)
     svc = AIServiceRepository.update(db, svc)
     return AIServiceService._to_list_item(svc, is_system=True)
 
@@ -815,6 +826,7 @@ async def list_system_embedding_services(
     """List all platform-level Embedding Services (OMNIADMIN only)."""
     from repositories.embedding_service_repository import EmbeddingServiceRepository
     from utils.secret_utils import mask_api_key
+    from tools.aws_bedrock_utils import parse_extra_config
     services = EmbeddingServiceRepository.get_system_services(db)
     return [
         EmbeddingServiceDetailSchema(
@@ -826,6 +838,8 @@ async def list_system_embedding_services(
             base_url=svc.endpoint or "",
             api_version=svc.api_version,
             created_at=svc.create_date,
+            aws_access_key_id=parse_extra_config(svc.extra_config).get("aws_access_key_id"),
+            aws_region=parse_extra_config(svc.extra_config).get("aws_region"),
         )
         for svc in services
     ]
@@ -841,6 +855,7 @@ async def create_system_embedding_service(
     from models.embedding_service import EmbeddingService
     from repositories.embedding_service_repository import EmbeddingServiceRepository
     from services.embedding_service_service import EmbeddingServiceService
+    from tools.aws_bedrock_utils import build_extra_config
     from datetime import datetime
 
     svc = EmbeddingService()
@@ -851,6 +866,7 @@ async def create_system_embedding_service(
     svc.api_key = body.api_key
     svc.endpoint = body.base_url or ""
     svc.api_version = body.api_version
+    svc.extra_config = build_extra_config(body.aws_access_key_id, body.aws_region)
     svc.create_date = datetime.now()
     svc = EmbeddingServiceRepository.create(db, svc)
     return EmbeddingServiceService._to_list_item(svc, is_system=True)
@@ -867,6 +883,7 @@ async def update_system_embedding_service(
     from repositories.embedding_service_repository import EmbeddingServiceRepository
     from services.embedding_service_service import EmbeddingServiceService
     from utils.secret_utils import is_masked_key
+    from tools.aws_bedrock_utils import build_extra_config
 
     svc = EmbeddingServiceRepository.get_by_id(db, service_id)
     if not svc or svc.app_id is not None:
@@ -879,6 +896,7 @@ async def update_system_embedding_service(
         svc.api_key = body.api_key
     svc.endpoint = body.base_url or ""
     svc.api_version = body.api_version
+    svc.extra_config = build_extra_config(body.aws_access_key_id, body.aws_region)
     svc = EmbeddingServiceRepository.update(db, svc)
     return EmbeddingServiceService._to_list_item(svc, is_system=True)
 
@@ -1009,6 +1027,7 @@ async def test_system_ai_service_connection_with_config(
     from repositories.ai_service_repository import AIServiceRepository
     from utils.secret_utils import is_masked_key
     from core.export_constants import PLACEHOLDER_API_KEY
+    from tools.aws_bedrock_utils import build_extra_config
 
     try:
         api_key = config.api_key or ""
@@ -1028,6 +1047,10 @@ async def test_system_ai_service_connection_with_config(
             "api_key": api_key,
             "endpoint": config.base_url,
             "api_version": getattr(config, "api_version", None),
+            "extra_config": build_extra_config(
+                getattr(config, "aws_access_key_id", None),
+                getattr(config, "aws_region", None),
+            ),
         }
         result = AIServiceService.test_connection_with_config(service_config)
         if isinstance(result, dict) and len(str(result.get("response", ""))) > 500:
@@ -1268,6 +1291,7 @@ async def test_system_embedding_service_connection_with_config(
     from repositories.embedding_service_repository import EmbeddingServiceRepository
     from utils.secret_utils import is_masked_key
     from core.export_constants import PLACEHOLDER_API_KEY
+    from tools.aws_bedrock_utils import build_extra_config
 
     try:
         api_key = config.api_key or ""
@@ -1286,6 +1310,10 @@ async def test_system_embedding_service_connection_with_config(
             "api_key": api_key,
             "endpoint": config.base_url,
             "api_version": config.api_version,
+            "extra_config": build_extra_config(
+                getattr(config, "aws_access_key_id", None),
+                getattr(config, "aws_region", None),
+            ),
         }
         return EmbeddingServiceService.test_connection_with_config(service_config)
     except HTTPException:

--- a/backend/routers/internal/ai_services.py
+++ b/backend/routers/internal/ai_services.py
@@ -125,6 +125,7 @@ async def test_ai_service_connection_with_config(
     from utils.secret_utils import is_masked_key
     from core.export_constants import PLACEHOLDER_API_KEY
     from repositories.ai_service_repository import AIServiceRepository
+    from tools.aws_bedrock_utils import build_extra_config
 
     try:
         # If user sent a masked placeholder, fall back to the stored key.
@@ -145,7 +146,11 @@ async def test_ai_service_connection_with_config(
             "description": config.model_name,
             "api_key": api_key,
             "endpoint": config.base_url,
-            "api_version": getattr(config, 'api_version', None)
+            "api_version": getattr(config, 'api_version', None),
+            "extra_config": build_extra_config(
+                getattr(config, 'aws_access_key_id', None),
+                getattr(config, 'aws_region', None),
+            ),
         }
         result = AIServiceService.test_connection_with_config(service_config)
         

--- a/backend/routers/internal/embedding_services.py
+++ b/backend/routers/internal/embedding_services.py
@@ -129,6 +129,7 @@ async def test_embedding_service_connection_with_config(
     from utils.secret_utils import is_masked_key
     from core.export_constants import PLACEHOLDER_API_KEY
     from repositories.embedding_service_repository import EmbeddingServiceRepository
+    from tools.aws_bedrock_utils import build_extra_config
 
     try:
         api_key = config.api_key or ""
@@ -147,6 +148,10 @@ async def test_embedding_service_connection_with_config(
             "api_key": api_key,
             "endpoint": config.base_url,
             "api_version": config.api_version,
+            "extra_config": build_extra_config(
+                getattr(config, 'aws_access_key_id', None),
+                getattr(config, 'aws_region', None),
+            ),
         }
         result = EmbeddingServiceService.test_connection_with_config(service_config)
         return result

--- a/backend/schemas/ai_service_schemas.py
+++ b/backend/schemas/ai_service_schemas.py
@@ -31,6 +31,9 @@ class AIServiceDetailSchema(BaseModel):
     created_at: Optional[datetime] = None
     available_providers: List[Dict[str, Any]] = []
     needs_api_key: bool = False
+    # AWS Bedrock identifiers (non-secret). Empty for other providers.
+    aws_access_key_id: Optional[str] = None
+    aws_region: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -43,8 +46,12 @@ class CreateUpdateAIServiceSchema(BaseModel):
     api_key: str
     base_url: Optional[str] = ""
     supports_video: bool = False
+    # AWS Bedrock identifiers (non-secret). The secret access key is sent
+    # via ``api_key``; the access key id and region travel here.
+    aws_access_key_id: Optional[str] = None
+    aws_region: Optional[str] = None
 
-    @field_validator("api_key", "base_url", mode="before")
+    @field_validator("api_key", "base_url", "aws_access_key_id", "aws_region", mode="before")
     @classmethod
     def _strip_credentials(cls, v):
         # Trim whitespace/newlines that often sneak in when pasting from

--- a/backend/schemas/embedding_service_schemas.py
+++ b/backend/schemas/embedding_service_schemas.py
@@ -30,7 +30,10 @@ class EmbeddingServiceDetailSchema(BaseModel):
     created_at: Optional[datetime] = None
     available_providers: List[Dict[str, Any]] = []
     needs_api_key: bool = False
-    
+    # AWS Bedrock identifiers (non-secret). Empty for other providers.
+    aws_access_key_id: Optional[str] = None
+    aws_region: Optional[str] = None
+
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -42,8 +45,12 @@ class CreateUpdateEmbeddingServiceSchema(BaseModel):
     api_key: str
     base_url: Optional[str] = ""
     api_version: Optional[str] = None
+    # AWS Bedrock identifiers (non-secret). The secret access key is sent
+    # via ``api_key``; the access key id and region travel here.
+    aws_access_key_id: Optional[str] = None
+    aws_region: Optional[str] = None
 
-    @field_validator("api_key", "base_url", "api_version", mode="before")
+    @field_validator("api_key", "base_url", "api_version", "aws_access_key_id", "aws_region", mode="before")
     @classmethod
     def _strip_credentials(cls, v):
         # Trim whitespace/newlines that often sneak in when pasting from

--- a/backend/schemas/provider_models_schemas.py
+++ b/backend/schemas/provider_models_schemas.py
@@ -72,8 +72,13 @@ class ListProviderModelsRequest(BaseModel):
     base_url: Optional[str] = ""
     api_version: Optional[str] = None
     purpose: ListPurpose = "chat"
+    # AWS Bedrock identifiers. The secret access key travels in ``api_key``
+    # (reusing the masking machinery); the access key id and region are
+    # non-secret and carried here.
+    aws_access_key_id: Optional[str] = None
+    aws_region: Optional[str] = None
 
-    @field_validator("api_key", "base_url", mode="before")
+    @field_validator("api_key", "base_url", "aws_access_key_id", "aws_region", mode="before")
     @classmethod
     def _strip_credentials(cls, v):
         return v.strip() if isinstance(v, str) else v

--- a/backend/services/ai_service_service.py
+++ b/backend/services/ai_service_service.py
@@ -8,6 +8,7 @@ from schemas.ai_service_schemas import (
 )
 from core.export_constants import PLACEHOLDER_API_KEY
 from utils.secret_utils import mask_api_key, is_masked_key
+from tools.aws_bedrock_utils import build_extra_config, parse_extra_config
 from datetime import datetime
 from typing import List
 from tools.aiServiceTools import create_llm_from_service
@@ -82,6 +83,7 @@ class AIServiceService:
             not service.api_key
             or service.api_key == PLACEHOLDER_API_KEY
         )
+        extra_cfg = parse_extra_config(service.extra_config)
         return AIServiceDetailSchema(
             service_id=service.service_id,
             name=service.name,
@@ -93,6 +95,8 @@ class AIServiceService:
             created_at=service.create_date,
             available_providers=providers,
             needs_api_key=needs_api_key,
+            aws_access_key_id=extra_cfg.get("aws_access_key_id"),
+            aws_region=extra_cfg.get("aws_region"),
         )
     
     @staticmethod
@@ -126,6 +130,11 @@ class AIServiceService:
             service.api_key = service_data.api_key
         service.endpoint = service_data.base_url  # Store base_url in endpoint
         service.supports_video = service_data.supports_video
+        # Persist provider-specific identifiers (AWS Bedrock) as JSON.
+        service.extra_config = build_extra_config(
+            service_data.aws_access_key_id,
+            service_data.aws_region,
+        )
         
         # Create or update the service
         if service_id == 0:
@@ -161,6 +170,7 @@ class AIServiceService:
             api_key=service.api_key,
             endpoint=service.endpoint,
             supports_video=service.supports_video or False,
+            extra_config=service.extra_config,
             create_date=datetime.now()
         )
         
@@ -192,6 +202,7 @@ class AIServiceService:
                     self.api_key = data.get('api_key')
                     self.endpoint = data.get('endpoint')
                     self.api_version = data.get('api_version')
+                    self.extra_config = data.get('extra_config')
             
             service = MockAIService(config)
             

--- a/backend/services/embedding_service_service.py
+++ b/backend/services/embedding_service_service.py
@@ -8,6 +8,7 @@ from schemas.embedding_service_schemas import (
 )
 from core.export_constants import PLACEHOLDER_API_KEY
 from utils.secret_utils import mask_api_key, is_masked_key
+from tools.aws_bedrock_utils import build_extra_config, parse_extra_config
 from typing import List, Optional
 from datetime import datetime
 
@@ -71,6 +72,7 @@ class EmbeddingServiceService:
             not service.api_key
             or service.api_key == PLACEHOLDER_API_KEY
         )
+        extra_cfg = parse_extra_config(service.extra_config)
         return EmbeddingServiceDetailSchema(
             service_id=service.service_id,
             name=service.name,
@@ -82,6 +84,8 @@ class EmbeddingServiceService:
             created_at=service.create_date,
             available_providers=providers,
             needs_api_key=needs_api_key,
+            aws_access_key_id=extra_cfg.get("aws_access_key_id"),
+            aws_region=extra_cfg.get("aws_region"),
         )
 
     @staticmethod
@@ -113,6 +117,11 @@ class EmbeddingServiceService:
             service.api_key = service_data.api_key
         service.endpoint = service_data.base_url
         service.api_version = service_data.api_version
+        # Persist provider-specific identifiers (AWS Bedrock) as JSON.
+        service.extra_config = build_extra_config(
+            service_data.aws_access_key_id,
+            service_data.aws_region,
+        )
         
         if service_id == 0:
             return EmbeddingServiceRepository.create(db, service)
@@ -178,6 +187,7 @@ class EmbeddingServiceService:
                 self.api_key = data.get("api_key")
                 self.endpoint = data.get("endpoint")
                 self.api_version = data.get("api_version")
+                self.extra_config = data.get("extra_config")
 
         try:
             embeddings = get_embeddings_model(_MockEmbeddingService(config))

--- a/backend/services/provider_models_service.py
+++ b/backend/services/provider_models_service.py
@@ -24,6 +24,7 @@ from tools.ai import provider_model_clients
 from tools.ai.model_catalog import (
     MANUAL_INPUT_PROVIDERS,
     PROVIDER_ANTHROPIC,
+    PROVIDER_BEDROCK,
     PROVIDER_CUSTOM,
     PROVIDER_GOOGLE,
     PROVIDER_MISTRAL,
@@ -50,6 +51,7 @@ _DISPATCH: Dict[str, str] = {
     PROVIDER_GOOGLE: "list_google_models",
     PROVIDER_OLLAMA: "list_ollama_models",
     PROVIDER_OPENROUTER: "list_openrouter_models",
+    PROVIDER_BEDROCK: "list_bedrock_models",
     # Custom is handled in-line: the AI Service runtime is ChatOllama, so
     # listing reuses the Ollama tags endpoint. Embeddings under Custom
     # use HuggingFace Inference which has no generic listing — those go
@@ -139,6 +141,10 @@ class ProviderModelsService:
         if req.provider in (PROVIDER_OLLAMA, PROVIDER_CUSTOM, PROVIDER_OPENROUTER):
             return
 
+        if req.provider == PROVIDER_BEDROCK:
+            ProviderModelsService._validate_bedrock_credentials(req)
+            return
+
         api_key = req.api_key or ""
         if not api_key or api_key == PLACEHOLDER_API_KEY:
             raise ProviderListingError(
@@ -149,6 +155,34 @@ class ProviderModelsService:
             raise ProviderListingError(
                 "invalid_request",
                 "Re-enter the API key — the masked value cannot be used to list models.",
+            )
+
+    @staticmethod
+    def _validate_bedrock_credentials(req: ListProviderModelsRequest) -> None:
+        """Bedrock needs an access key id + region alongside the secret.
+
+        The secret access key travels in ``api_key`` (so it reuses the
+        masking machinery); the access key id and region are non-secret
+        identifiers carried in dedicated fields.
+        """
+        access_key_id = (req.aws_access_key_id or "").strip()
+        region = (req.aws_region or "").strip()
+        secret = req.api_key or ""
+
+        if not access_key_id or not region:
+            raise ProviderListingError(
+                "invalid_request",
+                "AWS Access Key ID and Region are required to list Bedrock models.",
+            )
+        if not secret or secret == PLACEHOLDER_API_KEY:
+            raise ProviderListingError(
+                "invalid_request",
+                "AWS Secret Access Key is required to list Bedrock models.",
+            )
+        if is_masked_key(secret):
+            raise ProviderListingError(
+                "invalid_request",
+                "Re-enter the AWS Secret Access Key — the masked value cannot be used to list models.",
             )
 
     @staticmethod

--- a/backend/tools/ai/model_catalog.py
+++ b/backend/tools/ai/model_catalog.py
@@ -46,6 +46,7 @@ PROVIDER_CUSTOM = "Custom"
 PROVIDER_AZURE = "Azure"
 PROVIDER_GOOGLE_CLOUD = "GoogleCloud"
 PROVIDER_OPENROUTER = "OpenRouter"
+PROVIDER_BEDROCK = "Bedrock"
 
 MANUAL_INPUT_PROVIDERS = frozenset({PROVIDER_AZURE, PROVIDER_GOOGLE_CLOUD})
 
@@ -103,6 +104,7 @@ _EMBEDDING_PATTERNS = (
     re.compile(r"^text-embedding"),
     re.compile(r"^embed"),
     re.compile(r"-embed(?:ding)?(?:-|$)"),
+    re.compile(r"\.embed"),  # Bedrock style, e.g. cohere.embed-multilingual-v3
     re.compile(r"-bge-"),
     re.compile(r"^bge-"),
     re.compile(r"^nomic-embed"),

--- a/backend/tools/ai/provider_model_clients.py
+++ b/backend/tools/ai/provider_model_clients.py
@@ -23,6 +23,7 @@ from schemas.provider_models_schemas import (
 )
 from tools.ai.model_catalog import (
     PROVIDER_ANTHROPIC,
+    PROVIDER_BEDROCK,
     PROVIDER_GOOGLE,
     PROVIDER_MISTRAL,
     PROVIDER_OLLAMA,
@@ -544,3 +545,117 @@ def list_openrouter_models(req: ListProviderModelsRequest) -> List[ProviderModel
         models.append(enrich(PROVIDER_OPENROUTER, model_id, base=base))
 
     return models
+
+
+# ==================== AWS BEDROCK ====================
+
+
+def list_bedrock_models(req: ListProviderModelsRequest) -> List[ProviderModelInfo]:
+    """List foundation models available in an AWS Bedrock account.
+
+    Uses boto3's ``bedrock.list_foundation_models``. The result is filtered
+    to models that are ``ACTIVE`` and support ``ON_DEMAND`` invocation, so
+    the wizard only offers models that can be called directly. Note that a
+    model appearing here may still require explicit access activation in the
+    AWS console (Model access) before it can be invoked.
+    """
+    secret_access_key = req.api_key or ""
+    access_key_id = (req.aws_access_key_id or "").strip()
+    region = (req.aws_region or "").strip()
+
+    if not access_key_id or not secret_access_key or not region:
+        raise ProviderListingError(
+            "invalid_request",
+            "AWS Access Key ID, Secret Access Key and Region are required to list Bedrock models.",
+        )
+
+    try:
+        import boto3
+        from botocore.config import Config as _BotoConfig
+    except ImportError:
+        raise ProviderListingError(
+            "unsupported",
+            "AWS Bedrock support is not installed (langchain-aws / boto3 missing).",
+        )
+
+    boto_config = _BotoConfig(
+        connect_timeout=_DEFAULT_TIMEOUT_SECONDS,
+        read_timeout=_DEFAULT_TIMEOUT_SECONDS,
+        retries={"max_attempts": 1},
+    )
+
+    try:
+        client = boto3.client(
+            "bedrock",
+            region_name=region,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+            config=boto_config,
+        )
+        listing = client.list_foundation_models()
+    except Exception as exc:  # noqa: BLE001
+        from botocore.exceptions import (
+            ClientError,
+            EndpointConnectionError,
+            NoCredentialsError,
+        )
+
+        if isinstance(exc, NoCredentialsError):
+            code = "unauthorized"
+        elif isinstance(exc, ClientError):
+            error_code = exc.response.get("Error", {}).get("Code", "")
+            if error_code in ("UnrecognizedClientException", "InvalidSignatureException",
+                              "AccessDeniedException", "AuthFailure"):
+                code = "unauthorized"
+            elif error_code in ("ResourceNotFoundException",):
+                code = "not_found"
+            else:
+                code = "network"
+        elif isinstance(exc, EndpointConnectionError):
+            code = "network"
+        else:
+            code = "network"
+        sanitized = _sanitize(str(exc), secret_access_key, access_key_id)
+        logger.warning("Bedrock list failed (code=%s): %s", code, sanitized)
+        raise ProviderListingError(code, sanitized or "Bedrock listing failed")
+
+    models: List[ProviderModelInfo] = []
+    for raw in listing.get("modelSummaries", []) or []:
+        model_id = raw.get("modelId")
+        if not model_id:
+            continue
+
+        lifecycle_status = (raw.get("modelLifecycle") or {}).get("status")
+        if lifecycle_status and lifecycle_status != "ACTIVE":
+            continue
+
+        inference_types = raw.get("inferenceTypesSupported") or []
+        if inference_types and "ON_DEMAND" not in inference_types:
+            continue
+
+        input_modalities = set(raw.get("inputModalities") or [])
+        output_modalities = set(raw.get("outputModalities") or [])
+
+        caps = ProviderCapabilities()
+        if "EMBEDDING" in output_modalities:
+            caps.embedding = True
+        else:
+            if "TEXT" in output_modalities or not output_modalities:
+                caps.chat = True
+            if "IMAGE" in input_modalities:
+                caps.vision = True
+
+        display_name = raw.get("modelName") or model_id
+        owned_by = raw.get("providerName")
+
+        base = ProviderModelInfo(
+            id=model_id,
+            display_name=display_name,
+            owned_by=owned_by,
+            capabilities=caps,
+            source="api",
+        )
+        models.append(enrich(PROVIDER_BEDROCK, model_id, base=base))
+
+    return models
+

--- a/backend/tools/aiServiceTools.py
+++ b/backend/tools/aiServiceTools.py
@@ -1,4 +1,5 @@
 import base64
+import json
 from dotenv import load_dotenv
 from langchain_anthropic import ChatAnthropic
 from langchain_ollama import ChatOllama
@@ -62,6 +63,7 @@ def create_llm_from_service(ai_service, temperature=0, is_vision=False):
         ProviderEnum.Google.value: lambda: _build_google_llm(ai_service, temperature),
         ProviderEnum.GoogleCloud.value: lambda: _build_google_cloud_llm(ai_service, temperature),
         ProviderEnum.OpenRouter.value: lambda: _build_openrouter_llm(ai_service, temperature),
+        ProviderEnum.Bedrock.value: lambda: _build_bedrock_llm(ai_service, temperature),
     }
 
     # Handle case where provider might be an Enum object instead of string
@@ -221,6 +223,25 @@ def _build_azure_llm(ai_service, temperature):
         endpoint=ai_service.endpoint,
         api_version=ai_service.api_version,
     )
+
+
+def _build_bedrock_llm(ai_service, temperature):
+    from langchain_aws import ChatBedrockConverse
+
+    from tools.aws_bedrock_utils import resolve_bedrock_credentials
+
+    creds = resolve_bedrock_credentials(ai_service)
+    bedrock_kwargs = {
+        "model": ai_service.description,
+        "temperature": temperature,
+        **creds,
+    }
+
+    endpoint_raw = (ai_service.endpoint or "").strip()
+    if endpoint_raw:
+        bedrock_kwargs["endpoint_url"] = endpoint_raw
+
+    return ChatBedrockConverse(**bedrock_kwargs)
 
 
 _DEFAULT_GOOGLE_HOST = "generativelanguage.googleapis.com"

--- a/backend/tools/aws_bedrock_utils.py
+++ b/backend/tools/aws_bedrock_utils.py
@@ -1,0 +1,78 @@
+"""Helpers for AWS Bedrock credential handling.
+
+Bedrock needs three pieces of information that don't map onto the single
+``api_key`` column shared by every other provider:
+
+* ``aws_access_key_id`` and ``aws_region`` \u2014 stored as JSON in the
+  service's ``extra_config`` column (non-secret identifiers).
+* ``aws_secret_access_key`` \u2014 stored in the standard ``api_key`` column so
+  it reuses the existing masking / placeholder machinery.
+
+This module is intentionally dependency-free (no SQLAlchemy, no LangChain)
+so both the runtime builders (``aiServiceTools`` / ``embeddingTools``) and
+the listing adapter can import it without circular-import risk.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+# Default region used when a service has no region configured. Bedrock is
+# most widely available in us-east-1.
+DEFAULT_BEDROCK_REGION = "us-east-1"
+
+
+def parse_extra_config(raw: Any) -> dict:
+    """Parse a service ``extra_config`` value into a dict.
+
+    Accepts a JSON string, an already-parsed dict, or ``None``. Anything
+    malformed degrades to an empty dict rather than raising \u2014 a bad
+    config should surface as a clear "missing credentials" error later,
+    not a JSON traceback.
+    """
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+            return parsed if isinstance(parsed, dict) else {}
+        except (json.JSONDecodeError, ValueError):
+            return {}
+    return {}
+
+
+def build_extra_config(aws_access_key_id: Optional[str], aws_region: Optional[str]) -> Optional[str]:
+    """Serialise the non-secret Bedrock fields into an ``extra_config`` JSON string.
+
+    Returns ``None`` when both fields are empty so the column stays NULL
+    for non-Bedrock services.
+    """
+    data = {}
+    if aws_access_key_id:
+        data["aws_access_key_id"] = aws_access_key_id.strip()
+    if aws_region:
+        data["aws_region"] = aws_region.strip()
+    return json.dumps(data) if data else None
+
+
+def resolve_bedrock_credentials(service) -> dict:
+    """Build the boto3/LangChain kwargs for a Bedrock-backed service.
+
+    ``service`` may be an ORM model or any object exposing ``api_key`` and
+    ``extra_config`` attributes (e.g. the MockAIService used by the
+    connection tester).
+    """
+    cfg = parse_extra_config(getattr(service, "extra_config", None))
+    region = (cfg.get("aws_region") or "").strip() or DEFAULT_BEDROCK_REGION
+    access_key_id = (cfg.get("aws_access_key_id") or "").strip()
+    secret_access_key = (getattr(service, "api_key", None) or "").strip()
+
+    creds = {"region_name": region}
+    if access_key_id:
+        creds["aws_access_key_id"] = access_key_id
+    if secret_access_key:
+        creds["aws_secret_access_key"] = secret_access_key
+    return creds

--- a/backend/tools/embeddingTools.py
+++ b/backend/tools/embeddingTools.py
@@ -107,6 +107,21 @@ def _build_google_cloud_embeddings(embedding_service, model_id):
     )
 
 
+def _build_bedrock_embeddings(embedding_service, model_id):
+    from langchain_aws import BedrockEmbeddings
+
+    from tools.aws_bedrock_utils import resolve_bedrock_credentials
+
+    creds = resolve_bedrock_credentials(embedding_service)
+    kwargs = {"model_id": model_id, **creds}
+
+    endpoint_raw = (embedding_service.endpoint or "").strip()
+    if endpoint_raw:
+        kwargs["endpoint_url"] = endpoint_raw
+
+    return BedrockEmbeddings(**kwargs)
+
+
 _EMBEDDING_BUILDERS = {
     EmbeddingProvider.OpenAI.value: _build_openai_embeddings,
     EmbeddingProvider.MistralAI.value: _build_mistral_embeddings,
@@ -115,6 +130,7 @@ _EMBEDDING_BUILDERS = {
     EmbeddingProvider.Azure.value: _build_azure_embeddings,
     EmbeddingProvider.Google.value: _build_google_embeddings,
     EmbeddingProvider.GoogleCloud.value: _build_google_cloud_embeddings,
+    EmbeddingProvider.Bedrock.value: _build_bedrock_embeddings,
 }
 
 

--- a/frontend/src/components/services/CompactServiceEditor.tsx
+++ b/frontend/src/components/services/CompactServiceEditor.tsx
@@ -16,6 +16,12 @@ import type {
 
 const MASKED_KEY_PREFIX = '****';
 
+/** Provider-specific label for the secret field. */
+const API_KEY_LABELS: Record<string, string> = {
+  GoogleCloud: 'Service Account JSON',
+  Bedrock: 'AWS Secret Access Key',
+};
+
 interface CompactServiceEditorProps {
   readonly isOpen: boolean;
   readonly kind: ServiceKind;
@@ -46,6 +52,8 @@ function CompactServiceEditor({
   const [apiKeyChanged, setApiKeyChanged] = useState(false);
   const [baseUrl, setBaseUrl] = useState(service.base_url || '');
   const [apiVersion, setApiVersion] = useState(service.api_version || '');
+  const [awsAccessKeyId, setAwsAccessKeyId] = useState(service.aws_access_key_id || '');
+  const [awsRegion, setAwsRegion] = useState(service.aws_region || '');
   const [supportsVideo, setSupportsVideo] = useState(!!service.supports_video);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -58,6 +66,8 @@ function CompactServiceEditor({
     setApiKeyChanged(false);
     setBaseUrl(service.base_url || '');
     setApiVersion(service.api_version || '');
+    setAwsAccessKeyId(service.aws_access_key_id || '');
+    setAwsRegion(service.aws_region || '');
     setSupportsVideo(!!service.supports_video);
     setError(null);
   }, [service.service_id]);
@@ -65,10 +75,10 @@ function CompactServiceEditor({
   const showSupportsVideo =
     kind === 'ai' && (service.provider === 'Google' || service.provider === 'GoogleCloud');
   const showApiVersion = !!descriptor?.manualFields?.includes('api_version');
+  const showAwsFields = !!descriptor?.manualFields?.includes('aws_access_key_id');
   const baseUrlLabel =
     service.provider === 'GoogleCloud' ? 'GCP Project ID' : 'Base URL';
-  const apiKeyLabel =
-    service.provider === 'GoogleCloud' ? 'Service Account JSON' : 'API Key';
+  const apiKeyLabel = API_KEY_LABELS[service.provider] ?? 'API Key';
 
   const handleApiKeyFocus = () => {
     if (!apiKeyChanged && apiKey.startsWith(MASKED_KEY_PREFIX)) {
@@ -98,6 +108,8 @@ function CompactServiceEditor({
       base_url: baseUrl,
       api_version: apiVersion || undefined,
       supports_video: supportsVideo,
+      aws_access_key_id: showAwsFields ? awsAccessKeyId.trim() || undefined : undefined,
+      aws_region: showAwsFields ? awsRegion.trim() || undefined : undefined,
     };
     try {
       await onSave(payload);
@@ -210,6 +222,27 @@ function CompactServiceEditor({
               value={apiVersion}
               onChange={(e) => setApiVersion(e.target.value)}
             />
+          )}
+
+          {showAwsFields && (
+            <>
+              <FormField
+                id="aws_access_key_id"
+                label="AWS Access Key ID"
+                value={awsAccessKeyId}
+                onChange={(e) => setAwsAccessKeyId(e.target.value)}
+                placeholder="AKIA..."
+                required
+              />
+              <FormField
+                id="aws_region"
+                label="AWS Region"
+                value={awsRegion}
+                onChange={(e) => setAwsRegion(e.target.value)}
+                placeholder="us-east-1"
+                required
+              />
+            </>
           )}
 
           {showSupportsVideo && (

--- a/frontend/src/components/services/wizard/ServiceWizard.tsx
+++ b/frontend/src/components/services/wizard/ServiceWizard.tsx
@@ -80,6 +80,8 @@ function ServiceWizard({
         api_key: '',
         base_url: initialService.base_url || '',
         api_version: initialService.api_version || '',
+        aws_access_key_id: initialService.aws_access_key_id || '',
+        aws_region: initialService.aws_region || '',
       });
       setManualModelName(initialService.model_name || '');
       setSupportsVideo(!!initialService.supports_video);
@@ -117,10 +119,7 @@ function ServiceWizard({
       case 'provider':
         return !provider;
       case 'credentials':
-        if (!descriptor) return true;
-        if (descriptor.apiKey === 'required' && !credentials.api_key.trim()) return true;
-        if (descriptor.needsBaseUrl && !credentials.base_url.trim()) return true;
-        return false;
+        return isCredentialsStepDisabled(descriptor, credentials);
       case 'model':
         if (!descriptor?.supportsModelListing) return !manualModelName.trim();
         return !selectedModel;
@@ -166,6 +165,8 @@ function ServiceWizard({
       base_url: credentials.base_url,
       api_version: credentials.api_version || undefined,
       supports_video: supportsVideo,
+      aws_access_key_id: credentials.aws_access_key_id?.trim() || undefined,
+      aws_region: credentials.aws_region?.trim() || undefined,
     };
   };
 
@@ -298,6 +299,24 @@ function ensureUnique(base: string, existing: readonly string[]): string {
   let counter = 2;
   while (existing.includes(`${base} (${counter})`)) counter++;
   return `${base} (${counter})`;
+}
+
+/** Whether the credentials step is incomplete for the chosen provider. */
+function isCredentialsStepDisabled(
+  descriptor: ReturnType<typeof getProviderDescriptor>,
+  credentials: CredentialsState,
+): boolean {
+  if (!descriptor) return true;
+  if (descriptor.apiKey === 'required' && !credentials.api_key.trim()) return true;
+  if (descriptor.needsBaseUrl && !credentials.base_url.trim()) return true;
+  const manualFields = descriptor.manualFields ?? [];
+  if (manualFields.includes('aws_access_key_id') && !credentials.aws_access_key_id?.trim()) {
+    return true;
+  }
+  if (manualFields.includes('aws_region') && !credentials.aws_region?.trim()) {
+    return true;
+  }
+  return false;
 }
 
 export default ServiceWizard;

--- a/frontend/src/components/services/wizard/providers.ts
+++ b/frontend/src/components/services/wizard/providers.ts
@@ -22,7 +22,13 @@ export interface ProviderUIDescriptor {
   /** False for providers without a /models endpoint (Azure, GoogleCloud). */
   readonly supportsModelListing: boolean;
   /** Extra fields shown in the credentials step for manual-input providers. */
-  readonly manualFields?: readonly ('api_version' | 'project_id' | 'region')[];
+  readonly manualFields?: readonly (
+    | 'api_version'
+    | 'project_id'
+    | 'region'
+    | 'aws_access_key_id'
+    | 'aws_region'
+  )[];
   readonly apiKeyPlaceholder: string;
   readonly apiKeyHelp: string;
   /** Optional link to the provider's API key management page. Rendered
@@ -178,6 +184,24 @@ const ALL_PROVIDERS: readonly ProviderUIDescriptor[] = [
     apiKeyPlaceholder: '{"type":"service_account",...}',
     apiKeyHelp: 'Paste the full Service Account JSON key content.',
     apiKeyDocUrl: 'https://console.cloud.google.com/iam-admin/serviceaccounts',
+    supportedFor: ['ai', 'embedding'],
+  },
+  {
+    // AWS Bedrock. The api_key field carries the AWS Secret Access Key
+    // (so it reuses the masking machinery); the Access Key ID and Region
+    // are collected as dedicated non-secret fields and travel to the
+    // backend in extra_config. Listing works through boto3.
+    value: 'Bedrock',
+    label: 'AWS Bedrock',
+    description: 'Foundation models (Anthropic Claude, Amazon Titan, Cohere, Meta Llama, Mistral) via AWS Bedrock.',
+    Icon: Cloud,
+    apiKey: 'required',
+    needsBaseUrl: false,
+    supportsModelListing: true,
+    manualFields: ['aws_access_key_id', 'aws_region'],
+    apiKeyPlaceholder: 'AWS Secret Access Key',
+    apiKeyHelp: 'Your AWS Secret Access Key. Needs the bedrock:ListFoundationModels and bedrock:InvokeModel permissions.',
+    apiKeyDocUrl: 'https://console.aws.amazon.com/iam/home#/security_credentials',
     supportedFor: ['ai', 'embedding'],
   },
 ];

--- a/frontend/src/components/services/wizard/steps/CredentialsStep.tsx
+++ b/frontend/src/components/services/wizard/steps/CredentialsStep.tsx
@@ -4,6 +4,12 @@ import Alert from '../../../ui/Alert';
 import { getProviderDescriptor } from '../providers';
 import type { ServiceWizardMode } from '../../../../types/services';
 
+/** Provider-specific label for the secret field. */
+const API_KEY_LABELS: Record<string, string> = {
+  GoogleCloud: 'Service Account JSON',
+  Bedrock: 'AWS Secret Access Key',
+};
+
 export interface CredentialsState {
   api_key: string;
   /** For Azure: endpoint URL. For GoogleCloud: GCP project id. For
@@ -12,6 +18,10 @@ export interface CredentialsState {
   base_url: string;
   /** For Azure: API version. For GoogleCloud: region/location. */
   api_version: string;
+  /** AWS Bedrock: Access Key ID (non-secret). */
+  aws_access_key_id?: string;
+  /** AWS Bedrock: region, e.g. us-east-1. */
+  aws_region?: string;
 }
 
 interface CredentialsStepProps {
@@ -43,9 +53,10 @@ function CredentialsStep({
     onChange({ ...value, ...patch });
   const manualFields = descriptor.manualFields ?? [];
 
-  const apiKeyLabel = `${
-    descriptor.value === 'GoogleCloud' ? 'Service Account JSON' : 'API Key'
-  }${descriptor.apiKey === 'optional' ? ' (optional)' : ''}`;
+  const apiKeyBaseLabel = API_KEY_LABELS[descriptor.value] ?? 'API Key';
+  const apiKeyLabel = `${apiKeyBaseLabel}${
+    descriptor.apiKey === 'optional' ? ' (optional)' : ''
+  }`;
 
   let baseUrlLabel = 'Base URL';
   if (descriptor.value === 'GoogleCloud') baseUrlLabel = 'GCP Project ID';
@@ -120,6 +131,39 @@ function CredentialsStep({
           placeholder={
             descriptor.value === 'GoogleCloud' ? 'europe-west1' : '2024-08-01-preview'
           }
+        />
+      )}
+
+      {manualFields.includes('aws_access_key_id') && (
+        <FormField
+          label="AWS Access Key ID"
+          id="aws_access_key_id"
+          type="text"
+          value={value.aws_access_key_id ?? ''}
+          onChange={(e) => update({ aws_access_key_id: e.target.value })}
+          placeholder="AKIA..."
+          required
+        />
+      )}
+
+      {manualFields.includes('aws_region') && (
+        <FormField
+          label="AWS Region"
+          id="aws_region"
+          type="text"
+          value={value.aws_region ?? ''}
+          onChange={(e) => update({ aws_region: e.target.value })}
+          placeholder="us-east-1"
+          helpText="Region where Bedrock is enabled, e.g. us-east-1 or eu-west-1."
+          required
+        />
+      )}
+
+      {descriptor.value === 'Bedrock' && (
+        <Alert
+          type="info"
+          title="Model access may be required"
+          message="A listed model still needs to be enabled in the AWS console (Bedrock → Model access) before it can be invoked."
         />
       )}
 

--- a/frontend/src/components/services/wizard/steps/ModelSelectionStep.tsx
+++ b/frontend/src/components/services/wizard/steps/ModelSelectionStep.tsx
@@ -61,6 +61,8 @@ function ModelSelectionStep({
         api_key: credentials.api_key,
         base_url: credentials.base_url,
         api_version: credentials.api_version || undefined,
+        aws_access_key_id: credentials.aws_access_key_id?.trim() || undefined,
+        aws_region: credentials.aws_region?.trim() || undefined,
       }
     : null;
 

--- a/frontend/src/hooks/useProviderModels.ts
+++ b/frontend/src/hooks/useProviderModels.ts
@@ -94,6 +94,8 @@ export function useProviderModels({
     request?.api_key,
     request?.base_url,
     request?.api_version,
+    request?.aws_access_key_id,
+    request?.aws_region,
     tick,
   ]);
 

--- a/frontend/src/types/services.ts
+++ b/frontend/src/types/services.ts
@@ -39,6 +39,10 @@ export interface ListProviderModelsRequest {
   api_key: string;
   base_url?: string;
   api_version?: string;
+  // AWS Bedrock identifiers. The secret access key travels in `api_key`;
+  // these non-secret fields carry the access key id and region.
+  aws_access_key_id?: string;
+  aws_region?: string;
   // server overrides this — sending it is a no-op but keeps the type honest
   purpose?: ListPurpose;
 }
@@ -63,6 +67,10 @@ export interface ServiceFormData {
   base_url: string;
   api_version?: string;
   supports_video?: boolean;
+  // AWS Bedrock identifiers (non-secret). The secret access key is sent
+  // via `api_key`; these carry the access key id and region.
+  aws_access_key_id?: string;
+  aws_region?: string;
 }
 
 /** Existing service shape returned by getAIService / getEmbeddingService. */
@@ -75,4 +83,6 @@ export interface ExistingService {
   readonly base_url: string;
   readonly supports_video?: boolean;
   readonly api_version?: string;
+  readonly aws_access_key_id?: string;
+  readonly aws_region?: string;
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -611,6 +611,46 @@ files = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.36"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "boto3-1.43.36-py3-none-any.whl", hash = "sha256:42942dde254673abcbc9e6e60017c88341a4f49d99d24e1f2e290fb38138c26f"},
+    {file = "boto3-1.43.36.tar.gz", hash = "sha256:587d7ee92a12e440ad12b0e7f11f3358f0c4d65b19f64726efc94aaf194aff28"},
+]
+
+[package.dependencies]
+botocore = ">=1.43.36,<1.44.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.19.0,<0.20.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.43.36"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "botocore-1.43.36-py3-none-any.whl", hash = "sha256:3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d"},
+    {file = "botocore-1.43.36.tar.gz", hash = "sha256:4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = ">=1.25.4,<2.2.0 || >2.2.0,<3"
+
+[package.extras]
+crt = ["awscrt (==0.32.2)"]
+
+[[package]]
 name = "bs4"
 version = "0.0.2"
 description = "Dummy package for Beautiful Soup (beautifulsoup4)"
@@ -2164,6 +2204,18 @@ files = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64"},
+    {file = "jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d"},
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 description = "Apply JSON-Patches (RFC 6902)"
@@ -2374,6 +2426,30 @@ langchain-core = ">=1.2.11,<2.0.0"
 pydantic = ">=2.7.4,<3.0.0"
 
 [[package]]
+name = "langchain-aws"
+version = "1.6.1"
+description = "An integration package connecting AWS and LangChain"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "langchain_aws-1.6.1-py3-none-any.whl", hash = "sha256:a121f687b36678239dd96ee9d0503a0b7d5fc4570b3af6d19983ef6ebfaf115e"},
+    {file = "langchain_aws-1.6.1.tar.gz", hash = "sha256:b5b054f48e2697fa1b96733e9de2accfdd1a4948d9b4e3712e8180c4585cfd2f"},
+]
+
+[package.dependencies]
+boto3 = ">=1.42.42"
+langchain-core = ">=1.4.7"
+numpy = ">=1.0.0,<3"
+pydantic = ">=2.10.6,<3"
+
+[package.extras]
+anthropic = ["anthropic[bedrock]", "langchain-anthropic"]
+nova-sonic = ["aws-sdk-bedrock-runtime ; python_version >= \"3.12\""]
+tools = ["beautifulsoup4 (>=4.13.4)", "bedrock-agentcore (>=1.4.0) ; python_version >= \"3.10\"", "playwright (>=1.53.0)"]
+valkey = ["valkey-glide-sync (>=2.0.0)"]
+
+[[package]]
 name = "langchain-azure-ai"
 version = "1.0.61"
 description = "An integration package to support Azure AI Foundry capabilities in LangChain/LangGraph ecosystem."
@@ -2474,19 +2550,19 @@ tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<10.0.0"
 
 [[package]]
 name = "langchain-core"
-version = "1.4.0"
+version = "1.4.8"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main", "qdrant"]
 files = [
-    {file = "langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c"},
-    {file = "langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f"},
+    {file = "langchain_core-1.4.8-py3-none-any.whl", hash = "sha256:d84c28b05e3ba8d4271d0827aad5b592ccdaaf986e76768c23503f0a2045e8aa"},
+    {file = "langchain_core-1.4.8.tar.gz", hash = "sha256:5bf1f8411077c904182ad8f975943d36adcbf579c4e017b3a118b719229ebf9a"},
 ]
 
 [package.dependencies]
 jsonpatch = ">=1.33.0,<2.0.0"
-langchain-protocol = ">=0.0.14"
+langchain-protocol = ">=0.0.17"
 langsmith = ">=0.3.45,<1.0.0"
 packaging = ">=23.2.0"
 pydantic = ">=2.7.4,<3.0.0"
@@ -2605,18 +2681,18 @@ sqlalchemy = {version = ">=2,<3", extras = ["asyncio"]}
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.15"
+version = "0.0.18"
 description = "Python bindings for the LangChain agent streaming protocol"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main", "qdrant"]
 files = [
-    {file = "langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79"},
-    {file = "langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade"},
+    {file = "langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a"},
+    {file = "langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6"},
 ]
 
 [package.dependencies]
-typing-extensions = ">=4.7.0,<5.0.0"
+typing-extensions = ">=4.13.0,<5.0.0"
 
 [[package]]
 name = "langchain-qdrant"
@@ -5922,6 +5998,24 @@ files = [
 pyasn1 = ">=0.1.3"
 
 [[package]]
+name = "s3transfer"
+version = "0.19.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262"},
+    {file = "s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
+
+[[package]]
 name = "scalar-fastapi"
 version = "1.4.4"
 description = "This plugin provides an easy way to render a beautiful API reference based on a OpenAPI/Swagger file with FastAPI."
@@ -7265,4 +7359,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "cb536beaf1c5476e3879f9bbea0ccdb564f832f5921bbcda2f1901803b38d598"
+content-hash = "aeece3ac6792407cc28dfa0d5891072fed2693a228eebd2fc74227277a498f88"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ yt-dlp = ">=2024.0.0"
 pydub = ">=0.25.1"
 ffmpeg-python = "^0.2.0"
 pymupdf = "^1.27.2.3"
+langchain-aws = ">=1.0.0,<2.0.0"
 
 [tool.poetry.scripts]
 dev = "uvicorn backend.main:app --reload --port 8000"

--- a/tests/unit/tools/test_agent_tools.py
+++ b/tests/unit/tools/test_agent_tools.py
@@ -76,7 +76,7 @@ async def test_iact_tool_create_survives_mcp_load_failure():
     assert tool.react_agent is not None
     assert tool.mcp_client is None
     # Base tools are still present despite the MCP failure.
-    assert agentTools.get_current_date in mock_create.call_args.kwargs["tools"]
+    assert agentTools.fetch_file_in_base64 in mock_create.call_args.kwargs["tools"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds **AWS Bedrock** as a first-class AI Service and Embedding Service provider across the full stack (backend + frontend).

## Backend changes

| File | What changed |
|---|---|
| `backend/models/ai_service.py` | Added `Bedrock` to `ProviderEnum` |
| `backend/models/embedding_service.py` | Added `Bedrock` to `EmbeddingProvider` |
| `backend/models/base_service.py` | New `extra_config` (nullable Text/JSON) column for provider-specific non-secret config |
| `alembic/versions/bedrock001_add_extra_config_to_services.py` | Migration: adds `extra_config` to `AIService` + `embedding_service` tables (upgrade/downgrade tested) |
| `backend/tools/aws_bedrock_utils.py` | New helper: `parse_extra_config`, `build_extra_config`, `resolve_bedrock_credentials` |
| `backend/tools/aiServiceTools.py` | `_build_bedrock_llm()` using `ChatBedrockConverse` (lazy import) |
| `backend/tools/embeddingTools.py` | `_build_bedrock_embeddings()` using `BedrockEmbeddings` (lazy import) |
| `backend/tools/ai/model_catalog.py` | `PROVIDER_BEDROCK` constant; `.embed` pattern for Bedrock embedding model ids |
| `backend/tools/ai/provider_model_clients.py` | `list_bedrock_models()`: boto3 `bedrock.list_foundation_models`, filters ON_DEMAND+ACTIVE, maps capabilities, sanitises errors |
| `backend/services/provider_models_service.py` | Bedrock branch in dispatch + `_validate_bedrock_credentials` |
| `backend/schemas/provider_models_schemas.py` | `aws_access_key_id` / `aws_region` fields in `ListProviderModelsRequest` |
| `backend/schemas/ai_service_schemas.py` | Same AWS fields in `AIServiceDetailSchema` + `CreateUpdateAIServiceSchema` |
| `backend/schemas/embedding_service_schemas.py` | Same AWS fields in embedding schemas |
| `backend/services/ai_service_service.py` | `extra_config` round-trip (get detail, create/update, copy) |
| `backend/services/embedding_service_service.py` | Same for embedding services |
| `backend/routers/internal/ai_services.py` | AWS `extra_config` passthrough in test-connection route |
| `backend/routers/internal/embedding_services.py` | Same |
| `backend/routers/internal/admin.py` | System service routes: `extra_config` in detail, create, update, test-connection for both AI and embedding |
| `pyproject.toml` / `poetry.lock` | Added `langchain-aws >=1.0.0,<2.0.0` (resolves to 1.6.1 + boto3 1.43.36) |

### Credential storage design

| Field | Carries |
|---|---|
| `api_key` | AWS Secret Access Key (reuses existing masking machinery) |
| `extra_config` JSON | `{"aws_access_key_id": "...", "aws_region": "..."}` |
| `model_name` | Bedrock model id (e.g. `anthropic.claude-3-5-sonnet-20241022-v2:0`) |

## Frontend changes

| File | What changed |
|---|---|
| `frontend/src/types/services.ts` | `aws_access_key_id` / `aws_region` in `ListProviderModelsRequest`, `ServiceFormData`, `ExistingService` |
| `frontend/src/components/services/wizard/providers.ts` | AWS fields added to `manualFields` union; new **Bedrock** provider descriptor |
| `frontend/src/components/services/wizard/steps/CredentialsStep.tsx` | AWS fields in `CredentialsState`; renders Access Key ID + Region inputs; `API_KEY_LABELS` map |
| `frontend/src/components/services/wizard/steps/ModelSelectionStep.tsx` | Includes AWS fields in the listing request |
| `frontend/src/hooks/useProviderModels.ts` | AWS fields added to the `useEffect` dependency array |
| `frontend/src/components/services/wizard/ServiceWizard.tsx` | AWS fields in edit-model prefill, `buildPayload`; extracted `isCredentialsStepDisabled` helper |
| `frontend/src/components/services/CompactServiceEditor.tsx` | AWS state, reset, render, and payload wiring for the inline edit path |

## Notes

- Models available for listing depend on which models are enabled in **AWS console → Bedrock → Model access**. The wizard shows an info alert reminding users of this.
- The `extra_config` column is generic and can be reused for other providers needing extra non-secret config in the future.
- `requirements.txt` is not touched — it is stale/unused (the Dockerfile uses `poetry install`).
