### PR TITLE
fix(ai): use the OpenAI Responses API so reasoning models work with tools

### DIFF
--- a/backend/tools/aiServiceTools.py
+++ b/backend/tools/aiServiceTools.py
@@ -117,6 +117,14 @@ def _build_openai_llm(ai_service, temperature):
         temperature=temperature,
         api_key=ai_service.api_key,
         base_url=base_url,
+        # Reasoning models reject function tools on /v1/chat/completions ("Function tools
+        # with reasoning_effort are not supported ... use /v1/responses or set
+        # reasoning_effort to 'none'"), and every agent here is built with tools. The
+        # Responses API keeps reasoning on (unlike reasoning_effort='none') and is what
+        # the provider-side server tools (web_search, image_generation, code_interpreter)
+        # already expect. Only for OpenAI itself: a custom endpoint is an OpenAI-compatible
+        # gateway, and those speak /v1/chat/completions but not necessarily /v1/responses.
+        use_responses_api=base_url is None,
     )
 
 

--- a/tests/unit/tools/test_ai_service_tools.py
+++ b/tests/unit/tools/test_ai_service_tools.py
@@ -1,0 +1,43 @@
+"""Unit tests for ``tools.aiServiceTools._build_openai_llm``.
+
+Reasoning models (o-series, gpt-5.x) reject function tools on
+/v1/chat/completions, and every agent in this codebase is built with tools, so
+the OpenAI provider must talk to the Responses API. A custom endpoint, however,
+is an OpenAI-compatible gateway: those speak /v1/chat/completions and not
+necessarily /v1/responses, so they must keep the old surface.
+
+Tests verify:
+- No endpoint (OpenAI itself) selects the Responses API.
+- A custom endpoint keeps the chat completions API.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def _ai_service(endpoint: str | None = None) -> SimpleNamespace:
+    """Minimal stand-in for an AIService row, with only the fields the builder reads."""
+    return SimpleNamespace(
+        description="gpt-5.5",
+        api_key="sk-test-key",
+        endpoint=endpoint,
+    )
+
+
+class TestBuildOpenAILLM:
+    def test_uses_responses_api_when_no_custom_endpoint(self):
+        from tools.aiServiceTools import _build_openai_llm
+
+        llm = _build_openai_llm(_ai_service(endpoint=None), temperature=0)
+
+        assert llm.use_responses_api is True
+
+    def test_keeps_chat_completions_for_custom_endpoint(self):
+        from tools.aiServiceTools import _build_openai_llm
+
+        llm = _build_openai_llm(
+            _ai_service(endpoint="https://gateway.example.com/v1"), temperature=0
+        )
+
+        assert llm.use_responses_api is False


### PR DESCRIPTION
Closes #190

## What this does and why

Agents backed by an OpenAI reasoning model (`gpt-5.6-luna`, `-terra`, `-sol`) died with a 400 on every request: OpenAI rejects function tools on `/v1/chat/completions` for reasoning models, and every agent built here is bound to tools, so no request could get through.

`_build_openai_llm` now asks for the **Responses API**. That keeps reasoning enabled — unlike `reasoning_effort='none'`, which would silence the error by silently degrading the model — and it is the surface the provider-side server tools (web search, image generation, code interpreter) already expect.

**Custom endpoints are deliberately left on chat completions.** An AIService with an `endpoint` set points at an OpenAI-*compatible* gateway; those speak `/v1/chat/completions` but not necessarily `/v1/responses`, so flipping them too would break setups that work today. That is the whole reason the flag is `use_responses_api=base_url is None` rather than a constant.

## How it was tested

- New unit test `tests/unit/tools/test_ai_service_tools.py`: the Responses API is selected when no custom endpoint is set, and chat completions is kept when one is.
- Manually against five real models — `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.6-sol`: tool calling and structured output work on all five.

```
$ pytest tests/unit/tools/test_ai_service_tools.py
2 passed
```

## Breaking changes

None. Behaviour for custom endpoints and for non-reasoning OpenAI models is unchanged; the Responses API is the same model with the same tools over a different transport.

## PR Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the changes
- [x] Added/updated tests if applicable
- [ ] Database migrations tested (upgrade and downgrade) if applicable — N/A, no schema change
- [ ] Documentation updated if applicable — N/A
- [x] No hardcoded secrets or credentials
- [x] Commit messages follow Conventional Commits format
- [x] Commits are signed
