### PR TITLE
fix(files): read .docx attachments instead of handing the agent a placeholder

### DIFF
--- a/backend/services/file_management_service.py
+++ b/backend/services/file_management_service.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from fastapi import UploadFile, HTTPException
 
 from tools.PDFTools import extract_text_from_pdf, convert_pdf_to_images, check_pdf_has_text
+from tools.DocumentTools import extract_text_from_document
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -92,8 +93,10 @@ class FileReference:
         # No text extraction needed for images
         if self.file_type == "image":
             return "ready"
-        # Documents (.doc, .docx) don't have text extraction implemented yet
-        if "not implemented" in self.content.lower():
+        # Formats with no extractor (legacy .doc, spreadsheets, slides) carry a notice
+        # instead of text. Keyed off the placeholder check rather than one specific
+        # phrase, so a reworded notice cannot make an unread file look ready.
+        if not self._has_extractable_content():
             return "uploaded"  # File uploaded but not fully processed
         return "ready"
     
@@ -319,6 +322,8 @@ class FileManagementService:
                 # Read text files directly
                 with open(file_path, 'r', encoding='utf-8') as f:
                     return f.read()
+            elif file_type == "document":
+                return extract_text_from_document(file_path, os.path.basename(file_path))
             else:
                 # For other file types, return basic info
                 return f"File: {os.path.basename(file_path)} (type: {file_type})"
@@ -558,8 +563,7 @@ class FileManagementService:
                     return content, temp_path, file_size
                 
                 elif file_type == "document":
-                    # For documents, return basic info (in production, use document processing)
-                    content = f"Document file: {file.filename} (Document processing not implemented)"
+                    content = extract_text_from_document(temp_path, file.filename)
                     return content, temp_path, file_size
                 
                 else:

--- a/backend/services/file_management_service.py
+++ b/backend/services/file_management_service.py
@@ -100,19 +100,22 @@ class FileReference:
             return "uploaded"  # File uploaded but not fully processed
         return "ready"
     
+    # Every notice this service puts in ``content`` in place of real text starts
+    # with one of these. Matched as a prefix, not a substring: extracted document
+    # text can legitimately contain "File:" anywhere in the body, and a substring
+    # match would report a successfully-read attachment as unread.
+    PLACEHOLDER_PREFIXES = (
+        "Error processing",
+        "Image file:",
+        "Document file:",
+        "File:",
+    )
+
     def _has_extractable_content(self) -> bool:
         """Check if meaningful content was extracted"""
         if not self.content:
             return False
-        # Check for placeholder messages
-        placeholder_indicators = [
-            "not implemented",
-            "Error processing",
-            "Image file:",
-            "Document file:",
-            "File:"
-        ]
-        return not any(indicator in self.content for indicator in placeholder_indicators)
+        return not self.content.startswith(self.PLACEHOLDER_PREFIXES)
     
     def _get_content_preview(self, max_length: int = 200) -> Optional[str]:
         """Get preview of extracted content"""
@@ -318,8 +321,11 @@ class FileManagementService:
             if file_type == "pdf":
                 # Use existing PDF tools
                 return extract_text_from_pdf(file_path)
-            elif file_type in ["txt", "md", "json"]:
-                # Read text files directly
+            elif file_type == "text":
+                # Read text files directly. _get_file_type_from_path returns the
+                # category ("text"), not the extension, so matching on extensions
+                # here never fired and .txt/.md/.json/.csv fell through to the
+                # generic placeholder below.
                 with open(file_path, 'r', encoding='utf-8') as f:
                     return f.read()
             elif file_type == "document":

--- a/backend/tools/DocumentTools.py
+++ b/backend/tools/DocumentTools.py
@@ -1,0 +1,71 @@
+"""Text extraction for office documents attached to a chat.
+
+PDFs have their own module (``PDFTools``). This one covers the ``document``
+family (.docx, .doc, .xls, .ppt…), which until now returned the placeholder
+string "Document processing not implemented" *as the file's content* — the
+agent received that sentence instead of the document, so attaching a Word file
+silently did nothing.
+
+.docx is read with the same loader the silo indexing pipeline already uses
+(``Docx2txtLoader``), so a document attached to a chat and the same document
+indexed into a repository yield the same text.
+"""
+
+import os
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Formats we can turn into text. Anything else keeps an explicit "not read"
+# notice rather than pretending it was read.
+_DOCX_EXTENSIONS = {".docx"}
+
+
+def extract_text_from_document(file_path: str, filename: str) -> str:
+    """Extract plain text from an office document.
+
+    Args:
+        file_path: Path to the file on disk.
+        filename: Original name, used to pick the extractor and for messages.
+
+    Returns:
+        The document's text, or a human-readable notice when the format has no
+        extractor (legacy .doc, spreadsheets, slides) or the file cannot be
+        read. The caller treats the return value as the file's content, so a
+        notice must state plainly that the document was not read.
+    """
+    extension = os.path.splitext(filename or "")[1].lower()
+
+    if extension not in _DOCX_EXTENSIONS:
+        logger.info(
+            "No text extractor for '%s' (%s); attachment not read",
+            filename,
+            extension or "no extension",
+        )
+        return (
+            f"Document file: {filename} "
+            f"(text extraction is not supported for {extension or 'this format'})"
+        )
+
+    try:
+        from langchain_community.document_loaders import Docx2txtLoader
+
+        documents = Docx2txtLoader(file_path).load()
+        text = "\n\n".join(doc.page_content for doc in documents).strip()
+
+        if not text:
+            logger.warning(
+                "No text extracted from '%s' (empty or image-only document)", filename
+            )
+            return (
+                f"Document file: {filename} "
+                f"(no extractable text: it may be empty or contain only images)"
+            )
+
+        return text
+    except Exception as exc:
+        logger.error(
+            "Failed to extract text from '%s': %s", filename, exc, exc_info=True
+        )
+        return f"Error processing document {filename}: {exc}"

--- a/backend/tools/DocumentTools.py
+++ b/backend/tools/DocumentTools.py
@@ -65,7 +65,11 @@ def extract_text_from_document(file_path: str, filename: str) -> str:
 
         return text
     except Exception as exc:
+        # The notice becomes the file's content and is shown to the user and sent
+        # to the model, so it must not carry the exception text: that leaks server
+        # paths and parser internals, and would make the UI depend on the wording
+        # of a third-party error. The detail stays in the log.
         logger.error(
             "Failed to extract text from '%s': %s", filename, exc, exc_info=True
         )
-        return f"Error processing document {filename}: {exc}"
+        return f"Error processing document {filename}: the file could not be read"

--- a/tests/unit/services/test_file_reference_status.py
+++ b/tests/unit/services/test_file_reference_status.py
@@ -1,0 +1,78 @@
+"""Unit tests for ``FileReference`` placeholder detection.
+
+``_get_processing_status`` and ``_has_extractable_content`` decide whether an
+attachment was really read. They tell a placeholder apart from real content by
+looking at how the notice starts, because the notices this service produces are
+always prefixes ("Document file: …", "File: …", "Error processing …").
+
+The check used to be a *substring* match, which is a trap: extracted document
+text can legitimately contain "File:" in its body, and that would report a
+successfully-read attachment as unread.
+
+Tests verify:
+- Real extracted text is "ready", even when it contains a placeholder phrase.
+- Each kind of notice is recognised as a placeholder.
+"""
+
+from __future__ import annotations
+
+from services.file_management_service import FileReference
+
+
+def _reference(content: str, file_type: str = "document") -> FileReference:
+    return FileReference(
+        file_id="f-1",
+        filename="report.docx",
+        file_type=file_type,
+        content=content,
+    )
+
+
+class TestPlaceholderDetection:
+    def test_extracted_text_is_ready(self):
+        ref = _reference("Quarterly report\n\nRevenue grew by 12%.")
+
+        assert ref.has_extractable_content is True
+        assert ref.processing_status == "ready"
+
+    def test_extracted_text_containing_placeholder_phrase_is_still_ready(self):
+        # The document itself talks about files — a substring match would have
+        # declared this successfully-read document unread.
+        ref = _reference(
+            "Attachment policy\n\nFile: contract.pdf must be signed.\n"
+            "Support for macros is not implemented in this template."
+        )
+
+        assert ref.has_extractable_content is True
+        assert ref.processing_status == "ready"
+
+    def test_unsupported_format_notice_is_not_content(self):
+        ref = _reference(
+            "Document file: budget.xlsx (text extraction is not supported for .xlsx)"
+        )
+
+        assert ref.has_extractable_content is False
+        assert ref.processing_status == "uploaded"
+
+    def test_empty_document_notice_is_not_content(self):
+        ref = _reference(
+            "Document file: empty.docx (no extractable text: it may be empty or "
+            "contain only images)"
+        )
+
+        assert ref.has_extractable_content is False
+        assert ref.processing_status == "uploaded"
+
+    def test_error_notice_is_reported_as_error(self):
+        ref = _reference("Error processing document broken.docx: the file could not be read")
+
+        assert ref.has_extractable_content is False
+        assert ref.processing_status == "error"
+
+    def test_image_is_ready_without_text_extraction(self):
+        ref = _reference(
+            "Image file: chart.png (OCR processing not implemented)", file_type="image"
+        )
+
+        assert ref.processing_status == "ready"
+        assert ref.has_extractable_content is False

--- a/tests/unit/tools/test_document_tools.py
+++ b/tests/unit/tools/test_document_tools.py
@@ -81,3 +81,15 @@ class TestExtractTextFromDocument:
         result = extract_text_from_document(str(corrupt), "broken.docx")
 
         assert result.startswith("Error processing document")
+
+    def test_error_notice_does_not_leak_exception_detail(self, tmp_path):
+        # The notice becomes the file's content: it reaches the model and the UI,
+        # so the underlying exception (server paths, parser internals) must stay
+        # in the log and out of the returned string.
+        corrupt = tmp_path / "broken.docx"
+        corrupt.write_bytes(b"this is not a zip archive")
+
+        result = extract_text_from_document(str(corrupt), "broken.docx")
+
+        assert "zip" not in result.lower()
+        assert str(tmp_path) not in result

--- a/tests/unit/tools/test_document_tools.py
+++ b/tests/unit/tools/test_document_tools.py
@@ -1,0 +1,83 @@
+"""Unit tests for ``tools.DocumentTools.extract_text_from_document``.
+
+Attaching a .docx to a chat used to hand the agent the literal string "Document
+processing not implemented" as the file's content. The extractor must now return
+the document's text, and — for formats it cannot read — a notice that plainly
+says the file was not read, since the caller stores the return value as content.
+
+Tests verify:
+- A .docx is turned into its text.
+- An empty .docx yields a notice, not an empty string.
+- A format with no extractor (.xlsx, legacy .doc) yields a notice.
+- An unreadable/corrupt file yields an error notice instead of raising.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from tools.DocumentTools import extract_text_from_document
+
+
+_DOCUMENT_XML = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>{paragraphs}</w:body>
+</w:document>
+"""
+
+_PARAGRAPH_XML = "<w:p><w:r><w:t>{text}</w:t></w:r></w:p>"
+
+
+def _write_docx(path: Path, *paragraphs: str) -> Path:
+    """Write a minimal WordprocessingML .docx (a zip holding word/document.xml)."""
+    body = "".join(_PARAGRAPH_XML.format(text=text) for text in paragraphs)
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("word/document.xml", _DOCUMENT_XML.format(paragraphs=body))
+    return path
+
+
+class TestExtractTextFromDocument:
+    def test_extracts_text_from_docx(self, tmp_path):
+        docx = _write_docx(
+            tmp_path / "report.docx",
+            "Quarterly report",
+            "Revenue grew by 12%.",
+        )
+
+        result = extract_text_from_document(str(docx), "report.docx")
+
+        assert "Quarterly report" in result
+        assert "Revenue grew by 12%." in result
+
+    def test_empty_docx_returns_notice(self, tmp_path):
+        docx = _write_docx(tmp_path / "empty.docx")
+
+        result = extract_text_from_document(str(docx), "empty.docx")
+
+        assert "no extractable text" in result
+
+    def test_unsupported_format_returns_notice(self, tmp_path):
+        spreadsheet = tmp_path / "budget.xlsx"
+        spreadsheet.write_bytes(b"not really a spreadsheet")
+
+        result = extract_text_from_document(str(spreadsheet), "budget.xlsx")
+
+        assert "not supported" in result
+        assert ".xlsx" in result
+
+    def test_legacy_doc_returns_notice(self, tmp_path):
+        legacy = tmp_path / "old.doc"
+        legacy.write_bytes(b"\xd0\xcf\x11\xe0")  # OLE2 magic
+
+        result = extract_text_from_document(str(legacy), "old.doc")
+
+        assert "not supported" in result
+
+    def test_corrupt_docx_returns_error_notice(self, tmp_path):
+        corrupt = tmp_path / "broken.docx"
+        corrupt.write_bytes(b"this is not a zip archive")
+
+        result = extract_text_from_document(str(corrupt), "broken.docx")
+
+        assert result.startswith("Error processing document")


### PR DESCRIPTION
Closes #191

## What this does and why

A `.docx` attached to a chat was never read. `FileManagementService` classified it as a `document` and returned the string `"Document file: <name> (Document processing not implemented)"` **as the file's content**, so the agent received that sentence instead of the document and answered as if it had seen nothing — silently, with no warning to the user.

This PR adds `backend/tools/DocumentTools.py` and wires it into the two places that turn an uploaded file into content (`_process_file_content` and `process_file_for_agent`).

Three decisions worth calling out:

1. **`Docx2txtLoader`, not a new dependency.** It is the same loader the silo indexing pipeline already uses, and `docx2txt` is already in `poetry.lock`. A document attached to a chat and the same document indexed into a repository now yield the same text.
2. **Formats with no extractor stay honest.** The `document` type also covers legacy `.doc`, spreadsheets and slides. Those return a notice that plainly says the file was not read, rather than a string that reads like content. Same for an empty/image-only `.docx` and for an unreadable file.
3. **`_get_processing_status` no longer substring-matches one phrase.** It decided `ready` vs `uploaded` by looking for the literal `"not implemented"` in the content, so rewording the notice would have marked an unread file as `ready`. It now derives the status from `_has_extractable_content()`, the check that already exists for exactly this purpose.

## How it was tested

- New unit test `tests/unit/tools/test_document_tools.py` (5 cases): text is extracted from a real `.docx`; an empty `.docx`, an unsupported format (`.xlsx`), a legacy `.doc` and a corrupt file each return a notice instead of fake content or an exception. The fixture builds a minimal WordprocessingML file with `zipfile`, so no binary is committed.
- Existing suites touching the file pipeline re-run green.

```
$ pytest tests/unit/tools/test_document_tools.py
5 passed

$ pytest tests/unit/routers/test_public_files_router.py \
         tests/unit/routers/test_public_chat_router.py \
         tests/unit/services/test_agent_execution_service.py
47 passed
```

## Breaking changes

None for callers. One visible behaviour change, which is the point of the fix: a `.docx` that previously produced a placeholder now produces the document's text, so `processing_status` becomes `ready` and `has_extractable_content` becomes `true` for those files.

## PR Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the changes
- [x] Added/updated tests if applicable
- [ ] Database migrations tested (upgrade and downgrade) if applicable — N/A, no schema change
- [ ] Documentation updated if applicable — N/A
- [x] No hardcoded secrets or credentials
- [x] Commit messages follow Conventional Commits format
- [x] Commits are signed

---

## Update after review (`4972d3a`)

Three points raised in review, all valid, all addressed:

1. **Placeholder detection was a substring match.** Extracted text containing `"File:"` in its body would have reported a successfully-read document as unread — a regression this PR would have introduced, since it is the change to `_get_processing_status` that put that check on the critical path. Now anchored on the prefix, which is exact: every notice this service produces *starts* with one. `"not implemented"` dropped from the list — its only producer is the OCR placeholder, which already starts with `"Image file:"`.
2. **The error notice carried the raw exception.** That string becomes the file's content: it reaches the model and the UI, leaking server paths and third-party parser internals. Detail now stays in the log; the content carries a stable notice.
3. **`process_file_for_agent` matched extensions against a category.** `_get_file_type_from_path()` returns `"text"`, the branch tested for `"txt"/"md"/"json"`, so text files fell through to the generic placeholder. Pre-existing and currently unreachable (the method has no callers), but it is the same bug this PR is about, so it is fixed here.

Test count is now 12 new (6 in `test_document_tools.py`, 6 in `test_file_reference_status.py`), including regressions for (1) and (2):

```
$ pytest tests/unit/tools/test_document_tools.py \
         tests/unit/services/test_file_reference_status.py \
         tests/unit/routers/test_public_files_router.py \
         tests/unit/routers/test_public_chat_router.py \
         tests/unit/services/test_agent_execution_service.py
59 passed
```
