### PR TITLE
ci(github-actions): build stable images on release publish, add nightly tag

### DIFF
--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -372,7 +372,7 @@ Command: @release-manager release patch
 - ❌ Does not create database migrations
 - ❌ Does not fix bugs or implement features
 - ❌ Does not manage CI/CD pipeline configuration (that's separate from release tagging)
-- ❌ Does not build or publish Docker images (those are triggered by tags, not managed by this agent)
+- ❌ Does not build or publish Docker images (the stable image build is triggered when the GitHub Release is published in Phase 7, not managed by this agent)
 - ❌ Does not publish npm packages or PyPI packages directly (can be added if needed)
 - ❌ Does not manage Kubernetes deployments
 

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -2,12 +2,11 @@ name: Backend CI
 
 on:
   push:
-    branches: [develop, main]
-    tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
+    branches: [develop]          # nightly builds
   pull_request:
-    branches: [develop, main]
+    branches: [develop, main]    # build-only validation, no push
+  release:
+    types: [published]           # stable images, tagged with the release version
   workflow_dispatch:
 
 jobs:
@@ -40,13 +39,19 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/lksnext-ai-lab/mattinai-backend
+          # nightly       → latest develop build (moving)
+          # release vX.Y.Z → X.Y.Z, X.Y, and latest (latest=auto skips pre-releases
+          #                  like vX.Y.Z-rc1). The leading 'v' is dropped, per the
+          #                  container image tag convention.
           tags: |
+            type=raw,value=nightly,enable=${{ github.ref == 'refs/heads/develop' }}
             type=ref,event=branch
             type=ref,event=pr
             type=sha,prefix=sha-
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+          flavor: |
+            latest=auto
 
       - name: Build Docker image (push on non-PR events)
         uses: docker/build-push-action@v6

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -2,12 +2,11 @@ name: Frontend CI
 
 on:
   push:
-    branches: [develop, main]
-    tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
+    branches: [develop]          # nightly builds
   pull_request:
-    branches: [develop, main]
+    branches: [develop, main]    # build-only validation, no push
+  release:
+    types: [published]           # stable images, tagged with the release version
   workflow_dispatch:
 
 jobs:
@@ -40,13 +39,19 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/lksnext-ai-lab/mattinai-frontend
+          # nightly       → latest develop build (moving)
+          # release vX.Y.Z → X.Y.Z, X.Y, and latest (latest=auto skips pre-releases
+          #                  like vX.Y.Z-rc1). The leading 'v' is dropped, per the
+          #                  container image tag convention.
           tags: |
+            type=raw,value=nightly,enable=${{ github.ref == 'refs/heads/develop' }}
             type=ref,event=branch
             type=ref,event=pr
             type=sha,prefix=sha-
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+          flavor: |
+            latest=auto
 
       - name: Build Docker image (push on non-PR events)
         uses: docker/build-push-action@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Release image tagging**: The backend/frontend CI now tags `develop` builds with a moving `nightly` alias, and builds stable images when a **GitHub Release is published** — tagged `X.Y.Z`, `X.Y` and `latest` (the leading `v` is dropped; pre-releases are excluded from `latest`). Pushing to `main` no longer builds an image.
+
 ### Fixed
 
 ## [0.4.2] - 2026-05-21


### PR DESCRIPTION
## Qué

Cierra el circuito de build de imágenes de release y estandariza el tagging de las imágenes OSS en GHCR.

- **Estable = release publicada**: `backend-ci.yml` / `frontend-ci.yml` ahora construyen y pushean la imagen cuando se **publica una GitHub Release** (`release: types: [published]`), no en cada push a `main`. Tags: `X.Y.Z`, `X.Y` y `latest`.
- **`nightly`**: los push a `develop` publican además el alias móvil `nightly` (última develop).
- **Prefijo `v`**: se deja caer, siguiendo la convención de etiquetas de imagen (git tag `vX.Y.Z` → imagen `X.Y.Z`). `latest=auto` excluye pre-releases (`-rc`).
- **`main` ya no construye imagen** (evita el anti-patrón de versionar builds de rama).

## Convención resultante

| Evento | Tags publicados |
|---|---|
| push `develop` | `develop`, `nightly`, `sha-<hash>` |
| PR | build de validación, sin push |
| Release publicada | `X.Y.Z`, `X.Y`, `latest` |

Actualizado el doc de `@release-manager` (el build lo dispara la publicación de la release en Fase 7) y el `CHANGELOG`.

Los ajustes de documentación/params en `mattinai-infra` (nightly test / `X.Y.Z` pro) van en su propio repo.
