### PR TITLE
feat(agents): orchestrator-level metadata dropdown filters for chat

### DIFF
--- a/alembic/versions/chatfilt001_add_agent_exposed_chat_filters.py
+++ b/alembic/versions/chatfilt001_add_agent_exposed_chat_filters.py
@@ -1,0 +1,22 @@
+"""add agent exposed chat filters column
+
+Revision ID: chatfilt001
+Revises: bedrock001
+Create Date: 2026-07-16
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'chatfilt001'
+down_revision = 'bedrock001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('Agent', sa.Column('exposed_chat_filters', sa.JSON(), nullable=False, server_default='[]'))
+
+
+def downgrade():
+    op.drop_column('Agent', 'exposed_chat_filters')

--- a/alembic/versions/d2268fd39f77_merge_chat_filter_and_user_email_dedup_.py
+++ b/alembic/versions/d2268fd39f77_merge_chat_filter_and_user_email_dedup_.py
@@ -1,0 +1,24 @@
+"""Merge chat-filter and user-email-dedup migration branches
+
+Revision ID: d2268fd39f77
+Revises: chatfilt001, useremail001
+Create Date: 2026-07-27 10:15:39.112865
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd2268fd39f77'
+down_revision = ('chatfilt001', 'useremail001')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/alembic/versions/useremail001_dedupe_users_add_unique_email.py
+++ b/alembic/versions/useremail001_dedupe_users_add_unique_email.py
@@ -1,0 +1,212 @@
+"""Merge duplicate User rows (same email) and add a unique constraint on User.email.
+
+Fixes the OIDC first-login race in ``UserService.get_or_create_user`` (check-then-insert
+with no DB-level uniqueness) that could create 2-3 ``User`` rows sharing the same email.
+The application-level race fix lives in a separate change; this migration only repairs
+existing data and closes the schema gap that let it happen.
+
+Data-merge strategy (irreversible - see downgrade note below):
+
+For every email with more than one ``User`` row, we pick a canonical row using an
+activity score - ``count(owned App) + count(APIKey) + count(AppCollaborator)
++ count(usage_records) + count(MarketplaceUsage)`` - tie-broken by the lowest
+``user_id`` (oldest row). All "loser" rows for that email are then folded into the
+canonical row before being deleted:
+
+- ``App.owner_id``, ``APIKey.user_id`` (NO ACTION FKs) - reassigned to canonical.
+- ``AppCollaborator.user_id`` (NO ACTION FK) - reassigned to canonical unless canonical
+  already has a collaborator row for the same ``app_id``, in which case the loser's row
+  is dropped instead (avoids a duplicate collaborator entry).
+- ``AppCollaborator.invited_by`` (SET NULL FK, not in the original FK table but found via
+  grep for ``ForeignKey('User.user_id')`` across backend/models/) - reassigned to
+  canonical to preserve "who invited" attribution instead of relying on SET NULL.
+- ``subscriptions.user_id`` / ``user_credentials.user_id`` (CASCADE, 1:1 unique) -
+  reassigned only if canonical doesn't already have one; otherwise the loser's row is
+  left in place and is removed by the CASCADE when the loser ``User`` row is deleted
+  (logged via RAISE NOTICE - rare edge case).
+- ``usage_records`` (CASCADE, unique on ``(user_id, billing_period_start)``) and
+  ``MarketplaceUsage`` (CASCADE, unique on ``(user_id, year, month)``) - overlapping
+  periods are summed (``call_count``) into canonical's row and the loser's row dropped;
+  non-overlapping periods are reassigned.
+- ``AgentMarketplaceRating`` (CASCADE, unique on ``(profile_id, user_id)``) - if both
+  duplicates rated the same profile, the more recently ``updated_at`` rating wins and
+  the other is dropped; otherwise reassigned.
+- ``Conversation.user_id`` and ``crawl_job.triggered_by_user_id`` (SET NULL, nullable) -
+  reassigned explicitly rather than relying on SET NULL, so chat history / crawl
+  attribution isn't orphaned.
+- ``refresh_tokens.user_id`` (CASCADE, no uniqueness) - left untouched; stale sessions on
+  the loser row are simply cascade-deleted with it.
+
+Revision ID: useremail001
+Revises: 20260717_conversation_starters
+Create Date: 2026-07-24
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'useremail001'
+down_revision = '20260717_conversation_starters'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- Data fix: merge duplicate User rows sharing the same email -----------------
+    # NOTE: this data merge is NOT reversible (rows are combined/deleted). See the
+    # downgrade() docstring below.
+    op.execute("""
+    DO $$
+    DECLARE
+        dup_email   RECORD;
+        canonical_id INTEGER;
+        loser       RECORD;
+    BEGIN
+        FOR dup_email IN
+            SELECT email
+            FROM "User"
+            WHERE email IS NOT NULL
+            GROUP BY email
+            HAVING COUNT(*) > 1
+        LOOP
+            -- Canonical = highest activity score, tie-broken by lowest (oldest) user_id.
+            SELECT u.user_id INTO canonical_id
+            FROM "User" u
+            WHERE u.email = dup_email.email
+            ORDER BY
+                (
+                    (SELECT COUNT(*) FROM "App" a WHERE a.owner_id = u.user_id) +
+                    (SELECT COUNT(*) FROM "APIKey" k WHERE k.user_id = u.user_id) +
+                    (SELECT COUNT(*) FROM "AppCollaborator" c WHERE c.user_id = u.user_id) +
+                    (SELECT COUNT(*) FROM usage_records ur WHERE ur.user_id = u.user_id) +
+                    (SELECT COUNT(*) FROM "MarketplaceUsage" mu WHERE mu.user_id = u.user_id)
+                ) DESC,
+                u.user_id ASC
+            LIMIT 1;
+
+            FOR loser IN
+                SELECT user_id FROM "User" WHERE email = dup_email.email AND user_id <> canonical_id
+            LOOP
+                -- App.owner_id (NO ACTION FK) -- reassign
+                UPDATE "App" SET owner_id = canonical_id WHERE owner_id = loser.user_id;
+
+                -- APIKey.user_id (NO ACTION FK) -- reassign
+                UPDATE "APIKey" SET user_id = canonical_id WHERE user_id = loser.user_id;
+
+                -- AppCollaborator.user_id (NO ACTION FK) -- reassign unless canonical
+                -- already collaborates on the same app, then drop the loser's duplicate row.
+                UPDATE "AppCollaborator" ac
+                SET user_id = canonical_id
+                WHERE ac.user_id = loser.user_id
+                  AND NOT EXISTS (
+                      SELECT 1 FROM "AppCollaborator" ac2
+                      WHERE ac2.app_id = ac.app_id AND ac2.user_id = canonical_id
+                  );
+
+                DELETE FROM "AppCollaborator" WHERE user_id = loser.user_id;
+
+                -- AppCollaborator.invited_by (SET NULL FK) -- reassign attribution explicitly
+                UPDATE "AppCollaborator" SET invited_by = canonical_id WHERE invited_by = loser.user_id;
+
+                -- subscriptions (CASCADE, 1:1 unique) -- reassign only if canonical has none
+                IF NOT EXISTS (SELECT 1 FROM subscriptions WHERE user_id = canonical_id) THEN
+                    UPDATE subscriptions SET user_id = canonical_id WHERE user_id = loser.user_id;
+                ELSIF EXISTS (SELECT 1 FROM subscriptions WHERE user_id = loser.user_id) THEN
+                    RAISE NOTICE 'user email-merge: subscription row for loser user_id % (email %) left in place to cascade-delete; canonical user_id % already has one.', loser.user_id, dup_email.email, canonical_id;
+                END IF;
+
+                -- user_credentials (CASCADE, 1:1 unique) -- reassign only if canonical has none
+                IF NOT EXISTS (SELECT 1 FROM user_credentials WHERE user_id = canonical_id) THEN
+                    UPDATE user_credentials SET user_id = canonical_id WHERE user_id = loser.user_id;
+                ELSIF EXISTS (SELECT 1 FROM user_credentials WHERE user_id = loser.user_id) THEN
+                    RAISE NOTICE 'user email-merge: user_credentials row for loser user_id % (email %) left in place to cascade-delete; canonical user_id % already has one.', loser.user_id, dup_email.email, canonical_id;
+                END IF;
+
+                -- usage_records (CASCADE, unique on user_id+billing_period_start) --
+                -- sum overlapping periods into canonical, then drop loser's dupes, then reassign the rest.
+                UPDATE usage_records ur_c
+                SET call_count = ur_c.call_count + ur_l.call_count,
+                    updated_at = GREATEST(ur_c.updated_at, ur_l.updated_at)
+                FROM usage_records ur_l
+                WHERE ur_c.user_id = canonical_id
+                  AND ur_l.user_id = loser.user_id
+                  AND ur_c.billing_period_start = ur_l.billing_period_start;
+
+                DELETE FROM usage_records ur_l
+                WHERE ur_l.user_id = loser.user_id
+                  AND EXISTS (
+                      SELECT 1 FROM usage_records ur_c
+                      WHERE ur_c.user_id = canonical_id
+                        AND ur_c.billing_period_start = ur_l.billing_period_start
+                  );
+
+                UPDATE usage_records SET user_id = canonical_id WHERE user_id = loser.user_id;
+
+                -- MarketplaceUsage (CASCADE, unique on user_id+year+month) -- same aggregate-or-reassign logic
+                UPDATE "MarketplaceUsage" mu_c
+                SET call_count = mu_c.call_count + mu_l.call_count,
+                    updated_at = GREATEST(mu_c.updated_at, mu_l.updated_at)
+                FROM "MarketplaceUsage" mu_l
+                WHERE mu_c.user_id = canonical_id
+                  AND mu_l.user_id = loser.user_id
+                  AND mu_c.year = mu_l.year
+                  AND mu_c.month = mu_l.month;
+
+                DELETE FROM "MarketplaceUsage" mu_l
+                WHERE mu_l.user_id = loser.user_id
+                  AND EXISTS (
+                      SELECT 1 FROM "MarketplaceUsage" mu_c
+                      WHERE mu_c.user_id = canonical_id
+                        AND mu_c.year = mu_l.year
+                        AND mu_c.month = mu_l.month
+                  );
+
+                UPDATE "MarketplaceUsage" SET user_id = canonical_id WHERE user_id = loser.user_id;
+
+                -- AgentMarketplaceRating (CASCADE, unique on profile_id+user_id) -- keep the
+                -- most-recently-updated rating on conflict, then reassign the rest.
+                UPDATE "AgentMarketplaceRating" r_c
+                SET rating = r_l.rating,
+                    updated_at = r_l.updated_at
+                FROM "AgentMarketplaceRating" r_l
+                WHERE r_c.user_id = canonical_id
+                  AND r_l.user_id = loser.user_id
+                  AND r_c.profile_id = r_l.profile_id
+                  AND r_l.updated_at > r_c.updated_at;
+
+                DELETE FROM "AgentMarketplaceRating" r_l
+                WHERE r_l.user_id = loser.user_id
+                  AND EXISTS (
+                      SELECT 1 FROM "AgentMarketplaceRating" r_c
+                      WHERE r_c.user_id = canonical_id
+                        AND r_c.profile_id = r_l.profile_id
+                  );
+
+                UPDATE "AgentMarketplaceRating" SET user_id = canonical_id WHERE user_id = loser.user_id;
+
+                -- Conversation.user_id (SET NULL, nullable) -- reassign explicitly, don't orphan chat history
+                UPDATE "Conversation" SET user_id = canonical_id WHERE user_id = loser.user_id;
+
+                -- crawl_job.triggered_by_user_id (SET NULL, nullable) -- reassign explicitly
+                UPDATE crawl_job SET triggered_by_user_id = canonical_id WHERE triggered_by_user_id = loser.user_id;
+
+                -- refresh_tokens.user_id (CASCADE, no uniqueness) -- intentionally left alone;
+                -- stale sessions on the loser row cascade-delete with it below.
+            END LOOP;
+
+            -- All loser rows for this email are now safe to delete.
+            DELETE FROM "User" WHERE email = dup_email.email AND user_id <> canonical_id;
+        END LOOP;
+    END $$;
+    """)
+
+    # --- Schema fix: prevent this from ever happening again --------------------------
+    op.create_unique_constraint('uq_user_email', 'User', ['email'])
+
+
+def downgrade() -> None:
+    # The row merge performed in upgrade() is NOT reversible -- duplicate rows were
+    # combined (usage/rating data summed, FKs repointed) and the loser rows deleted.
+    # There is no data to restore. Downgrade only removes the schema constraint so a
+    # subsequent upgrade path (or manual recovery) isn't blocked by it.
+    op.drop_constraint('uq_user_email', 'User', type_='unique')

--- a/backend/models/agent.py
+++ b/backend/models/agent.py
@@ -83,6 +83,7 @@ class Agent(Base):
     rag_search_type = Column(String(45), default='similarity', nullable=False, server_default='similarity')
     rag_score_threshold = Column(Float, nullable=True)  # only used when rag_search_type='similarity_score_threshold'
     rag_fixed_filters = Column(JSON, nullable=True)     # list of {field, op, value} filter clauses applied on every retrieval
+    exposed_chat_filters = Column(JSON, default=list, nullable=False, server_default='[]')  # list of metadata field names the designer exposes as end-user chat-time dropdown filters
     rag_max_retrieval_calls = Column(Integer, nullable=True)  # NULL = legacy unbounded behaviour
 
     # Memory management via LangChain SummarizationMiddleware (when has_memory=True)

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,5 +1,5 @@
 import enum
-from sqlalchemy import Column, Integer, String, DateTime, Boolean
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, UniqueConstraint
 from sqlalchemy.orm import relationship
 from db.database import Base
 from datetime import datetime
@@ -13,6 +13,11 @@ class PlatformRole(str, enum.Enum):
 
 class User(Base):
     __tablename__ = 'User'
+    # Named to match the constraint added by alembic/versions/useremail001_dedupe_users_add_unique_email.py
+    # -- keeps ORM metadata and the real migration-managed schema in agreement (autogenerate-safe).
+    __table_args__ = (
+        UniqueConstraint('email', name='uq_user_email'),
+    )
     user_id = Column(Integer, primary_key=True)
     email = Column(String(255))
     name = Column(String(255))

--- a/backend/routers/internal/agents.py
+++ b/backend/routers/internal/agents.py
@@ -386,6 +386,11 @@ async def create_or_update_agent(
         'silo_id': agent_data.silo_id,
         'output_parser_id': agent_data.output_parser_id,
         'temperature': agent_data.temperature,
+        # tool_ids is included here (in addition to being used below for
+        # update_agent_tools) so that AgentService.create_or_update_agent can
+        # validate exposed_chat_filters against the in-progress subagent
+        # selection, before update_agent_tools() reconciles the actual M:N rows.
+        'tool_ids': agent_data.tool_ids or [],
         # OCR-specific fields
         'vision_service_id': agent_data.vision_service_id,
         'vision_system_prompt': agent_data.vision_system_prompt,
@@ -396,6 +401,8 @@ async def create_or_update_agent(
         'rag_score_threshold': agent_data.rag_score_threshold,
         'rag_max_retrieval_calls': agent_data.rag_max_retrieval_calls,
         'rag_fixed_filters': agent_data.rag_fixed_filters,
+        # Orchestrator-level chat-time dropdown filter whitelist
+        'exposed_chat_filters': agent_data.exposed_chat_filters,
     }
 
     # Avoid logging full prompt bodies / filter values at INFO; log identity + shape only.
@@ -474,6 +481,54 @@ async def get_agent_mcp_usage(
         "mcp_servers": servers,
         "used_in_mcp_servers": len(servers) > 0
     }
+
+
+@agents_router.get("/{agent_id}/available-chat-filter-fields",
+                   summary="Get available chat-time dropdown filter fields",
+                   tags=["Agents"])
+async def get_available_chat_filter_fields(
+    app_id: int,
+    agent_id: int,
+    auth_context: Annotated[AuthContext, Depends(get_current_user_oauth)],
+    role: Annotated[AppRole, Depends(require_min_role("editor"))],
+    db: Annotated[Session, Depends(get_db)],
+    agent_service: Annotated[AgentService, Depends(get_agent_service)],
+    tool_ids: Annotated[List[int], Query()] = [],
+    silo_id: Annotated[Optional[int], Query()] = None,
+):
+    """
+    Get the union of metadata filter fields available to expose as end-user
+    chat-time dropdown filters, aggregated from the given candidate subagents'
+    silos plus the given silo (typically the orchestrator's own).
+
+    agent_id is accepted for REST consistency / future permission scoping, but
+    the fields are computed purely from the tool_ids/silo_id query params — the
+    agent itself need not exist yet (e.g. this endpoint is also called while
+    still creating a new agent, using the "new agent" sentinel agent_id=0).
+    """
+    fields = agent_service.get_available_chat_filter_fields(db, tool_ids, silo_id)
+    return {"fields": fields}
+
+
+@agents_router.get("/{agent_id}/chat-filters",
+                   summary="Get chat-time dropdown filter values for an agent",
+                   tags=["Agents"])
+async def get_chat_filter_values(
+    app_id: int,
+    agent_id: int,
+    auth_context: Annotated[AuthContext, Depends(get_current_user_oauth)],
+    role: Annotated[AppRole, Depends(require_min_role("viewer"))],
+    db: Annotated[Session, Depends(get_db)],
+    agent_service: Annotated[AgentService, Depends(get_agent_service)],
+):
+    """
+    Get the distinct values for each metadata field the designer exposed via
+    ``exposed_chat_filters``, for use by the Playground's chat-time dropdown
+    filters. Any user able to chat with the agent can call this (viewer role).
+    """
+    agent = _get_agent_or_404(db, agent_id, app_id)
+    filters = agent_service.get_chat_filter_values(db, agent)
+    return {"filters": filters}
 
 
 @agents_router.post("/{agent_id}/update-prompt",

--- a/backend/routers/internal/marketplace.py
+++ b/backend/routers/internal/marketplace.py
@@ -295,7 +295,6 @@ async def get_marketplace_conversation(
         )
         return ConversationWithHistoryResponse(
             **conversation.to_dict(),
-            app_id=conversation.agent.app_id,
             messages=history or [],
         )
     except Exception as e:

--- a/backend/routers/internal/marketplace.py
+++ b/backend/routers/internal/marketplace.py
@@ -7,7 +7,7 @@ from utils.security import generate_signature
 
 from lks_idprovider import AuthContext
 from sqlalchemy.orm import Session
-from typing import AsyncGenerator, List, Optional, Dict, Annotated
+from typing import Any, AsyncGenerator, List, Optional, Dict, Annotated
 
 from db.database import get_db
 from routers.internal.auth_utils import get_current_user_oauth
@@ -504,6 +504,24 @@ def _parse_file_references_json(file_references: Optional[str]) -> Optional[list
         return None
 
 
+def _parse_optional_json(value: Optional[str], param_name: str) -> Any:
+    """Parse a JSON-encoded optional string, logging a warning on decode failure.
+
+    Mirrors the identically-named helper in ``routers/internal/agents.py`` so the
+    Playground and Marketplace chat endpoints handle the ``search_params`` form
+    field the same way. Kept file-local since the helper in ``agents.py`` is
+    file-private too and duplicating small parsing helpers is the established
+    pattern in this router (see ``_parse_file_references_json`` above).
+    """
+    if not value:
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        logger.warning(f"Invalid {param_name} JSON, ignoring")
+        return None
+
+
 def _extract_jwt_token(request: Request) -> Optional[str]:
     """Extract JWT token from Authorization header."""
     auth_header = request.headers.get("Authorization", "")
@@ -584,6 +602,29 @@ def _prepare_marketplace_chat(
     return conversation, agent
 
 
+@marketplace_router.get(
+    "/conversations/{conversation_id}/chat-filters",
+    summary="Get chat-time dropdown filter values for a marketplace conversation's agent",
+)
+async def get_marketplace_chat_filter_values(
+    conversation_id: int,
+    db: Annotated[Session, Depends(get_db)],
+    current_user: Annotated[AuthContext, Depends(get_current_user_oauth)],
+):
+    """Get distinct values for the agent's exposed chat-time dropdown filters.
+
+    Reuses ``_prepare_marketplace_chat`` for the established
+    ownership/visibility/quota validation on this router, even though this is
+    a pure read — it's a one-shot call on chat page load, not per-message, so
+    the quota check it performs is a negligible cost.
+    """
+    user_id = int(current_user.identity.id)
+    _, agent = _prepare_marketplace_chat(conversation_id, user_id, db)
+
+    filters = AgentService().get_chat_filter_values(db, agent)
+    return {"filters": filters}
+
+
 @marketplace_router.post(
     "/conversations/{conversation_id}/chat",
     summary="Chat in marketplace conversation",
@@ -597,6 +638,7 @@ async def marketplace_chat(
     current_user: Annotated[AuthContext, Depends(get_current_user_oauth)],
     files: Annotated[List[UploadFile], File()] = None,
     file_references: Annotated[Optional[str], Form()] = None,
+    search_params: Annotated[Optional[str], Form()] = None,
 ):
     """Send a message in a marketplace conversation."""
     user_id = int(current_user.identity.id)
@@ -606,6 +648,7 @@ async def marketplace_chat(
     all_file_references: list = []
     try:
         parsed_refs = _parse_file_references_json(file_references)
+        parsed_search_params = _parse_optional_json(search_params, "search_params")
         jwt_token = _extract_jwt_token(request)
 
         user_context = {
@@ -630,7 +673,7 @@ async def marketplace_chat(
             agent_id=agent.agent_id,
             message=message,
             file_references=all_file_references,
-            search_params=None,
+            search_params=parsed_search_params,
             user_context=user_context,
             conversation_id=conversation_id,
             db=db,
@@ -669,6 +712,7 @@ async def marketplace_chat_stream(
     current_user: Annotated[AuthContext, Depends(get_current_user_oauth)],
     files: Annotated[List[UploadFile], File()] = None,
     file_references: Annotated[Optional[str], Form()] = None,
+    search_params: Annotated[Optional[str], Form()] = None,
 ):
     """Stream a marketplace chat turn as Server-Sent Events.
 
@@ -680,6 +724,7 @@ async def marketplace_chat_stream(
 
     try:
         parsed_refs = _parse_file_references_json(file_references)
+        parsed_search_params = _parse_optional_json(search_params, "search_params")
         jwt_token = _extract_jwt_token(request)
 
         user_context = {
@@ -705,7 +750,7 @@ async def marketplace_chat_stream(
             agent_id=agent.agent_id,
             message=message,
             file_references=all_file_references,
-            search_params=None,
+            search_params=parsed_search_params,
             user_context=user_context,
             conversation_id=conversation_id,
             db=db,

--- a/backend/routers/public/v1/agents.py
+++ b/backend/routers/public/v1/agents.py
@@ -9,6 +9,7 @@ from schemas.agent_schemas import (
     PublicAgentDetailSchema,
     PublicAgentsResponseSchema,
     PublicAgentResponseSchema,
+    PublicChatFilterFieldSchema,
     CreateAgentRequestSchema,
     CreateOCRAgentRequestSchema,
     UpdateAgentRequestSchema,
@@ -329,3 +330,40 @@ async def delete_agent(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Failed to delete agent",
         )
+
+
+# ==================== CHAT-TIME FILTER METADATA ====================
+
+
+@agents_router.get(
+    "/{agent_id}/chat-filters/{field_name}",
+    summary="Get distinct values for one chat-time filter field",
+    tags=["Agents"],
+    response_model=PublicChatFilterFieldSchema,
+)
+async def get_chat_filter_field_values(
+    app_id: int,
+    agent_id: int,
+    field_name: str,
+    api_key: Annotated[str, Depends(get_api_key_auth)],
+    db: Annotated[Session, Depends(get_db)],
+):
+    """
+    Get the distinct values for a single metadata filter field the agent
+    designer exposed via exposed_chat_filters, aggregated across the agent's
+    own silo and all its subagents' silos. 404 if field_name is not one of
+    this agent's exposed filters. Use the returned values to build
+    search_params.filter before calling /call or /call/stream.
+    """
+    validate_api_key_for_app(app_id, api_key, db)
+    agent = validate_agent_ownership(db, agent_id, app_id)
+
+    agent_service = AgentService()
+    values = agent_service.get_chat_filter_field_values(db, agent, field_name)
+    if values is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Filter '{field_name}' not found for this agent",
+        )
+
+    return PublicChatFilterFieldSchema(field_name=field_name, values=values)

--- a/backend/routers/public/v1/schemas.py
+++ b/backend/routers/public/v1/schemas.py
@@ -190,6 +190,17 @@ class UpdatedCountResponseSchema(BaseModel):
     """Number of documents whose metadata was updated"""
     updated: int
 
+class MetadataValuesRequestSchema(BaseModel):
+    """Schema for listing the distinct values of a metadata field"""
+    field: str
+    filter_metadata: Optional[Dict[str, Any]] = None
+    prefix: Optional[str] = None
+    limit: Optional[int] = None
+
+class MetadataValuesResponseSchema(BaseModel):
+    """Distinct values of a metadata field"""
+    values: List[str]
+
 class DocumentSchema(BaseModel):
     """Document schema"""
     page_content: str

--- a/backend/routers/public/v1/schemas.py
+++ b/backend/routers/public/v1/schemas.py
@@ -176,6 +176,10 @@ class DeleteByMetadataRequestSchema(BaseModel):
     """Schema for deleting documents by metadata filter"""
     filter_metadata: Dict[str, Any]
 
+class CountByMetadataRequestSchema(BaseModel):
+    """Schema for counting documents by metadata filter"""
+    filter_metadata: Dict[str, Any]
+
 class DocumentSchema(BaseModel):
     """Document schema"""
     page_content: str

--- a/backend/routers/public/v1/schemas.py
+++ b/backend/routers/public/v1/schemas.py
@@ -180,6 +180,16 @@ class CountByMetadataRequestSchema(BaseModel):
     """Schema for counting documents by metadata filter"""
     filter_metadata: Dict[str, Any]
 
+class UpdateMetadataRequestSchema(BaseModel):
+    """Schema for updating the metadata of documents matching a filter"""
+    filter_metadata: Dict[str, Any]
+    metadata_updates: Dict[str, Any]
+    replace: bool = False
+
+class UpdatedCountResponseSchema(BaseModel):
+    """Number of documents whose metadata was updated"""
+    updated: int
+
 class DocumentSchema(BaseModel):
     """Document schema"""
     page_content: str

--- a/backend/routers/public/v1/silos.py
+++ b/backend/routers/public/v1/silos.py
@@ -15,6 +15,8 @@ from .schemas import (
     DeleteDocsRequestSchema,
     DeleteByMetadataRequestSchema,
     CountByMetadataRequestSchema,
+    UpdateMetadataRequestSchema,
+    UpdatedCountResponseSchema,
     DocsResponseSchema,
     FileIndexResponseSchema,
     PublicSiloSchema,
@@ -505,6 +507,58 @@ async def count_docs_by_metadata(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Failed to count documents",
+        )
+
+
+@silos_router.post(
+    "/{silo_id}/docs/update-metadata",
+    summary="Update docs metadata by metadata filter",
+    tags=["Silos"],
+    response_model=UpdatedCountResponseSchema,
+)
+async def update_docs_metadata(
+    app_id: int,
+    silo_id: int,
+    request: UpdateMetadataRequestSchema,
+    api_key: Annotated[str, Depends(get_api_key_auth)],
+    db: Annotated[Session, Depends(get_db)],
+):
+    """Update the metadata of the documents matching a filter, in place.
+
+    Re-labels existing chunks without re-embedding them: vectors and content are
+    untouched. By default the updates are merged over the current metadata, so
+    the call is idempotent; `replace: true` overwrites it wholesale.
+    """
+    validate_api_key_for_app(app_id, api_key, db)
+    validate_silo_ownership(db, silo_id, app_id)
+
+    try:
+        if not request.filter_metadata:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="filter_metadata cannot be empty",
+            )
+        if not request.metadata_updates:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="metadata_updates cannot be empty",
+            )
+
+        updated = SiloService.update_docs_metadata(
+            silo_id=silo_id,
+            filter_metadata=request.filter_metadata,
+            metadata_updates=request.metadata_updates,
+            replace=request.replace,
+            db=db,
+        )
+        return UpdatedCountResponseSchema(updated=updated)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating documents metadata in silo {silo_id} for app {app_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to update documents metadata",
         )
 
 

--- a/backend/routers/public/v1/silos.py
+++ b/backend/routers/public/v1/silos.py
@@ -14,6 +14,7 @@ from .schemas import (
     MultipleDocumentIndexSchema,
     DeleteDocsRequestSchema,
     DeleteByMetadataRequestSchema,
+    CountByMetadataRequestSchema,
     DocsResponseSchema,
     FileIndexResponseSchema,
     PublicSiloSchema,
@@ -464,6 +465,46 @@ async def delete_docs_by_metadata(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Failed to delete documents",
+        )
+
+
+@silos_router.post(
+    "/{silo_id}/docs/count-by-metadata",
+    summary="Count docs by metadata filter",
+    tags=["Silos"],
+    response_model=CountResponseSchema,
+)
+async def count_docs_by_metadata(
+    app_id: int,
+    silo_id: int,
+    request: CountByMetadataRequestSchema,
+    api_key: Annotated[str, Depends(get_api_key_auth)],
+    db: Annotated[Session, Depends(get_db)],
+):
+    """Count documents matching a metadata filter (MongoDB-style operators)."""
+    validate_api_key_for_app(app_id, api_key, db)
+    validate_silo_ownership(db, silo_id, app_id)
+
+    try:
+        if not request.filter_metadata:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="filter_metadata cannot be empty",
+            )
+
+        count = SiloService.count_docs_with_filter(
+            silo_id=silo_id,
+            filter_metadata=request.filter_metadata,
+            db=db,
+        )
+        return CountResponseSchema(count=count)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error counting documents by metadata in silo {silo_id} for app {app_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to count documents",
         )
 
 

--- a/backend/routers/public/v1/silos.py
+++ b/backend/routers/public/v1/silos.py
@@ -5,7 +5,7 @@ import json
 import tempfile
 import os
 
-from services.silo_service import SiloService
+from services.silo_service import DEFAULT_METADATA_VALUES_LIMIT, SiloService
 
 from .schemas import (
     MessageResponseSchema,
@@ -17,6 +17,8 @@ from .schemas import (
     CountByMetadataRequestSchema,
     UpdateMetadataRequestSchema,
     UpdatedCountResponseSchema,
+    MetadataValuesRequestSchema,
+    MetadataValuesResponseSchema,
     DocsResponseSchema,
     FileIndexResponseSchema,
     PublicSiloSchema,
@@ -507,6 +509,59 @@ async def count_docs_by_metadata(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Failed to count documents",
+        )
+
+
+@silos_router.post(
+    "/{silo_id}/docs/metadata-values",
+    summary="List the distinct values of a metadata field",
+    tags=["Silos"],
+    response_model=MetadataValuesResponseSchema,
+)
+async def list_metadata_values(
+    app_id: int,
+    silo_id: int,
+    request: MetadataValuesRequestSchema,
+    api_key: Annotated[str, Depends(get_api_key_auth)],
+    db: Annotated[Session, Depends(get_db)],
+):
+    """List the distinct values a metadata field takes in a silo.
+
+    Enumeration, not search: it is resolved with a SELECT DISTINCT over the
+    collection, so there is no embedding call and no similarity ranking. Use it
+    to find out what a silo already holds for a target — `docs/find` is a
+    top-k semantic search and its result cap makes it unfit for that.
+    """
+    validate_api_key_for_app(app_id, api_key, db)
+    validate_silo_ownership(db, silo_id, app_id)
+
+    try:
+        if not request.field or not request.field.strip():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="field cannot be empty",
+            )
+
+        values = SiloService.get_metadata_field_values(
+            silo_id=silo_id,
+            field=request.field.strip(),
+            prefix=request.prefix,
+            limit=request.limit or DEFAULT_METADATA_VALUES_LIMIT,
+            db=db,
+            filter_metadata=request.filter_metadata,
+        )
+        return MetadataValuesResponseSchema(values=values)
+    except HTTPException:
+        raise
+    except ValueError as e:
+        # Only ever raised for an invalid field name, which quotes the caller's
+        # own input — safe to surface.
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error listing metadata values in silo {silo_id} for app {app_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to list metadata values",
         )
 
 

--- a/backend/schemas/agent_schemas.py
+++ b/backend/schemas/agent_schemas.py
@@ -365,3 +365,9 @@ class PublicAgentsResponseSchema(BaseModel):
 class PublicAgentResponseSchema(BaseModel):
     """Single agent response for public API"""
     agent: PublicAgentDetailSchema
+
+
+class PublicChatFilterFieldSchema(BaseModel):
+    """Distinct values for one chat-time metadata filter field, public API."""
+    field_name: str
+    values: List[str]

--- a/backend/schemas/agent_schemas.py
+++ b/backend/schemas/agent_schemas.py
@@ -61,6 +61,28 @@ class RagConfigFieldsMixin(BaseModel):
         return validated
 
 
+class ExposedChatFiltersMixin(BaseModel):
+    """Shared ``exposed_chat_filters`` field + validator.
+
+    Agent-level (not silo-scoped): a whitelist of metadata field NAMES the
+    designer allows end users to pick a value for as chat-time dropdown
+    filters. Distinct from ``rag_fixed_filters`` (admin-pinned, always
+    applied on every retrieval) — this is just a whitelist of names the
+    Playground/Marketplace chat UI may surface as end-user-selectable
+    dropdowns. Doesn't require a silo since an orchestrator often has none
+    of its own — its candidate fields are unioned from its attached
+    subagents' silos too.
+    """
+    exposed_chat_filters: Optional[List[str]] = []
+
+    @field_validator("exposed_chat_filters")
+    @classmethod
+    def validate_exposed_chat_filters(cls, v: Optional[List[str]]) -> List[str]:
+        if not v:
+            return []
+        return list(dict.fromkeys(s.strip() for s in v if isinstance(s, str) and s.strip()))
+
+
 class RuntimeSearchParamsSchema(BaseModel):
     """Bounds for caller-supplied runtime search params on the public chat API.
 
@@ -165,11 +187,12 @@ class AgentDetailSchema(BaseModel):
     rag_score_threshold: Optional[float] = None
     rag_max_retrieval_calls: Optional[int] = None
     rag_fixed_filters: Optional[List[dict]] = None
+    exposed_chat_filters: List[str] = []
 
     model_config = ConfigDict(from_attributes=True)
 
 
-class CreateUpdateAgentSchema(RagConfigFieldsMixin):
+class CreateUpdateAgentSchema(RagConfigFieldsMixin, ExposedChatFiltersMixin):
     """Schema for creating or updating an agent"""
     name: str
     description: Optional[str] = ""

--- a/backend/schemas/conversation_schemas.py
+++ b/backend/schemas/conversation_schemas.py
@@ -24,7 +24,6 @@ class ConversationResponse(ConversationBase):
     """Schema for conversation response"""
     conversation_id: int
     agent_id: int
-    app_id: int
     user_id: Optional[int] = None
     session_id: str
     created_at: datetime

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -1,10 +1,11 @@
-from typing import Union, List, Dict, Any, Optional
+from typing import Union, List, Dict, Any, Optional, Set
 from sqlalchemy.orm import Session
 from models.agent import Agent, DEFAULT_AGENT_TEMPERATURE, DEFAULT_MEMORY_SUMMARIZE_THRESHOLD
 from models.ocr_agent import OCRAgent
 from schemas.agent_schemas import AgentListItemSchema, AgentDetailSchema
 from repositories.agent_repository import AgentRepository
 from repositories.skill_repository import SkillRepository
+from services.metadata_values_cache_service import MetadataValuesCacheService
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -143,6 +144,7 @@ class AgentService:
             rag_score_threshold=getattr(agent, 'rag_score_threshold', None) if isinstance(getattr(agent, 'rag_score_threshold', None), (float, int, type(None))) else None,
             rag_max_retrieval_calls=getattr(agent, 'rag_max_retrieval_calls', None) if isinstance(getattr(agent, 'rag_max_retrieval_calls', None), (int, type(None))) else None,
             rag_fixed_filters=getattr(agent, 'rag_fixed_filters', None) if isinstance(getattr(agent, 'rag_fixed_filters', None), (list, type(None))) else None,
+            exposed_chat_filters=getattr(agent, 'exposed_chat_filters', None) or [],
         )
 
     def _get_agent_for_detail(self, db: Session, agent_id: int):
@@ -190,7 +192,167 @@ class AgentService:
     def get_agent(self, db: Session, agent_id: int, agent_type: str = 'basic') -> Union[Agent, OCRAgent]:
         """Get agent by ID and type"""
         return AgentRepository.get_agent_by_id_and_type(db, agent_id, agent_type)
-    
+
+    def get_available_chat_filter_fields(
+        self, db: Session, tool_ids: List[int], own_silo_id: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get the union of metadata filter fields available for chat-time exposure.
+
+        Aggregates ``{name, type, description}`` entries from the metadata
+        definitions of the given candidate subagent silos plus the orchestrator's
+        own silo (if any). Accepts raw candidate ``tool_ids``/``own_silo_id``
+        (not persisted ``AgentTool`` associations) so it works mid-edit, before
+        the agent (or its subagent associations) has actually been saved.
+
+        On a name collision across silos the first-seen ``type`` wins. Never
+        raises: a broken or missing metadata_definition for one silo simply
+        contributes nothing to the union.
+
+        Args:
+            db: Database session.
+            tool_ids: Candidate subagent agent_ids (may include non-tool agents;
+                any without a silo are skipped).
+            own_silo_id: The orchestrator's own silo_id, if any.
+
+        Returns:
+            List of ``{"name": str, "type": str, "description": Optional[str]}``
+            dicts, sorted by name.
+        """
+        silo_ids: set = set()
+        if own_silo_id:
+            silo_ids.add(own_silo_id)
+
+        if tool_ids:
+            rows = db.query(Agent.agent_id, Agent.silo_id).filter(Agent.agent_id.in_(tool_ids)).all()
+            for _, silo_id in rows:
+                if silo_id:
+                    silo_ids.add(silo_id)
+
+        fields_by_name: Dict[str, Dict[str, Any]] = {}
+        for silo_id in silo_ids:
+            try:
+                silo_info = AgentRepository.get_silo_with_metadata_definition(db, silo_id)
+                metadata_def = silo_info.get('metadata_definition') if silo_info else None
+                fields = (metadata_def or {}).get('fields') or []
+                for field in fields:
+                    if not isinstance(field, dict) or not field.get('name'):
+                        continue
+                    name = field['name']
+                    if name not in fields_by_name:
+                        fields_by_name[name] = {
+                            'name': name,
+                            'type': field.get('type', 'str'),
+                            'description': field.get('description'),
+                        }
+            except Exception as exc:
+                logger.warning(f"Failed to load metadata definition for silo {silo_id}: {exc}")
+                continue
+
+        return sorted(fields_by_name.values(), key=lambda f: f['name'])
+
+    def _get_silo_ids_by_metadata_field(self, db: Session, silo_ids: Set[int]) -> Dict[str, Set[int]]:
+        """Map each declared metadata field name to the silo_ids that declare it.
+
+        Reuses the same ``AgentRepository.get_silo_with_metadata_definition``
+        lookup as :meth:`get_available_chat_filter_fields`, but keeps the
+        silo-to-field association instead of collapsing it to a name union,
+        since callers need to know which silo(s) to query for a given field's
+        distinct values.
+
+        Never raises: a broken or missing metadata_definition for one silo
+        simply contributes nothing.
+
+        Args:
+            db: Database session.
+            silo_ids: Candidate silo_ids to inspect.
+
+        Returns:
+            Dict mapping field name to the set of silo_ids declaring it.
+        """
+        field_to_silos: Dict[str, Set[int]] = {}
+        for silo_id in silo_ids:
+            try:
+                silo_info = AgentRepository.get_silo_with_metadata_definition(db, silo_id)
+                metadata_def = silo_info.get('metadata_definition') if silo_info else None
+                fields = (metadata_def or {}).get('fields') or []
+                for field in fields:
+                    if not isinstance(field, dict) or not field.get('name'):
+                        continue
+                    field_to_silos.setdefault(field['name'], set()).add(silo_id)
+            except Exception as exc:
+                logger.warning(f"Failed to load metadata definition for silo {silo_id}: {exc}")
+                continue
+        return field_to_silos
+
+    def get_chat_filter_values(self, db: Session, agent: Agent) -> List[Dict[str, Any]]:
+        """Get the distinct values for each orchestrator-exposed chat filter field.
+
+        For every field name in ``agent.exposed_chat_filters``, finds every silo
+        (the agent's own silo, plus each direct subagent's silo) whose
+        ``metadata_definition`` declares that field, then unions the DISTINCT
+        values for that field across those silos via
+        :meth:`MetadataValuesCacheService.get_distinct_values` (TTL-cached, so
+        N-subagent fan-out on every chat page load doesn't hit the vector store
+        repeatedly).
+
+        Never raises: a failure fetching values for one silo/field is logged
+        and skipped, never blowing up the aggregation for other fields/silos.
+        A field is omitted entirely when no silo declares it or the union of
+        values is empty.
+
+        Args:
+            db: Database session.
+            agent: The orchestrator agent (its ``exposed_chat_filters``,
+                ``silo_id`` and ``tool_associations`` are read directly).
+
+        Returns:
+            List of ``{"field_name": str, "values": List[str]}`` dicts, sorted
+            by field_name, with each field's values sorted too.
+        """
+        exposed_fields = getattr(agent, 'exposed_chat_filters', None) or []
+        if not exposed_fields:
+            return []
+
+        silo_ids: Set[int] = set()
+        own_silo_id = getattr(agent, 'silo_id', None)
+        if own_silo_id:
+            silo_ids.add(own_silo_id)
+
+        for assoc in getattr(agent, 'tool_associations', None) or []:
+            tool = getattr(assoc, 'tool', None)
+            tool_silo_id = getattr(tool, 'silo_id', None) if tool else None
+            if tool_silo_id:
+                silo_ids.add(tool_silo_id)
+
+        if not silo_ids:
+            return []
+
+        field_to_silos = self._get_silo_ids_by_metadata_field(db, silo_ids)
+
+        results: List[Dict[str, Any]] = []
+        for field_name in exposed_fields:
+            candidate_silo_ids = field_to_silos.get(field_name)
+            if not candidate_silo_ids:
+                continue
+
+            values: Set[str] = set()
+            for silo_id in candidate_silo_ids:
+                try:
+                    silo_values = MetadataValuesCacheService.get_distinct_values(silo_id, field_name, db)
+                    values.update(silo_values)
+                except Exception as exc:
+                    logger.warning(
+                        f"Failed to fetch distinct values for silo {silo_id}, field {field_name!r}: {exc}"
+                    )
+                    continue
+
+            if not values:
+                continue
+
+            results.append({"field_name": field_name, "values": sorted(values)})
+
+        return sorted(results, key=lambda r: r['field_name'])
+
     def create_or_update_agent(self, db: Session, agent_data: dict, agent_type: str, user_id: int = None) -> int:
         """Create or update agent"""
         agent_id = agent_data.get('agent_id')
@@ -240,6 +402,24 @@ class AgentService:
                 raise ValueError(
                     f"rag_fixed_filters references unknown metadata fields: {unknown}. "
                     f"Allowed fields: {sorted(declared_fields)}"
+                )
+
+        # Validate exposed_chat_filters against the union of metadata fields available
+        # from the agent's own silo + its candidate subagents' silos. Uses the raw
+        # incoming tool_ids/silo_id (not persisted associations) so it works mid-edit,
+        # before update_agent_tools() reconciles the actual M:N rows (it runs after
+        # this method returns).
+        raw_exposed_filters = agent_data.get('exposed_chat_filters')
+        if raw_exposed_filters:
+            candidate_tool_ids = agent_data.get('tool_ids') or []
+            candidate_silo_id = agent_data.get('silo_id') or getattr(agent, 'silo_id', None)
+            available = self.get_available_chat_filter_fields(db, candidate_tool_ids, candidate_silo_id)
+            available_names = {f['name'] for f in available}
+            unknown_chat_filters = [name for name in raw_exposed_filters if name not in available_names]
+            if unknown_chat_filters:
+                raise ValueError(
+                    f"exposed_chat_filters references unknown metadata fields: {unknown_chat_filters}. "
+                    f"Available fields: {sorted(available_names)}"
                 )
 
         update_method = self._update_normal_agent
@@ -340,6 +520,11 @@ class AgentService:
             agent.rag_score_threshold = data['rag_score_threshold']
         if 'rag_fixed_filters' in data:
             agent.rag_fixed_filters = data['rag_fixed_filters']
+
+        # exposed_chat_filters (orchestrator-level chat dropdown whitelist): the
+        # column is NOT NULL, so always coerce to a list, clearing via explicit [].
+        if 'exposed_chat_filters' in data:
+            agent.exposed_chat_filters = data.get('exposed_chat_filters') or []
 
     def update_agent_tools(self, db: Session, agent_id: int, tool_ids: list, form_data: dict = None):
         """Update agent tools associations"""

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -284,6 +284,42 @@ class AgentService:
                 continue
         return field_to_silos
 
+    def _collect_candidate_silo_ids(self, agent: Agent) -> Set[int]:
+        """Own silo_id + each direct subagent's silo_id.
+
+        Shared by :meth:`get_chat_filter_values` and
+        :meth:`get_chat_filter_field_values` so the traversal logic lives once.
+        """
+        silo_ids: Set[int] = set()
+        own_silo_id = getattr(agent, 'silo_id', None)
+        if own_silo_id:
+            silo_ids.add(own_silo_id)
+
+        for assoc in getattr(agent, 'tool_associations', None) or []:
+            tool = getattr(assoc, 'tool', None)
+            tool_silo_id = getattr(tool, 'silo_id', None) if tool else None
+            if tool_silo_id:
+                silo_ids.add(tool_silo_id)
+
+        return silo_ids
+
+    def _fetch_distinct_values(self, db: Session, silo_ids: Set[int], field_name: str) -> Set[str]:
+        """Union distinct values for *field_name* across *silo_ids*.
+
+        Never raises: a failure fetching values for one silo is logged and
+        skipped, never blowing up the aggregation for the others.
+        """
+        values: Set[str] = set()
+        for silo_id in silo_ids:
+            try:
+                values.update(MetadataValuesCacheService.get_distinct_values(silo_id, field_name, db))
+            except Exception as exc:
+                logger.warning(
+                    f"Failed to fetch distinct values for silo {silo_id}, field {field_name!r}: {exc}"
+                )
+                continue
+        return values
+
     def get_chat_filter_values(self, db: Session, agent: Agent) -> List[Dict[str, Any]]:
         """Get the distinct values for each orchestrator-exposed chat filter field.
 
@@ -313,17 +349,7 @@ class AgentService:
         if not exposed_fields:
             return []
 
-        silo_ids: Set[int] = set()
-        own_silo_id = getattr(agent, 'silo_id', None)
-        if own_silo_id:
-            silo_ids.add(own_silo_id)
-
-        for assoc in getattr(agent, 'tool_associations', None) or []:
-            tool = getattr(assoc, 'tool', None)
-            tool_silo_id = getattr(tool, 'silo_id', None) if tool else None
-            if tool_silo_id:
-                silo_ids.add(tool_silo_id)
-
+        silo_ids = self._collect_candidate_silo_ids(agent)
         if not silo_ids:
             return []
 
@@ -335,23 +361,51 @@ class AgentService:
             if not candidate_silo_ids:
                 continue
 
-            values: Set[str] = set()
-            for silo_id in candidate_silo_ids:
-                try:
-                    silo_values = MetadataValuesCacheService.get_distinct_values(silo_id, field_name, db)
-                    values.update(silo_values)
-                except Exception as exc:
-                    logger.warning(
-                        f"Failed to fetch distinct values for silo {silo_id}, field {field_name!r}: {exc}"
-                    )
-                    continue
-
+            values = self._fetch_distinct_values(db, candidate_silo_ids, field_name)
             if not values:
                 continue
 
             results.append({"field_name": field_name, "values": sorted(values)})
 
         return sorted(results, key=lambda r: r['field_name'])
+
+    def get_chat_filter_field_values(
+        self, db: Session, agent: Agent, field_name: str
+    ) -> Optional[List[str]]:
+        """Distinct values for ONE orchestrator-exposed chat filter field.
+
+        Returns ``None`` if *field_name* is not in ``agent.exposed_chat_filters``
+        — this is the security boundary: callers may only query fields the
+        designer explicitly exposed, never arbitrary internal metadata field
+        names (the public router maps ``None`` to a 404).
+
+        Returns ``[]`` (not ``None``) if the field is exposed but no silo
+        currently declares it / has values — that's a valid, non-error state.
+
+        Args:
+            db: Database session.
+            agent: The orchestrator agent.
+            field_name: The single filter field to look up.
+
+        Returns:
+            Sorted list of distinct values, ``[]`` if none, or ``None`` if
+            *field_name* isn't one of this agent's exposed filters.
+        """
+        exposed_fields = getattr(agent, 'exposed_chat_filters', None) or []
+        if field_name not in exposed_fields:
+            return None
+
+        silo_ids = self._collect_candidate_silo_ids(agent)
+        if not silo_ids:
+            return []
+
+        field_to_silos = self._get_silo_ids_by_metadata_field(db, silo_ids)
+        candidate_silo_ids = field_to_silos.get(field_name)
+        if not candidate_silo_ids:
+            return []
+
+        values = self._fetch_distinct_values(db, candidate_silo_ids, field_name)
+        return sorted(values)
 
     def create_or_update_agent(self, db: Session, agent_data: dict, agent_type: str, user_id: int = None) -> int:
         """Create or update agent"""

--- a/backend/services/silo_service.py
+++ b/backend/services/silo_service.py
@@ -1359,6 +1359,69 @@ class SiloService:
         return doc_count
 
     @staticmethod
+    def update_docs_metadata(
+        silo_id: int,
+        filter_metadata: Dict[str, Any],
+        metadata_updates: Dict[str, Any],
+        db: Session,
+        replace: bool = False,
+    ) -> int:
+        """
+        Update the metadata of the documents matching a filter, in place.
+
+        Re-labelling documents without re-embedding them: the vectors and the
+        content are untouched, only ``cmetadata`` changes. Callers use it when a
+        label they indexed under is renamed upstream and the existing chunks must
+        follow, instead of paying a full re-index.
+
+        Args:
+            silo_id: ID of the silo
+            filter_metadata: Metadata filter dict (MongoDB-style, e.g., {"field": {"$eq": "value"}})
+            metadata_updates: Keys to write on the matched documents
+            db: Database session
+            replace: If True the metadata is replaced wholesale; by default the
+                updates are merged over the existing keys (idempotent)
+
+        Returns:
+            Number of documents updated
+        """
+        logger.info(
+            f"Updating metadata in silo {silo_id} with filter: {filter_metadata} "
+            f"(replace={replace})"
+        )
+
+        if not SiloService.check_silo_collection_exists(silo_id, db):
+            logger.warning(f"Collection for silo {silo_id} does not exist")
+            return 0
+
+        silo = SiloRepository.get_by_id(silo_id, db)
+        if not silo:
+            logger.error(f"Silo {silo_id} not found")
+            return 0
+
+        collection_name = COLLECTION_PREFIX + str(silo_id)
+        updated = _get_vector_store(silo).update_documents_metadata(
+            collection_name,
+            filter_metadata=filter_metadata,
+            metadata_updates=metadata_updates,
+            replace=replace,
+        )
+        logger.info(f"Successfully updated {updated} document(s) in silo {silo_id}")
+
+        # The metadata values feeding the UI filters are cached per silo; a
+        # rename changes them, so a stale cache would keep offering the old
+        # value in the dropdowns.
+        try:
+            from services.metadata_values_cache_service import MetadataValuesCacheService
+            MetadataValuesCacheService.invalidate(silo_id)
+        except Exception as _cache_exc:
+            logger.warning(
+                "metadata_values_cache: invalidation failed after update_docs_metadata for silo=%d: %s",
+                silo_id, _cache_exc,
+            )
+        return updated
+
+    @staticmethod
     def find_docs_in_collection(
         silo_id: int,
         query: str,

--- a/backend/services/silo_service.py
+++ b/backend/services/silo_service.py
@@ -31,6 +31,12 @@ COLLECTION_PREFIX = 'silo_'
 DEFAULT_SEARCH_LIMIT = 100
 MAX_SEARCH_LIMIT = 200
 
+# Distinct metadata values are read straight from SQL — no embedding call and no
+# similarity ranking — so this is an enumeration and can afford a much higher cap
+# than a search. Callers use it to list what a silo holds for one target.
+DEFAULT_METADATA_VALUES_LIMIT = 1000
+MAX_METADATA_VALUES_LIMIT = 5000
+
 # Per-chunk marker stamping each indexing run; lets reindex delete only stale chunks.
 INDEX_BATCH_FIELD = 'index_batch'
 
@@ -1827,18 +1833,20 @@ class SiloService:
         prefix: Optional[str] = None,
         limit: int = 100,
         db: Session = None,
+        filter_metadata: Optional[Dict[str, Any]] = None,
     ) -> List[str]:
         """
         Return distinct values for a metadata field in the silo's vector collection.
-        Sorted alphabetically, filtered by optional case-insensitive prefix.
-        limit is clamped to 1–500.
+        Sorted alphabetically, filtered by optional case-insensitive prefix and by
+        an optional PGVector-style metadata filter.
+        limit is clamped to 1–MAX_METADATA_VALUES_LIMIT.
         Raises ValueError for invalid field names, NotFoundError for missing silo.
         """
         import re
         if not field or not re.match(r'^[\w.\-]+$', field):
             raise ValueError(f"Invalid metadata field name: '{field}'")
 
-        limit = min(max(1, limit), 500)
+        limit = min(max(1, limit), MAX_METADATA_VALUES_LIMIT)
 
         silo = SiloRepository.get_by_id(silo_id, db)
         if not silo:
@@ -1847,4 +1855,5 @@ class SiloService:
         collection_name = COLLECTION_PREFIX + str(silo_id)
         return _get_vector_store(silo).get_distinct_metadata_values(
             collection_name, field, prefix=prefix, limit=limit,
+            filter_metadata=filter_metadata,
         )

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import Session
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from models.user import User, PlatformRole
 from models.api_key import APIKey
 from models.app import App
@@ -54,7 +55,14 @@ class UserService:
 
     @staticmethod
     def get_or_create_user(db: Session, email: str, name: str = None) -> Tuple[User, bool]:
-        """Get existing user or create one. Returns (user, created)."""
+        """Get existing user or create one. Returns (user, created).
+
+        Race-safe against concurrent first-login requests (e.g. parallel OIDC-protected
+        calls firing on initial login): if two calls both miss the SELECT and race to
+        INSERT, the `uq_user_email` unique constraint rejects the loser's INSERT with an
+        IntegrityError. That loser rolls back and re-fetches the winner's row instead of
+        propagating the error, so callers never see a spurious 500 or duplicate user.
+        """
         user_repo = UserRepository(db)
 
         user = user_repo.get_by_email(email)
@@ -63,8 +71,15 @@ class UserService:
             user = user_repo.update(user, name)
             return user, False
 
-        new_user = user_repo.create(email, name)
-        return new_user, True
+        try:
+            new_user = user_repo.create(email, name)
+            return new_user, True
+        except IntegrityError:
+            db.rollback()
+            user = user_repo.get_by_email(email)
+            if user:
+                return user_repo.update(user, name), False
+            raise
 
     @staticmethod
     def get_user_by_id(db: Session, user_id: int) -> User:

--- a/backend/tools/agentTools.py
+++ b/backend/tools/agentTools.py
@@ -229,9 +229,23 @@ async def create_agent(agent: Agent, search_params=None, session_id=None, user_c
         else:
             logger.warning("Server-side tool '%s' not supported by provider %s — skipped", tool_name, provider_name)
 
+    # Gate 1: orchestrator-level whitelist. Only fields the orchestrator itself
+    # declares in exposed_chat_filters may be forwarded to sub-agents — anything
+    # the caller puts in search_params["filter"] that isn't on that list is
+    # dropped right here, before it ever reaches a sub-agent (Gate 2 applies a
+    # second, silo-scoped whitelist per sub-agent in IACTTool.create).
+    exposed_fields = set(getattr(agent, "exposed_chat_filters", None) or [])
+    orchestrator_caller_filter = {
+        k: v for k, v in (search_params or {}).get("filter", {}).items() if k in exposed_fields
+    }
+
     for tool in agent.tool_associations:
         sub_agent = tool.tool
-        tools.append(await IACTTool.create(sub_agent, user_context=user_context))
+        tools.append(
+            await IACTTool.create(
+                sub_agent, user_context=user_context, caller_filter=orchestrator_caller_filter
+            )
+        )
 
     # Base tools — always available for every agent
     if working_dir:
@@ -349,6 +363,20 @@ def _resolve_and_build_retriever_tool(agent, caller_search_params):
     MUST be invoked via ``asyncio.to_thread`` so it never blocks the event loop.
     """
     from services.silo_service import resolve_search_params  # noqa: PLC0415 — avoids import cycle
+    from tools.vector_stores.metadata_filters import MetadataFilterClause, validate_clauses, ops_for_backend  # noqa: PLC0415
+
+    # Gate 2: silo-scoped whitelist. A caller_search_params["filter"] entry may have
+    # survived the orchestrator's own exposed_chat_filters whitelist (Gate 1, in
+    # create_agent) but this specific subagent's silo might not declare that field at
+    # all. validate_clauses discards anything this silo's metadata_definition doesn't
+    # know about, so a filter never gets applied to a nonexistent metadata key.
+    raw_filter = (caller_search_params or {}).get("filter") or {}
+    if raw_filter and agent.silo is not None:
+        backend_ops = ops_for_backend(getattr(agent.silo, "vector_db_type", None))
+        clauses = [MetadataFilterClause(field=k, op="$eq", value=v) for k, v in raw_filter.items()]
+        valid = validate_clauses(clauses, getattr(agent.silo, "metadata_definition", None), backend_ops)
+        scoped_filter = {c.field: c.value for c in valid}
+        caller_search_params = {**caller_search_params, "filter": scoped_filter} if scoped_filter else None
 
     resolved_sp, resolved_pinned = resolve_search_params(agent, caller_search_params)
     return get_retriever_tool(
@@ -542,12 +570,29 @@ class IACTTool(BaseTool):
         self.mcp_client = None
 
     @classmethod
-    async def create(cls, agent: Agent, user_context: Optional[Dict] = None) -> "IACTTool":
+    async def create(
+        cls,
+        agent: Agent,
+        user_context: Optional[Dict] = None,
+        caller_filter: Optional[Dict[str, Any]] = None,
+    ) -> "IACTTool":
         """Build an agent-as-tool, including the sub-agent's MCP tools.
 
         MCP tools are loaded with an awaited MultiServerMCPClient, which is not
         possible inside a synchronous ``__init__``; hence this async factory. It
         is the only supported way to obtain a ready-to-use ``IACTTool``.
+
+        Args:
+            caller_filter: Optional flat ``{field: value}`` filter already
+                whitelisted against the root orchestrator's own
+                ``exposed_chat_filters`` (Gate 1, in ``create_agent``). It is
+                forwarded unchanged to nested tool-agents — a nested
+                orchestrator's own sub-agents get a shot at the same
+                already-whitelisted fields, no re-derivation needed. Each
+                sub-agent's silo retriever applies its own silo-scoped
+                whitelist on top (Gate 2, in
+                ``_resolve_and_build_retriever_tool``) before merging it into
+                the existing RAG precedence resolution.
         """
         instance = cls(agent, user_context=user_context)
 
@@ -555,7 +600,9 @@ class IACTTool(BaseTool):
         # Add nested tool agents recursively
         for tool in agent.tool_associations:
             sub_agent = tool.tool
-            tools.append(await IACTTool.create(sub_agent, user_context=user_context))
+            tools.append(
+                await IACTTool.create(sub_agent, user_context=user_context, caller_filter=caller_filter)
+            )
 
         # Add base useful tools
         tools.append(fetch_file_in_base64)
@@ -563,13 +610,17 @@ class IACTTool(BaseTool):
         # Add silo retriever if configured. The sub-agent uses the same dynamic
         # metadata-aware tool as the root agent, driven by its OWN RAG config
         # (rag_k / rag_search_type / rag_score_threshold / rag_fixed_filters /
-        # rag_max_retrieval_calls). Caller search params are NOT propagated from the
-        # root agent (caller_search_params=None) — sub-agents are self-contained (FR-12).
+        # rag_max_retrieval_calls). Gate 1 (in create_agent) already whitelisted
+        # caller_filter by field name against the orchestrator's own
+        # exposed_chat_filters; here Gate 2 additionally scopes it down to fields
+        # THIS sub-agent's own silo declares (_resolve_and_build_retriever_tool),
+        # before it is merged into the existing RAG precedence resolution.
         if agent.silo_id is not None:
-            # Caller params NOT propagated (None) — the sub-agent uses its OWN config.
             # Off the event loop: resolution + construction do synchronous DB work.
             retriever_tool = await asyncio.to_thread(
-                _resolve_and_build_retriever_tool, agent, None
+                _resolve_and_build_retriever_tool,
+                agent,
+                {"filter": caller_filter} if caller_filter else None,
             )
             if retriever_tool is not None:
                 tools.append(retriever_tool)

--- a/backend/tools/vector_stores/pgvector_store.py
+++ b/backend/tools/vector_stores/pgvector_store.py
@@ -450,16 +450,29 @@ class PGVectorStore(VectorStoreInterface):
         field: str,
         prefix: Optional[str] = None,
         limit: int = 100,
+        filter_metadata: Optional[Dict[str, Any]] = None,
     ) -> List[str]:
+        # The embedding table is aliased ``e`` because _build_filter_sql always
+        # emits fragments prefixed with it.
+        params: Dict[str, Any] = {
+            "field": field,
+            "collection_name": collection_name,
+            "prefix_pattern": (prefix + "%") if prefix else None,
+            "prefix": prefix if prefix else None,
+            "limit": limit,
+        }
+        where_extra = self._build_filter_sql(filter_metadata, params) if filter_metadata else ""
+
         sql = text(
-            """
-            SELECT DISTINCT lpe.cmetadata->>:field AS val
-            FROM langchain_pg_embedding lpe
-            JOIN langchain_pg_collection lpc ON lpe.collection_id = lpc.uuid
-            WHERE lpc.name = :collection_name
-              AND lpe.cmetadata->>:field IS NOT NULL
-              AND lpe.cmetadata->>:field != ''
-              AND (:prefix IS NULL OR LOWER(lpe.cmetadata->>:field) LIKE LOWER(:prefix_pattern))
+            f"""
+            SELECT DISTINCT e.cmetadata->>:field AS val
+            FROM langchain_pg_embedding e
+            JOIN langchain_pg_collection c ON e.collection_id = c.uuid
+            WHERE c.name = :collection_name
+              AND e.cmetadata->>:field IS NOT NULL
+              AND e.cmetadata->>:field != ''
+              AND (:prefix IS NULL OR LOWER(e.cmetadata->>:field) LIKE LOWER(:prefix_pattern))
+              {where_extra}
             ORDER BY val
             LIMIT :limit
             """
@@ -467,16 +480,7 @@ class PGVectorStore(VectorStoreInterface):
 
         try:
             with self.engine.connect() as connection:
-                result = connection.execute(
-                    sql,
-                    {
-                        "field": field,
-                        "collection_name": collection_name,
-                        "prefix_pattern": (prefix + "%") if prefix else None,
-                        "prefix": prefix if prefix else None,
-                        "limit": limit,
-                    },
-                )
+                result = connection.execute(sql, params)
                 return [str(row[0]) for row in result if row[0] is not None]
         except Exception as exc:
             logger.error("PGVector get_distinct_metadata_values error: %s", exc)

--- a/backend/tools/vector_stores/qdrant_store.py
+++ b/backend/tools/vector_stores/qdrant_store.py
@@ -557,15 +557,18 @@ class QdrantStore(VectorStoreInterface):
         field: str,
         prefix: Optional[str] = None,
         limit: int = 100,
+        filter_metadata: Optional[Dict[str, Any]] = None,
     ) -> List[str]:
         seen: set = set()
         offset = None
         batch_size = 200
+        scroll_filter = self._build_qdrant_filter(filter_metadata) if filter_metadata else None
 
         try:
             while len(seen) < limit:
                 results, next_offset = self.client.scroll(
                     collection_name=collection_name,
+                    scroll_filter=scroll_filter,
                     limit=batch_size,
                     offset=offset,
                     with_payload=True,

--- a/backend/tools/vector_stores/vector_store_interface.py
+++ b/backend/tools/vector_stores/vector_store_interface.py
@@ -242,6 +242,7 @@ class VectorStoreInterface(ABC):
         field: str,
         prefix: Optional[str] = None,
         limit: int = 100,
+        filter_metadata: Optional[Dict[str, Any]] = None,
     ) -> List[str]:
         """
         Return distinct string values for a metadata field in a collection.
@@ -251,6 +252,11 @@ class VectorStoreInterface(ABC):
             field: Metadata field name
             prefix: Optional case-insensitive prefix filter
             limit: Maximum number of values to return
+            filter_metadata: Optional PGVector-style metadata filter narrowing
+                which documents contribute values (e.g.
+                ``{"modelo_maquina": {"$eq": "LS5000"}}``). Lets a caller
+                enumerate one subset of a collection without a similarity
+                search and without the result cap that search carries.
 
         Returns:
             Alphabetically sorted list of distinct values.

--- a/frontend/src/components/forms/ExposedChatFiltersSection.tsx
+++ b/frontend/src/components/forms/ExposedChatFiltersSection.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react';
+import { Filter } from 'lucide-react';
+import { apiService } from '../../services/api';
+
+interface ChatFilterField {
+  name: string;
+  type: string;
+  description?: string;
+}
+
+export interface ExposedChatFiltersSectionProps {
+  readonly appId: number;
+  readonly agentId: number;
+  readonly toolIds: number[];
+  readonly siloId?: number | null;
+  readonly value: string[];
+  readonly onChange: (fields: string[]) => void;
+}
+
+/**
+ * Designer-facing picker: choose which metadata fields — declared across this agent's
+ * currently-selected subagents (tool_ids) and/or its own silo — are exposed as
+ * end-user chat-time dropdown filters. Candidates are recomputed live as the form's
+ * tool/silo selection changes, even before the agent is saved (agentId may be 0/new).
+ * Renders nothing when there are no candidate fields to expose.
+ */
+function ExposedChatFiltersSection({
+  appId,
+  agentId,
+  toolIds,
+  siloId,
+  value,
+  onChange,
+}: ExposedChatFiltersSectionProps) {
+  const [fields, setFields] = useState<ChatFilterField[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasCandidates = toolIds.length > 0 || !!siloId;
+
+  useEffect(() => {
+    if (!hasCandidates) {
+      setFields([]);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    apiService
+      .getAvailableChatFilterFields(appId, agentId, toolIds, siloId)
+      .then((response) => {
+        if (!cancelled) setFields(response.fields ?? []);
+      })
+      .catch((err: unknown) => {
+        console.error('Failed to load available chat filter fields', err);
+        if (!cancelled) {
+          setFields([]);
+          setError('Could not load available filter fields.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [appId, agentId, toolIds, siloId]);
+
+  if (!hasCandidates) return null;
+
+  const toggleField = (name: string) => {
+    onChange(value.includes(name) ? value.filter((f) => f !== name) : [...value, name]);
+  };
+
+  return (
+    <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8">
+      <div className="flex items-center mb-6">
+        <div className="w-10 h-10 bg-indigo-100 rounded-xl flex items-center justify-center mr-4">
+          <Filter className="w-5 h-5 text-indigo-600" aria-hidden="true" />
+        </div>
+        <div>
+          <h3 className="text-xl font-semibold text-gray-900">Chat filters</h3>
+          <p className="text-sm text-gray-500">
+            Metadata fields end users can filter on when chatting with this agent
+          </p>
+        </div>
+      </div>
+
+      {loading && <p className="text-sm text-gray-500">Loading available fields…</p>}
+
+      {!loading && error && (
+        <p role="alert" className="text-sm text-red-600">
+          {error}
+        </p>
+      )}
+
+      {!loading && !error && fields.length === 0 && (
+        <p className="text-sm text-gray-500">No metadata fields available from the selected tools/silo yet.</p>
+      )}
+
+      {!loading && !error && fields.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {fields.map((field) => (
+            <div key={field.name} className="flex items-center p-3 bg-gray-50 rounded-xl">
+              <input
+                id={`exposed_chat_filter_${field.name}`}
+                type="checkbox"
+                checked={value.includes(field.name)}
+                onChange={() => toggleField(field.name)}
+                className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              <label
+                htmlFor={`exposed_chat_filter_${field.name}`}
+                className="ml-3 text-sm font-medium text-gray-900"
+              >
+                {field.name}
+                {field.description && (
+                  <span className="block text-xs font-normal text-gray-500">{field.description}</span>
+                )}
+              </label>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ExposedChatFiltersSection;

--- a/frontend/src/components/playground/ChatInterface.tsx
+++ b/frontend/src/components/playground/ChatInterface.tsx
@@ -490,20 +490,6 @@ function ChatInterface({
 
   return (
     <div className="space-y-4">
-      {/* Orchestrator-level exposed chat filters — independent of the legacy
-          "Filter by Metadata" panel below, since orchestrators typically have
-          no own silo/metadataFields at all. */}
-      {chatFilters.length > 0 && (
-        <div className="pg-glass rounded-xl px-4 py-3">
-          <OrchestratorFilterDropdowns
-            filters={chatFilters}
-            selected={exposedFilterValues}
-            onChange={setExposedFilterValues}
-            disabled={isStreaming}
-          />
-        </div>
-      )}
-
       {/* Metadata Filters Section */}
       {metadataFields && metadataFields.length > 0 && (
         <div className="pg-glass rounded-xl overflow-hidden">
@@ -819,6 +805,22 @@ function ChatInterface({
 
           {/* Input area */}
           <div className="px-4 pb-4 pt-3 border-t border-white/20 dark:border-gray-700/30">
+            {/* Orchestrator-level exposed chat filters — independent of the legacy
+                "Filter by Metadata" panel above, since orchestrators typically have
+                no own silo/metadataFields at all. Self-contained: owns its own
+                collapse state, active-filter chips, and container. Placed directly
+                above the composer (mirrors MarketplaceChatPage) so it stays visible
+                without scrolling and reads as "what will scope my next message". */}
+            {chatFilters.length > 0 && (
+              <div className="mb-3">
+                <OrchestratorFilterDropdowns
+                  filters={chatFilters}
+                  selected={exposedFilterValues}
+                  onChange={setExposedFilterValues}
+                  disabled={isStreaming}
+                />
+              </div>
+            )}
             <div className="pg-glass rounded-xl px-3 py-2.5 flex items-end gap-2">
               {/* File attach button */}
               <div>

--- a/frontend/src/components/playground/ChatInterface.tsx
+++ b/frontend/src/components/playground/ChatInterface.tsx
@@ -7,6 +7,8 @@ import SearchFilters from './SearchFilters';
 import type { SearchFilterMetadataField } from './SearchFilters';
 import AttachedFilesPanel from './AttachedFilesPanel';
 import type { PanelFile } from './AttachedFilesPanel';
+import OrchestratorFilterDropdowns from './OrchestratorFilterDropdowns';
+import type { ChatFilterField } from './OrchestratorFilterDropdowns';
 
 interface Message {
   id: string;
@@ -67,6 +69,8 @@ function ChatInterface({
     undefined
   );
   const [filtersKey, setFiltersKey] = useState(0);
+  const [chatFilters, setChatFilters] = useState<ChatFilterField[]>([]);
+  const [exposedFilterValues, setExposedFilterValues] = useState<Record<string, string>>({});
   /** UI-only state to render the floating "scroll to bottom" button. Behaviour
    *  is driven by refs to avoid scroll-handler re-renders racing the streaming flush. */
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
@@ -233,6 +237,29 @@ function ChatInterface({
     }
   }, [metadataFields, filterMetadata]);
 
+  // Orchestrator-level exposed chat filters — aggregated across the agent's own
+  // silo + all its subagents' silos, for whatever field names the designer whitelisted.
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadChatFilters = async () => {
+      try {
+        const response = await apiService.getAgentChatFilters(appId, agentId);
+        if (isMounted) setChatFilters(response.filters || []);
+      } catch (error) {
+        console.error('Error loading chat filters:', error);
+        if (isMounted) setChatFilters([]);
+      }
+    };
+
+    loadChatFilters();
+    setExposedFilterValues({});
+
+    return () => {
+      isMounted = false;
+    };
+  }, [appId, agentId]);
+
   // ─── Message sending ─────────────────────────────────────────────────────────
 
   const handleSendMessage = async () => {
@@ -254,9 +281,20 @@ function ChatInterface({
     setTimeout(() => scrollToBottom('instant'), 50);
 
     try {
-      const hasFilters =
+      // Legacy "Filter by Metadata" panel sends its filter as the entire search_params
+      // root (a pre-existing bug, out of scope here — see SearchFilters.tsx). The new
+      // orchestrator dropdowns must be nested under a "filter" key per resolve_search_params.
+      // Merge defensively so neither panel clobbers the other if both happen to render.
+      const hasLegacyFilters =
         filterMetadata !== undefined && Object.keys(filterMetadata).length > 0;
-      const searchParams = hasFilters ? filterMetadata : undefined;
+      const hasExposedFilters = Object.keys(exposedFilterValues).length > 0;
+      const searchParams =
+        hasLegacyFilters || hasExposedFilters
+          ? {
+              ...(hasLegacyFilters ? filterMetadata : {}),
+              ...(hasExposedFilters ? { filter: exposedFilterValues } : {}),
+            }
+          : undefined;
 
       // Hold streaming content visible while we commit the final message
       setHoldStreamingContent(true);
@@ -312,6 +350,7 @@ function ChatInterface({
       setPersistentFiles([]);
       setFilterMetadata(undefined);
       setFiltersKey((prev) => prev + 1);
+      setExposedFilterValues({});
     } catch (error) {
       console.error('Error resetting conversation:', error);
     }
@@ -451,6 +490,20 @@ function ChatInterface({
 
   return (
     <div className="space-y-4">
+      {/* Orchestrator-level exposed chat filters — independent of the legacy
+          "Filter by Metadata" panel below, since orchestrators typically have
+          no own silo/metadataFields at all. */}
+      {chatFilters.length > 0 && (
+        <div className="pg-glass rounded-xl px-4 py-3">
+          <OrchestratorFilterDropdowns
+            filters={chatFilters}
+            selected={exposedFilterValues}
+            onChange={setExposedFilterValues}
+            disabled={isStreaming}
+          />
+        </div>
+      )}
+
       {/* Metadata Filters Section */}
       {metadataFields && metadataFields.length > 0 && (
         <div className="pg-glass rounded-xl overflow-hidden">

--- a/frontend/src/components/playground/OrchestratorFilterDropdowns.tsx
+++ b/frontend/src/components/playground/OrchestratorFilterDropdowns.tsx
@@ -1,3 +1,5 @@
+import { useId, useState } from 'react';
+
 export interface ChatFilterField {
   field_name: string;
   values: string[];
@@ -10,12 +12,17 @@ interface OrchestratorFilterDropdownsProps {
   readonly disabled?: boolean;
 }
 
+/** "modelo_maquina" -> "Modelo maquina" — developer-facing field names read as a label. */
+function humanizeFieldName(fieldName: string): string {
+  const spaced = fieldName.replace(/[_-]+/g, ' ').trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
 /**
- * Presentational-only dropdown row for orchestrator-level metadata filters
- * (`Agent.exposed_chat_filters`). One native `<select>` per field, aggregated
- * across the orchestrator's own silo + all its subagents' silos. The parent
- * owns fetching `filters` and the `selected` state — this component never
- * calls the API itself.
+ * Self-contained, collapsible panel for orchestrator-level metadata filters
+ * (`Agent.exposed_chat_filters`) — aggregated across the orchestrator's own
+ * silo + all its subagents' silos. The parent only owns fetching `filters`
+ * and the `selected` state; presentation (collapse, chips, labels) lives here.
  */
 function OrchestratorFilterDropdowns({
   filters,
@@ -23,13 +30,19 @@ function OrchestratorFilterDropdowns({
   onChange,
   disabled = false,
 }: Readonly<OrchestratorFilterDropdownsProps>) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const panelId = useId();
+
   if (filters.length === 0) {
     return null;
   }
 
+  const activeEntries = Object.entries(selected).filter(([, value]) => value);
+  const activeCount = activeEntries.length;
+
   const handleFieldChange = (fieldName: string, value: string) => {
     if (!value) {
-      // Actually delete the key so a cleared field never sends an empty-string filter value.
+      // Delete the key so a cleared field never sends an empty-string filter value.
       const { [fieldName]: _removed, ...rest } = selected;
       onChange(rest);
       return;
@@ -37,35 +50,131 @@ function OrchestratorFilterDropdowns({
     onChange({ ...selected, [fieldName]: value });
   };
 
+  const handleClearOne = (fieldName: string) => handleFieldChange(fieldName, '');
+  const handleClearAll = () => onChange({});
+
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      {filters.map((field) => (
-        <div key={field.field_name}>
-          <label
-            htmlFor={`orchestrator-filter-${field.field_name}`}
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+    <div className="pg-glass rounded-xl overflow-hidden">
+      <button
+        type="button"
+        className="w-full px-4 py-3 flex items-center justify-between text-left hover:bg-white/30 dark:hover:bg-gray-700/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition-colors"
+        onClick={() => setIsExpanded((prev) => !prev)}
+        aria-expanded={isExpanded}
+        aria-controls={panelId}
+      >
+        <span className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+          <svg
+            className="w-4 h-4 text-indigo-500"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
           >
-            {field.field_name}
-          </label>
-          <select
-            id={`orchestrator-filter-${field.field_name}`}
-            value={selected[field.field_name] ?? ''}
-            onChange={(e) => handleFieldChange(field.field_name, e.target.value)}
-            disabled={disabled}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
-                       bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100
-                       focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent
-                       disabled:opacity-50 disabled:cursor-not-allowed text-sm"
-          >
-            <option value="">— any —</option>
-            {field.values.map((value) => (
-              <option key={value} value={value}>
-                {value}
-              </option>
-            ))}
-          </select>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 12h12M3 6h18M9 18h6"
+            />
+          </svg>
+          Filters
+          {activeCount > 0 && (
+            <span className="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full bg-indigo-500 text-white text-xs font-semibold">
+              {activeCount}
+            </span>
+          )}
+        </span>
+        <svg
+          className={`w-4 h-4 text-gray-400 transition-transform duration-200 ${
+            isExpanded ? 'rotate-180' : ''
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {/* Active-filter chips stay visible even while collapsed — the conversation
+          is actually being scoped by these, so hiding them would be misleading. */}
+      {activeCount > 0 && (
+        <div className="flex items-center gap-1.5 flex-wrap px-4 pb-3 pt-0.5">
+          {activeEntries.map(([fieldName, value]) => (
+            <span
+              key={fieldName}
+              className="inline-flex items-center gap-1 pl-2.5 pr-1 py-1 rounded-full text-xs font-medium
+                         bg-indigo-50 dark:bg-indigo-500/10 text-indigo-700 dark:text-indigo-300
+                         border border-indigo-200 dark:border-indigo-500/30"
+            >
+              <span className="opacity-70">{humanizeFieldName(fieldName)}:</span>
+              <span>{value}</span>
+              <button
+                type="button"
+                onClick={() => handleClearOne(fieldName)}
+                disabled={disabled}
+                aria-label={`Clear ${humanizeFieldName(fieldName)} filter`}
+                className="ml-0.5 rounded-full p-0.5 text-indigo-500 hover:text-indigo-700 hover:bg-indigo-100
+                           dark:text-indigo-400 dark:hover:text-indigo-200 dark:hover:bg-indigo-500/20
+                           disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </span>
+          ))}
+          {activeCount > 1 && (
+            <button
+              type="button"
+              onClick={handleClearAll}
+              disabled={disabled}
+              className="text-xs font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200
+                         underline-offset-2 hover:underline disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              Clear all
+            </button>
+          )}
         </div>
-      ))}
+      )}
+
+      <div
+        id={panelId}
+        className={`border-t border-white/20 dark:border-gray-700/30 px-4 py-3 bg-white/20 dark:bg-gray-800/20 ${
+          isExpanded ? '' : 'hidden'
+        }`}
+      >
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filters.map((field) => (
+            <div key={field.field_name}>
+              <label
+                htmlFor={`${panelId}-${field.field_name}`}
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+              >
+                {humanizeFieldName(field.field_name)}
+              </label>
+              <select
+                id={`${panelId}-${field.field_name}`}
+                value={selected[field.field_name] ?? ''}
+                onChange={(e) => handleFieldChange(field.field_name, e.target.value)}
+                disabled={disabled}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
+                           bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100
+                           focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent
+                           disabled:opacity-50 disabled:cursor-not-allowed text-sm transition-shadow"
+              >
+                <option value="">— any —</option>
+                {field.values.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/playground/OrchestratorFilterDropdowns.tsx
+++ b/frontend/src/components/playground/OrchestratorFilterDropdowns.tsx
@@ -1,0 +1,73 @@
+export interface ChatFilterField {
+  field_name: string;
+  values: string[];
+}
+
+interface OrchestratorFilterDropdownsProps {
+  readonly filters: ChatFilterField[];
+  readonly selected: Record<string, string>;
+  readonly onChange: (selected: Record<string, string>) => void;
+  readonly disabled?: boolean;
+}
+
+/**
+ * Presentational-only dropdown row for orchestrator-level metadata filters
+ * (`Agent.exposed_chat_filters`). One native `<select>` per field, aggregated
+ * across the orchestrator's own silo + all its subagents' silos. The parent
+ * owns fetching `filters` and the `selected` state — this component never
+ * calls the API itself.
+ */
+function OrchestratorFilterDropdowns({
+  filters,
+  selected,
+  onChange,
+  disabled = false,
+}: Readonly<OrchestratorFilterDropdownsProps>) {
+  if (filters.length === 0) {
+    return null;
+  }
+
+  const handleFieldChange = (fieldName: string, value: string) => {
+    if (!value) {
+      // Actually delete the key so a cleared field never sends an empty-string filter value.
+      const { [fieldName]: _removed, ...rest } = selected;
+      onChange(rest);
+      return;
+    }
+    onChange({ ...selected, [fieldName]: value });
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {filters.map((field) => (
+        <div key={field.field_name}>
+          <label
+            htmlFor={`orchestrator-filter-${field.field_name}`}
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+          >
+            {field.field_name}
+          </label>
+          <select
+            id={`orchestrator-filter-${field.field_name}`}
+            value={selected[field.field_name] ?? ''}
+            onChange={(e) => handleFieldChange(field.field_name, e.target.value)}
+            disabled={disabled}
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
+                       bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100
+                       focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent
+                       disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+          >
+            <option value="">— any —</option>
+            {field.values.map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </select>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default OrchestratorFilterDropdowns;

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -11,6 +11,7 @@ import { Tabs } from '../components/ui/Tabs';
 import type { TabItem } from '../components/ui/Tabs';
 import RagConfigSection, { SCORE_THRESHOLD_REQUIRED_MSG } from '../components/forms/RagConfigSection';
 import type { RagConfigValue, RagFixedFilter, RagSearchType } from '../components/forms/RagConfigSection';
+import ExposedChatFiltersSection from '../components/forms/ExposedChatFiltersSection';
 import type { SearchFilterMetadataField } from '../components/playground/SearchFilters';
 import type { AgentMCPUsage } from '../core/types';
 import type { MarketplaceVisibility, MarketplaceProfileUpdate } from '../types/marketplace';
@@ -37,6 +38,7 @@ interface Agent {
   tool_ids?: number[];
   mcp_config_ids?: number[];
   skill_ids?: number[];
+  exposed_chat_filters?: string[];
   created_at: string;
   request_count: number;
   marketplace_visibility?: MarketplaceVisibility;
@@ -78,6 +80,7 @@ interface AgentFormData {
   tool_ids: number[];
   mcp_config_ids: number[];
   skill_ids: number[];
+  exposed_chat_filters: string[];
   // OCR-specific fields
   vision_service_id?: number;
   vision_system_prompt?: string;
@@ -214,6 +217,7 @@ function AgentFormPage() {
     tool_ids: [],
     mcp_config_ids: [],
     skill_ids: [],
+    exposed_chat_filters: [],
     rag_k: 10,
     rag_search_type: 'similarity',
     rag_score_threshold: null,
@@ -303,6 +307,7 @@ function AgentFormPage() {
         tool_ids: response.tool_ids || [],
         mcp_config_ids: response.mcp_config_ids || [],
         skill_ids: response.skill_ids || [],
+        exposed_chat_filters: response.exposed_chat_filters || [],
         // OCR-specific fields
         vision_service_id: response.vision_service_id || undefined,
         vision_system_prompt: response.vision_system_prompt || '',
@@ -497,6 +502,7 @@ function AgentFormPage() {
       tool_ids: formData.tool_ids,
       mcp_config_ids: formData.mcp_config_ids,
       skill_ids: formData.skill_ids,
+      exposed_chat_filters: formData.exposed_chat_filters,
       // OCR-specific fields
       vision_service_id: formData.vision_service_id,
       vision_system_prompt: formData.vision_system_prompt,
@@ -1251,6 +1257,18 @@ function AgentFormPage() {
                   )}
                 </div>
               )}
+
+              {/* Chat filters — designer picks which metadata fields end users can filter on.
+                  Mounted unconditionally (not gated behind silo_id): an orchestrator commonly
+                  has no own silo and delegates entirely to subagents' silos via tool_ids. */}
+              <ExposedChatFiltersSection
+                appId={Number.parseInt(appId ?? '0')}
+                agentId={Number.parseInt(agentId ?? '0')}
+                toolIds={formData.tool_ids}
+                siloId={formData.silo_id}
+                value={formData.exposed_chat_filters}
+                onChange={(fields) => handleInputChange('exposed_chat_filters', fields)}
+              />
 
               {/* MCP Configs Card - Only for regular agents */}
               {agent?.mcp_configs && formData.type !== 'ocr_agent' && (

--- a/frontend/src/pages/MarketplaceChatPage.tsx
+++ b/frontend/src/pages/MarketplaceChatPage.tsx
@@ -657,7 +657,7 @@ export default function MarketplaceChatPage() {
           )}
 
           {chatFilters.length > 0 && (
-            <div className="pg-glass rounded-xl px-4 py-3 mb-3">
+            <div className="mb-3">
               <OrchestratorFilterDropdowns
                 filters={chatFilters}
                 selected={exposedFilterValues}

--- a/frontend/src/pages/MarketplaceChatPage.tsx
+++ b/frontend/src/pages/MarketplaceChatPage.tsx
@@ -7,6 +7,8 @@ import MessageContent from '../components/playground/MessageContent';
 import StreamingMessage from '../components/playground/StreamingMessage';
 import AttachedFilesPanel from '../components/playground/AttachedFilesPanel';
 import type { PanelFile } from '../components/playground/AttachedFilesPanel';
+import OrchestratorFilterDropdowns from '../components/playground/OrchestratorFilterDropdowns';
+import type { ChatFilterField } from '../components/playground/OrchestratorFilterDropdowns';
 import { LoadingState } from '../components/ui/LoadingState';
 import { ErrorState } from '../components/ui/ErrorState';
 import { useStreamingChat, type StreamFnOptions } from '../hooks/useStreamingChat';
@@ -58,6 +60,8 @@ export default function MarketplaceChatPage() {
   const [isLoadingFiles, setIsLoadingFiles] = useState(false);
   const [quotaInfo, setQuotaInfo] = useState<QuotaInfo | null>(null);
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+  const [chatFilters, setChatFilters] = useState<ChatFilterField[]>([]);
+  const [exposedFilterValues, setExposedFilterValues] = useState<Record<string, string>>({});
 
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -78,6 +82,7 @@ export default function MarketplaceChatPage() {
       apiService.chatMarketplaceStream(numericId, message, {
         files: opts.files,
         fileReferences: persistentFiles.length > 0 ? persistentFiles.map((f) => f.file_id) : undefined,
+        searchParams: opts.searchParams,
         onEvent: opts.onEvent,
         signal: opts.signal,
       }),
@@ -228,6 +233,27 @@ export default function MarketplaceChatPage() {
     };
   }, [numericId]);
 
+  // Orchestrator-level exposed chat filters — resolved via the conversation's
+  // agent, aggregated across its own silo + all its subagents' silos.
+  useEffect(() => {
+    if (!numericId || Number.isNaN(numericId)) return;
+    let isMounted = true;
+    setExposedFilterValues({});
+    const loadChatFilters = async () => {
+      try {
+        const response = await apiService.getMarketplaceChatFilters(numericId);
+        if (isMounted) setChatFilters(response.filters || []);
+      } catch (err) {
+        console.error('Error loading chat filters:', err);
+        if (isMounted) setChatFilters([]);
+      }
+    };
+    loadChatFilters();
+    return () => {
+      isMounted = false;
+    };
+  }, [numericId]);
+
   const refreshFileList = useCallback(async () => {
     try {
       const response = await apiService.listMarketplaceFiles(numericId);
@@ -267,8 +293,10 @@ export default function MarketplaceChatPage() {
 
     try {
       setHoldStreamingContent(true);
+      const hasExposedFilters = Object.keys(exposedFilterValues).length > 0;
       const result = await sendMessage(trimmed, {
         conversationId: numericId,
+        searchParams: hasExposedFilters ? { filter: exposedFilterValues } : undefined,
       });
 
       const rawResponse = result.response || '';
@@ -324,6 +352,7 @@ export default function MarketplaceChatPage() {
     scrollToBottom,
     refreshFileList,
     fetchQuotaInfo,
+    exposedFilterValues,
   ]);
 
   const handleKeyDown = useCallback(
@@ -624,6 +653,17 @@ export default function MarketplaceChatPage() {
                 ({quotaInfo.call_count}/{quotaInfo.quota}).
                 Your quota resets at the start of next month (UTC).
               </span>
+            </div>
+          )}
+
+          {chatFilters.length > 0 && (
+            <div className="pg-glass rounded-xl px-4 py-3 mb-3">
+              <OrchestratorFilterDropdowns
+                filters={chatFilters}
+                selected={exposedFilterValues}
+                onChange={setExposedFilterValues}
+                disabled={isStreaming || isQuotaExceeded}
+              />
             </div>
           )}
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -120,6 +120,7 @@ export interface Agent {
   tool_ids?: number[];
   mcp_config_ids?: number[];
   skill_ids?: number[];
+  exposed_chat_filters?: string[];
   created_at: string;
   request_count: number;
   marketplace_visibility?: MarketplaceVisibility;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -300,6 +300,33 @@ class ApiService {
     return this.request(`/internal/apps/${appId}/agents/${agentId}/mcp-usage`);
   }
 
+  async getAvailableChatFilterFields(
+    appId: number,
+    agentId: number,
+    toolIds: number[],
+    siloId?: number | null,
+  ): Promise<{ fields: { name: string; type: string; description?: string }[] }> {
+    const params = new URLSearchParams();
+    toolIds.forEach((id) => params.append('tool_ids', String(id)));
+    if (siloId) params.append('silo_id', String(siloId));
+    return this.request(
+      `/internal/apps/${appId}/agents/${agentId}/available-chat-filter-fields?${params}`,
+    );
+  }
+
+  async getAgentChatFilters(
+    appId: number,
+    agentId: number,
+  ): Promise<{ filters: { field_name: string; values: string[] }[] }> {
+    return this.request(`/internal/apps/${appId}/agents/${agentId}/chat-filters`);
+  }
+
+  async getMarketplaceChatFilters(
+    conversationId: number,
+  ): Promise<{ filters: { field_name: string; values: string[] }[] }> {
+    return this.request(`/internal/marketplace/conversations/${conversationId}/chat-filters`);
+  }
+
   async updateAgentPrompt(appId: number, agentId: number, promptType: 'system' | 'template', prompt: string) {
     return this.request(`/internal/apps/${appId}/agents/${agentId}/update-prompt`, {
       method: 'POST',
@@ -1788,6 +1815,7 @@ class ApiService {
     options: {
       files?: File[];
       fileReferences?: string[];
+      searchParams?: unknown;
       onEvent: (event: StreamEvent) => void;
       signal?: AbortSignal;
     },
@@ -1797,6 +1825,9 @@ class ApiService {
 
     if (options.fileReferences && options.fileReferences.length > 0) {
       formData.append('file_references', JSON.stringify(options.fileReferences));
+    }
+    if (options.searchParams) {
+      formData.append('search_params', JSON.stringify(options.searchParams));
     }
     if (options.files && options.files.length > 0) {
       options.files.forEach((file) => formData.append('files', file));

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,17 @@ os.environ.setdefault("AICT_LOGIN", "LOCAL")
 os.environ.setdefault("AICT_OMNIADMINS", "admin@test.com")
 os.environ.setdefault("AICT_MODE", "SELF-HOSTED")
 os.environ.setdefault("FRONTEND_URL", "http://localhost:5173")
+# The `client` fixture reruns the full app lifespan (incl. omniadmin_bootstrap) on every
+# test. bootstrap_omniadmins provisions AICT_OMNIADMINS via its own real, auto-committing
+# SessionLocal() -- a separate connection from the `db` fixture's rolled-back outer
+# transaction. Several tests' `admin_headers` fixtures monkeypatch AICT_OMNIADMINS to
+# fake_user's email (already flushed-but-uncommitted in the `db` session); bootstrap's
+# separate session then tries to INSERT that same email and blocks waiting for the `db`
+# session's transaction to finish -- which can't happen until the test body runs, which
+# can't start until `client` setup (running bootstrap) finishes. Disabling the default
+# here avoids that deadlock; tests that exercise bootstrap_omniadmins directly already
+# monkeypatch this flag to "true" themselves (see test_local_auth_provisioning.py).
+os.environ.setdefault("AUTH_BOOTSTRAP_OMNIADMINS", "false")
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/integration/export_import/test_silo_export_import_integration.py
+++ b/tests/integration/export_import/test_silo_export_import_integration.py
@@ -24,9 +24,15 @@ from repositories.silo_repository import SiloRepository
 
 @pytest.fixture
 def test_user(db_session: Session) -> User:
-    """Create test user."""
+    """Create test user.
+
+    Email must be unique per invocation: db_session.commit() is a real commit
+    against the module-session-scoped `engine` fixture (not the rolled-back
+    per-test transaction other suites use), so a hardcoded email would collide
+    across the many tests in this file once User.email has a unique constraint.
+    """
     user = User(
-        email="test_silo@example.com",
+        email=f"test_silo-{datetime.now().timestamp()}@example.com",
         name="Test Silo User",
     )
     db_session.add(user)

--- a/tests/integration/routers/public/test_agents.py
+++ b/tests/integration/routers/public/test_agents.py
@@ -220,3 +220,153 @@ class TestDeleteAgent:
             headers=api_headers(fake_api_key.key),
         )
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Chat-time filter field values
+# ---------------------------------------------------------------------------
+
+
+def _make_output_parser(db, app_id, fields):
+    from models.output_parser import OutputParser
+
+    parser = OutputParser(name="Test Metadata Parser", fields=fields, app_id=app_id)
+    db.add(parser)
+    db.flush()
+    return parser
+
+
+def _make_silo(db, app_id, metadata_definition_id, vector_db_type="PGVECTOR"):
+    from models.silo import Silo
+
+    silo = Silo(
+        name=f"Test Silo {metadata_definition_id}",
+        silo_type="REPO",
+        app_id=app_id,
+        metadata_definition_id=metadata_definition_id,
+        vector_db_type=vector_db_type,
+    )
+    db.add(silo)
+    db.flush()
+    return silo
+
+
+def _make_subagent(db, app_id, silo_id, name="SubAgent"):
+    from models.agent import Agent
+
+    agent = Agent(
+        name=name,
+        description=f"{name} description",
+        system_prompt="",
+        app_id=app_id,
+        silo_id=silo_id,
+        is_tool=True,
+    )
+    db.add(agent)
+    db.flush()
+    return agent
+
+
+def _make_orchestrator(db, app_id, exposed_chat_filters, sub_agents):
+    from models.agent import Agent, AgentTool
+
+    orchestrator = Agent(
+        name="Orchestrator",
+        description="Orchestrator description",
+        system_prompt="",
+        app_id=app_id,
+        silo_id=None,
+        has_memory=False,
+        exposed_chat_filters=exposed_chat_filters,
+    )
+    db.add(orchestrator)
+    db.flush()
+
+    for sub in sub_agents:
+        db.add(AgentTool(agent_id=orchestrator.agent_id, tool_id=sub.agent_id))
+    db.flush()
+
+    return orchestrator
+
+
+def chat_filter_url(app_id: int, agent_id: int, field_name: str) -> str:
+    return f"{agents_url(app_id, agent_id)}/chat-filters/{field_name}"
+
+
+class TestGetChatFilterFieldValues:
+    def test_returns_200_with_values(self, client, fake_app, fake_api_key, db, mocker):
+        parser = _make_output_parser(
+            db, fake_app.app_id, fields=[{"name": "machine_model", "type": "str"}]
+        )
+        silo = _make_silo(db, fake_app.app_id, parser.parser_id)
+        sub = _make_subagent(db, fake_app.app_id, silo.silo_id)
+        orchestrator = _make_orchestrator(
+            db, fake_app.app_id, exposed_chat_filters=["machine_model"], sub_agents=[sub]
+        )
+
+        mocker.patch(
+            "services.agent_service.MetadataValuesCacheService.get_distinct_values",
+            return_value=["X100", "X200"],
+        )
+
+        resp = client.get(
+            chat_filter_url(fake_app.app_id, orchestrator.agent_id, "machine_model"),
+            headers=api_headers(fake_api_key.key),
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"field_name": "machine_model", "values": ["X100", "X200"]}
+
+    def test_field_not_exposed_returns_404(self, client, fake_app, fake_api_key, db):
+        orchestrator = _make_orchestrator(
+            db, fake_app.app_id, exposed_chat_filters=["machine_model"], sub_agents=[]
+        )
+
+        resp = client.get(
+            chat_filter_url(fake_app.app_id, orchestrator.agent_id, "not_exposed"),
+            headers=api_headers(fake_api_key.key),
+        )
+        assert resp.status_code == 404
+
+    def test_field_exposed_but_no_declaring_silo_returns_empty_list(
+        self, client, fake_app, fake_api_key, db
+    ):
+        orchestrator = _make_orchestrator(
+            db, fake_app.app_id, exposed_chat_filters=["machine_model"], sub_agents=[]
+        )
+
+        resp = client.get(
+            chat_filter_url(fake_app.app_id, orchestrator.agent_id, "machine_model"),
+            headers=api_headers(fake_api_key.key),
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"field_name": "machine_model", "values": []}
+
+    def test_agent_from_other_app_returns_404(self, client, fake_app, fake_api_key, db):
+        orchestrator = _make_orchestrator(
+            db, fake_app.app_id, exposed_chat_filters=["machine_model"], sub_agents=[]
+        )
+        other_app_id = fake_app.app_id + 1000
+
+        resp = client.get(
+            chat_filter_url(other_app_id, orchestrator.agent_id, "machine_model"),
+            headers=api_headers(fake_api_key.key),
+        )
+        assert resp.status_code in (401, 403, 404)
+
+    def test_nonexistent_agent_returns_404(self, client, fake_app, fake_api_key, db):
+        resp = client.get(
+            chat_filter_url(fake_app.app_id, 999999, "machine_model"),
+            headers=api_headers(fake_api_key.key),
+        )
+        assert resp.status_code == 404
+
+    def test_no_api_key_returns_401(self, client, fake_app, fake_agent):
+        resp = client.get(chat_filter_url(fake_app.app_id, fake_agent.agent_id, "machine_model"))
+        assert resp.status_code == 401
+
+    def test_invalid_api_key_returns_401(self, client, fake_app, fake_agent):
+        resp = client.get(
+            chat_filter_url(fake_app.app_id, fake_agent.agent_id, "machine_model"),
+            headers=api_headers("totally-invalid-key"),
+        )
+        assert resp.status_code in (401, 403)

--- a/tests/integration/routers/public/test_silos.py
+++ b/tests/integration/routers/public/test_silos.py
@@ -452,6 +452,47 @@ class TestDocOperations:
         )
         assert resp.status_code == 400
 
+    @patch("routers.public.v1.silos.SiloService.update_docs_metadata")
+    def test_update_metadata(
+        self, mock_update, client, fake_app, fake_silo, fake_api_key, db
+    ):
+        mock_update.return_value = 12
+
+        resp = client.post(
+            silos_url(fake_app.app_id, fake_silo.silo_id, "docs/update-metadata"),
+            json={
+                "filter_metadata": {"categoria": {"$eq": "LS5000"}},
+                "metadata_updates": {"categoria": "Serie LS5000"},
+            },
+            headers=api_headers(fake_api_key.key),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["updated"] == 12
+        # Merge by default: a caller re-labelling one key must not wipe the rest.
+        assert mock_update.call_args.kwargs["replace"] is False
+
+    def test_update_metadata_empty_filter_returns_400(
+        self, client, fake_app, fake_silo, fake_api_key, db
+    ):
+        # An empty filter would match the whole collection — the one mistake that
+        # turns a rename into a silo-wide overwrite.
+        resp = client.post(
+            silos_url(fake_app.app_id, fake_silo.silo_id, "docs/update-metadata"),
+            json={"filter_metadata": {}, "metadata_updates": {"categoria": "X"}},
+            headers=api_headers(fake_api_key.key),
+        )
+        assert resp.status_code == 400
+
+    def test_update_metadata_empty_updates_returns_400(
+        self, client, fake_app, fake_silo, fake_api_key, db
+    ):
+        resp = client.post(
+            silos_url(fake_app.app_id, fake_silo.silo_id, "docs/update-metadata"),
+            json={"filter_metadata": {"categoria": {"$eq": "LS5000"}}, "metadata_updates": {}},
+            headers=api_headers(fake_api_key.key),
+        )
+        assert resp.status_code == 400
+
     @patch("routers.public.v1.silos.SiloService.index_multiple_content")
     @patch("routers.public.v1.silos.SiloService.extract_documents_from_file")
     def test_index_file(

--- a/tests/integration/routers/public/test_silos.py
+++ b/tests/integration/routers/public/test_silos.py
@@ -428,6 +428,30 @@ class TestDocOperations:
         )
         assert resp.status_code == 400
 
+    @patch("routers.public.v1.silos.SiloService.count_docs_with_filter")
+    def test_count_by_metadata(
+        self, mock_count, client, fake_app, fake_silo, fake_api_key, db
+    ):
+        mock_count.return_value = 7
+
+        resp = client.post(
+            silos_url(fake_app.app_id, fake_silo.silo_id, "docs/count-by-metadata"),
+            json={"filter_metadata": {"resource_id": {"$eq": "123"}}},
+            headers=api_headers(fake_api_key.key),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 7
+
+    def test_count_by_metadata_empty_filter_returns_400(
+        self, client, fake_app, fake_silo, fake_api_key, db
+    ):
+        resp = client.post(
+            silos_url(fake_app.app_id, fake_silo.silo_id, "docs/count-by-metadata"),
+            json={"filter_metadata": {}},
+            headers=api_headers(fake_api_key.key),
+        )
+        assert resp.status_code == 400
+
     @patch("routers.public.v1.silos.SiloService.index_multiple_content")
     @patch("routers.public.v1.silos.SiloService.extract_documents_from_file")
     def test_index_file(

--- a/tests/integration/routers/public/test_silos.py
+++ b/tests/integration/routers/public/test_silos.py
@@ -8,6 +8,8 @@ Only vector DB / service operations are mocked — auth, routing, Pydantic, and 
 import pytest
 from unittest.mock import patch, MagicMock
 
+from services.silo_service import DEFAULT_METADATA_VALUES_LIMIT
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -489,6 +491,64 @@ class TestDocOperations:
         resp = client.post(
             silos_url(fake_app.app_id, fake_silo.silo_id, "docs/update-metadata"),
             json={"filter_metadata": {"categoria": {"$eq": "LS5000"}}, "metadata_updates": {}},
+            headers=api_headers(fake_api_key.key),
+        )
+        assert resp.status_code == 400
+
+    @patch("routers.public.v1.silos.SiloService.get_metadata_field_values")
+    def test_metadata_values(
+        self, mock_values, client, fake_app, fake_silo, fake_api_key, db
+    ):
+        mock_values.return_value = ["https://wiki/A", "https://wiki/B"]
+
+        resp = client.post(
+            silos_url(fake_app.app_id, fake_silo.silo_id, "docs/metadata-values"),
+            json={
+                "field": "source_url",
+                "filter_metadata": {"categoria": {"$eq": "LS5000"}},
+            },
+            headers=api_headers(fake_api_key.key),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["values"] == ["https://wiki/A", "https://wiki/B"]
+        # The filter must reach the service: without it the caller would get the
+        # whole silo's values instead of its own target's.
+        assert mock_values.call_args.kwargs["filter_metadata"] == {
+            "categoria": {"$eq": "LS5000"}
+        }
+
+    @patch("routers.public.v1.silos.SiloService.get_metadata_field_values")
+    def test_metadata_values_defaults_the_limit(
+        self, mock_values, client, fake_app, fake_silo, fake_api_key, db
+    ):
+        mock_values.return_value = []
+
+        client.post(
+            silos_url(fake_app.app_id, fake_silo.silo_id, "docs/metadata-values"),
+            json={"field": "ticket_id"},
+            headers=api_headers(fake_api_key.key),
+        )
+        assert mock_values.call_args.kwargs["limit"] == DEFAULT_METADATA_VALUES_LIMIT
+
+    def test_metadata_values_empty_field_returns_400(
+        self, client, fake_app, fake_silo, fake_api_key, db
+    ):
+        resp = client.post(
+            silos_url(fake_app.app_id, fake_silo.silo_id, "docs/metadata-values"),
+            json={"field": "   "},
+            headers=api_headers(fake_api_key.key),
+        )
+        assert resp.status_code == 400
+
+    @patch("routers.public.v1.silos.SiloService.get_metadata_field_values")
+    def test_metadata_values_invalid_field_name_returns_400(
+        self, mock_values, client, fake_app, fake_silo, fake_api_key, db
+    ):
+        mock_values.side_effect = ValueError("Invalid metadata field name: 'a b'")
+
+        resp = client.post(
+            silos_url(fake_app.app_id, fake_silo.silo_id, "docs/metadata-values"),
+            json={"field": "a b"},
             headers=api_headers(fake_api_key.key),
         )
         assert resp.status_code == 400

--- a/tests/integration/test_conversations_router.py
+++ b/tests/integration/test_conversations_router.py
@@ -1,0 +1,240 @@
+"""
+Integration tests for the conversations endpoints.
+
+Endpoints under test (backend/routers/internal/conversations.py):
+  - POST   /internal/conversations                            (create conversation)
+  - GET    /internal/conversations?agent_id=...                (list conversations)
+  - GET    /internal/conversations/{conversation_id}           (get conversation)
+  - GET    /internal/conversations/{conversation_id}/history   (get conversation + message history)
+  - PATCH  /internal/conversations/{conversation_id}           (update conversation)
+
+Regression coverage:
+  `ConversationResponse` (backend/schemas/conversation_schemas.py) used to declare
+  a required `app_id: int` field that nothing ever populated -- no column on the
+  `Conversation` ORM model, no service logic setting it. Every endpoint here that
+  serializes a raw `Conversation` ORM object through `ConversationResponse` (or
+  `ConversationWithHistoryResponse`, which inherits from it) raised a Pydantic
+  `ResponseValidationError` ("Field required [type=missing] ... app_id"), i.e. a
+  500 on every call. This suite exercises the full router with zero mocking of
+  the response schema to catch any regression of that bug.
+"""
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Create conversation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateConversation:
+    """POST /internal/conversations"""
+
+    def test_create_conversation_returns_200_with_expected_fields(
+        self, client, fake_agent, auth_headers, db
+    ):
+        db.flush()
+        response = client.post(
+            f"/internal/conversations?agent_id={fake_agent.agent_id}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert isinstance(body["conversation_id"], int)
+        assert body["agent_id"] == fake_agent.agent_id
+        assert body["session_id"].startswith(f"conv_{fake_agent.agent_id}_")
+        assert body["message_count"] == 0
+        assert body["last_message"] is None
+        assert "created_at" in body
+        assert "updated_at" in body
+        # The bug reported app_id as a required-but-unpopulated field on this
+        # schema; it must not be present anymore (it was removed entirely).
+        assert "app_id" not in body
+
+    def test_create_conversation_with_title(self, client, fake_agent, auth_headers, db):
+        db.flush()
+        response = client.post(
+            "/internal/conversations",
+            headers=auth_headers,
+            params={"agent_id": fake_agent.agent_id, "title": "My Chat"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["title"] == "My Chat"
+
+    def test_create_conversation_without_title_gets_auto_title(
+        self, client, fake_agent, auth_headers, db
+    ):
+        db.flush()
+        response = client.post(
+            f"/internal/conversations?agent_id={fake_agent.agent_id}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["title"]  # auto-generated, non-empty
+
+
+# ---------------------------------------------------------------------------
+# List conversations
+# ---------------------------------------------------------------------------
+
+
+class TestListConversations:
+    """GET /internal/conversations?agent_id=..."""
+
+    def test_list_conversations_after_create(self, client, fake_agent, auth_headers, db):
+        """
+        Regression test for the app_id ResponseValidationError bug.
+
+        Prior to the fix, `ConversationResponse` required an `app_id: int`
+        field that nothing populated, so this endpoint raised a 500
+        ResponseValidationError (`Field required [type=missing] ... app_id`)
+        for any Conversation ORM object serialized through it -- meaning
+        listing conversations was completely broken.
+        """
+        db.flush()
+        create_resp = client.post(
+            f"/internal/conversations?agent_id={fake_agent.agent_id}",
+            headers=auth_headers,
+        )
+        assert create_resp.status_code == 200
+        created_id = create_resp.json()["conversation_id"]
+
+        list_resp = client.get(
+            "/internal/conversations",
+            headers=auth_headers,
+            params={"agent_id": fake_agent.agent_id},
+        )
+
+        assert list_resp.status_code == 200
+        body = list_resp.json()
+        assert body["total"] == 1
+        assert len(body["conversations"]) == 1
+        assert body["conversations"][0]["conversation_id"] == created_id
+        assert "app_id" not in body["conversations"][0]
+
+    def test_list_conversations_empty_for_agent_with_none(
+        self, client, fake_agent, auth_headers, db
+    ):
+        db.flush()
+        response = client.get(
+            "/internal/conversations",
+            headers=auth_headers,
+            params={"agent_id": fake_agent.agent_id},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 0
+        assert body["conversations"] == []
+
+
+# ---------------------------------------------------------------------------
+# Get conversation
+# ---------------------------------------------------------------------------
+
+
+class TestGetConversation:
+    """GET /internal/conversations/{conversation_id}"""
+
+    def test_get_conversation_by_id(self, client, fake_agent, auth_headers, db):
+        db.flush()
+        created = client.post(
+            f"/internal/conversations?agent_id={fake_agent.agent_id}",
+            headers=auth_headers,
+        ).json()
+
+        response = client.get(
+            f"/internal/conversations/{created['conversation_id']}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["conversation_id"] == created["conversation_id"]
+        assert body["agent_id"] == fake_agent.agent_id
+
+    def test_get_conversation_not_found_returns_404(self, client, auth_headers, db):
+        response = client.get(
+            "/internal/conversations/999999",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Get conversation history
+# ---------------------------------------------------------------------------
+
+
+class TestGetConversationHistory:
+    """GET /internal/conversations/{conversation_id}/history"""
+
+    def test_history_is_empty_for_fresh_conversation(
+        self, client, fake_agent, auth_headers, db
+    ):
+        """A freshly created conversation has no LangGraph checkpointer
+        messages yet, so `messages` must come back as an empty list."""
+        db.flush()
+        created = client.post(
+            f"/internal/conversations?agent_id={fake_agent.agent_id}",
+            headers=auth_headers,
+        ).json()
+
+        response = client.get(
+            f"/internal/conversations/{created['conversation_id']}/history",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["conversation_id"] == created["conversation_id"]
+        assert body["messages"] == []
+        assert "app_id" not in body
+
+    def test_history_not_found_returns_404(self, client, auth_headers, db):
+        response = client.get(
+            "/internal/conversations/999999/history",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Update conversation
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateConversation:
+    """PATCH /internal/conversations/{conversation_id}"""
+
+    def test_update_title(self, client, fake_agent, auth_headers, db):
+        db.flush()
+        created = client.post(
+            f"/internal/conversations?agent_id={fake_agent.agent_id}",
+            headers=auth_headers,
+        ).json()
+
+        response = client.patch(
+            f"/internal/conversations/{created['conversation_id']}",
+            headers=auth_headers,
+            json={"title": "New Title"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["title"] == "New Title"
+        assert body["conversation_id"] == created["conversation_id"]
+
+    def test_update_not_found_returns_404(self, client, auth_headers, db):
+        response = client.patch(
+            "/internal/conversations/999999",
+            headers=auth_headers,
+            json={"title": "New Title"},
+        )
+
+        assert response.status_code == 404

--- a/tests/integration/test_oidc_duplicate_user_race.py
+++ b/tests/integration/test_oidc_duplicate_user_race.py
@@ -17,11 +17,10 @@ Fix (two parts, both already landed on this branch):
 These tests require the REAL Postgres unique constraint to be present -- a pure unit test
 with a mocked session cannot trigger a genuine ``IntegrityError`` -- so they live here in
 ``tests/integration/`` against the real test DB (port 5433) rather than in ``tests/unit/``.
-The two tests that actually need the constraint to fire bring it up themselves via the
-``ensure_email_unique_constraint`` fixture (see its docstring below) rather than assuming
-it is already present -- this repo's test-DB schema is built from ORM metadata
-(``Base.metadata.create_all()``), not from the Alembic migration, so the constraint is
-NOT guaranteed to exist on a fresh/ephemeral test DB.
+``models/user.py`` declares ``uq_user_email`` via ``__table_args__`` (matching the name
+used by the ``useremail001`` migration), so this repo's test-DB schema -- built from ORM
+metadata via ``Base.metadata.create_all()`` -- already carries the real constraint; no
+test-local workaround is needed to bring it up.
 
 Concurrency strategy (deterministic -- no real threads, no flaky timing):
   Two real ``SessionLocal()`` sessions are used directly (mirroring two separate FastAPI
@@ -47,79 +46,13 @@ Concurrency strategy (deterministic -- no real threads, no flaky timing):
 
 import uuid
 
-import pytest
-from sqlalchemy import inspect, text
+from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 
 from db.database import SessionLocal
 from models.user import User
 from repositories.user_repository import UserRepository
 from services.user_service import UserService
-
-_TEST_SCOPED_CONSTRAINT_NAME = "uq_user_email_test_scoped"
-
-
-@pytest.fixture
-def ensure_email_unique_constraint(test_engine):
-    """Guarantees a real UNIQUE constraint on ``User.email`` exists for the duration of
-    a single test, then removes it again immediately afterward.
-
-    Why this fixture exists (rather than relying on ambient DB state or a permanent
-    model change):
-
-    - The session-scoped ``test_engine`` fixture builds the schema via
-      ``Base.metadata.create_all()`` (ORM metadata), NOT by running the ``useremail001``
-      Alembic migration -- see ``tests/integration/test_localauth001_migration.py``'s
-      docstring for the same caveat about this repo's test-DB schema strategy. So
-      whether the real ``uq_user_email`` constraint exists here depends entirely on
-      whatever state the target Postgres database happened to be in beforehand -- it is
-      NOT guaranteed on a fresh/ephemeral test DB. This was confirmed while writing this
-      test: a from-scratch schema built purely from ``create_all()`` has no such
-      constraint, since ``models/user.py``'s ``email`` column does not declare
-      ``unique=True``.
-    - Adding ``unique=True`` directly to ``User.email`` in ``backend/models/user.py``
-      would make ``create_all()`` always include the constraint -- but this was tried
-      and reverted during development of this test: it turns the ``fake_user`` fixture's
-      shared, hardcoded email (``"testuser@mattin-test.com"``, reused by dozens of
-      unrelated tests across the suite) into a permanent, session-wide lock-contention
-      hazard. If any other test's session is ever left open (e.g. a hung fixture
-      teardown) while holding that email, every subsequent ``fake_user``-based test
-      would then block waiting on the Postgres row lock instead of harmlessly
-      coexisting in separate, never-committed transactions like they do today -- this
-      produced a full test-suite deadlock, observed firsthand while developing this fix.
-
-    Instead, this fixture adds the constraint (under its own distinct name, if not
-    already present) immediately before the single test that needs it runs, and drops
-    it again immediately after -- a window of a few milliseconds -- so it cannot collide
-    with any other test's use of the shared ``fake_user`` email.
-    """
-    inspector = inspect(test_engine)
-    already_present = any(
-        c["name"] == "uq_user_email" for c in inspector.get_unique_constraints("User")
-    )
-
-    added_here = False
-    if not already_present:
-        with test_engine.begin() as conn:
-            conn.execute(
-                text(
-                    f'ALTER TABLE "User" ADD CONSTRAINT {_TEST_SCOPED_CONSTRAINT_NAME} '
-                    "UNIQUE (email)"
-                )
-            )
-        added_here = True
-
-    try:
-        yield
-    finally:
-        if added_here:
-            with test_engine.begin() as conn:
-                conn.execute(
-                    text(
-                        f'ALTER TABLE "User" DROP CONSTRAINT IF EXISTS '
-                        f"{_TEST_SCOPED_CONSTRAINT_NAME}"
-                    )
-                )
 
 
 def _unique_email(label: str) -> str:
@@ -172,9 +105,7 @@ class TestUserRepositoryUniqueConstraint:
     """Sanity check that the real DB constraint is present and fires -- isolates the
     schema half of the fix from the service-level recovery logic tested below."""
 
-    def test_create_raises_integrity_error_on_duplicate_email(
-        self, test_engine, ensure_email_unique_constraint
-    ):
+    def test_create_raises_integrity_error_on_duplicate_email(self, test_engine):
         email = _unique_email("constraint-sanity")
         session_a = SessionLocal()
         session_b = SessionLocal()
@@ -207,9 +138,7 @@ class TestGetOrCreateUserConcurrentRace:
     out of the call instead of being caught and recovered from.
     """
 
-    def test_concurrent_calls_converge_to_single_user_row(
-        self, test_engine, ensure_email_unique_constraint
-    ):
+    def test_concurrent_calls_converge_to_single_user_row(self, test_engine):
         email = _unique_email("concurrent")
         session_a = SessionLocal()
         session_b = SessionLocal()

--- a/tests/integration/test_oidc_duplicate_user_race.py
+++ b/tests/integration/test_oidc_duplicate_user_race.py
@@ -1,0 +1,254 @@
+"""Integration regression tests for the OIDC duplicate-user-creation race.
+
+Bug: two concurrent OIDC first-login requests for a brand-new email could both miss the
+SELECT in ``UserService.get_or_create_user`` (plain check-then-insert, no DB-level
+uniqueness, no locking) and both proceed to INSERT, creating 2 (or up to 3, if a third
+request also raced in) ``User`` rows sharing the same email.
+
+Fix (two parts, both already landed on this branch):
+  1. ``alembic/versions/useremail001_dedupe_users_add_unique_email.py`` adds a
+     ``uq_user_email`` UNIQUE constraint on ``User.email`` (plus a one-time dedupe of any
+     pre-existing duplicate rows).
+  2. ``UserService.get_or_create_user`` (``backend/services/user_service.py``) now catches
+     the ``IntegrityError`` raised by that constraint when the INSERT loses the race,
+     rolls back, and re-fetches the winner's row instead of propagating a 500 or leaving a
+     duplicate.
+
+These tests require the REAL Postgres unique constraint to be present -- a pure unit test
+with a mocked session cannot trigger a genuine ``IntegrityError`` -- so they live here in
+``tests/integration/`` against the real test DB (port 5433) rather than in ``tests/unit/``.
+The two tests that actually need the constraint to fire bring it up themselves via the
+``ensure_email_unique_constraint`` fixture (see its docstring below) rather than assuming
+it is already present -- this repo's test-DB schema is built from ORM metadata
+(``Base.metadata.create_all()``), not from the Alembic migration, so the constraint is
+NOT guaranteed to exist on a fresh/ephemeral test DB.
+
+Concurrency strategy (deterministic -- no real threads, no flaky timing):
+  Two real ``SessionLocal()`` sessions are used directly (mirroring two separate FastAPI
+  requests, each with its own ``Depends(get_db)`` session) rather than the standard
+  savepoint-rollback ``db`` fixture: the race must be visible as a genuine UNIQUE-constraint
+  conflict across two independent DB transactions, which a single shared connection/
+  savepoint cannot reproduce.
+
+  Session B is bumped to ``REPEATABLE READ`` *before* its first statement, fixing its MVCC
+  snapshot at that point (while the email definitely does not exist yet). Session A ("A"
+  wins the race) then runs ``get_or_create_user`` to completion, fully creating and
+  committing a new user for that same email. Postgres enforces UNIQUE constraints against
+  the actual committed data regardless of a transaction's MVCC snapshot, so when Session
+  B's ``get_or_create_user`` re-does its own SELECT (still returns None -- per its frozen
+  snapshot, A's commit is invisible to it) and attempts the INSERT, it collides with the
+  real ``uq_user_email`` constraint and raises ``IntegrityError`` -- exactly the path the
+  fix's ``except IntegrityError`` block exists to recover from.
+
+  Each test commits real rows to the test DB (bypassing the savepoint-rollback fixture,
+  same pattern as ``tests/integration/test_crawl_worker_concurrency.py``) and cleans up
+  manually in a ``finally`` block.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import inspect, text
+from sqlalchemy.exc import IntegrityError
+
+from db.database import SessionLocal
+from models.user import User
+from repositories.user_repository import UserRepository
+from services.user_service import UserService
+
+_TEST_SCOPED_CONSTRAINT_NAME = "uq_user_email_test_scoped"
+
+
+@pytest.fixture
+def ensure_email_unique_constraint(test_engine):
+    """Guarantees a real UNIQUE constraint on ``User.email`` exists for the duration of
+    a single test, then removes it again immediately afterward.
+
+    Why this fixture exists (rather than relying on ambient DB state or a permanent
+    model change):
+
+    - The session-scoped ``test_engine`` fixture builds the schema via
+      ``Base.metadata.create_all()`` (ORM metadata), NOT by running the ``useremail001``
+      Alembic migration -- see ``tests/integration/test_localauth001_migration.py``'s
+      docstring for the same caveat about this repo's test-DB schema strategy. So
+      whether the real ``uq_user_email`` constraint exists here depends entirely on
+      whatever state the target Postgres database happened to be in beforehand -- it is
+      NOT guaranteed on a fresh/ephemeral test DB. This was confirmed while writing this
+      test: a from-scratch schema built purely from ``create_all()`` has no such
+      constraint, since ``models/user.py``'s ``email`` column does not declare
+      ``unique=True``.
+    - Adding ``unique=True`` directly to ``User.email`` in ``backend/models/user.py``
+      would make ``create_all()`` always include the constraint -- but this was tried
+      and reverted during development of this test: it turns the ``fake_user`` fixture's
+      shared, hardcoded email (``"testuser@mattin-test.com"``, reused by dozens of
+      unrelated tests across the suite) into a permanent, session-wide lock-contention
+      hazard. If any other test's session is ever left open (e.g. a hung fixture
+      teardown) while holding that email, every subsequent ``fake_user``-based test
+      would then block waiting on the Postgres row lock instead of harmlessly
+      coexisting in separate, never-committed transactions like they do today -- this
+      produced a full test-suite deadlock, observed firsthand while developing this fix.
+
+    Instead, this fixture adds the constraint (under its own distinct name, if not
+    already present) immediately before the single test that needs it runs, and drops
+    it again immediately after -- a window of a few milliseconds -- so it cannot collide
+    with any other test's use of the shared ``fake_user`` email.
+    """
+    inspector = inspect(test_engine)
+    already_present = any(
+        c["name"] == "uq_user_email" for c in inspector.get_unique_constraints("User")
+    )
+
+    added_here = False
+    if not already_present:
+        with test_engine.begin() as conn:
+            conn.execute(
+                text(
+                    f'ALTER TABLE "User" ADD CONSTRAINT {_TEST_SCOPED_CONSTRAINT_NAME} '
+                    "UNIQUE (email)"
+                )
+            )
+        added_here = True
+
+    try:
+        yield
+    finally:
+        if added_here:
+            with test_engine.begin() as conn:
+                conn.execute(
+                    text(
+                        f'ALTER TABLE "User" DROP CONSTRAINT IF EXISTS '
+                        f"{_TEST_SCOPED_CONSTRAINT_NAME}"
+                    )
+                )
+
+
+def _unique_email(label: str) -> str:
+    return f"oidc-race-{label}-{uuid.uuid4().hex}@mattin-test.com"
+
+
+def _cleanup(email: str) -> None:
+    """Delete any User row(s) left behind for `email` (real commit, real cleanup).
+
+    Uses a brand-new session/connection so it works regardless of the state the
+    racing sessions were left in (including a rolled-back or aborted transaction).
+    """
+    cleanup_session = SessionLocal()
+    try:
+        cleanup_session.query(User).filter(User.email == email).delete()
+        cleanup_session.commit()
+    finally:
+        cleanup_session.close()
+
+
+class TestGetOrCreateUserSequential:
+    """Basic (non-racing) regression coverage: the IntegrityError handling added for the
+    race fix must not have broken the normal, uncontested get-or-create path."""
+
+    def test_second_call_returns_existing_user_not_a_duplicate(self, test_engine):
+        email = _unique_email("sequential")
+        try:
+            session = SessionLocal()
+            try:
+                user1, created1 = UserService.get_or_create_user(session, email, name="First Login")
+                user2, created2 = UserService.get_or_create_user(session, email, name="First Login")
+            finally:
+                session.close()
+
+            assert created1 is True, "First call for a brand-new email must create the user"
+            assert created2 is False, "Second call for the same email must not create a duplicate"
+            assert user1.user_id == user2.user_id
+
+            verify_session = SessionLocal()
+            try:
+                count = verify_session.query(User).filter(User.email == email).count()
+            finally:
+                verify_session.close()
+            assert count == 1
+        finally:
+            _cleanup(email)
+
+
+class TestUserRepositoryUniqueConstraint:
+    """Sanity check that the real DB constraint is present and fires -- isolates the
+    schema half of the fix from the service-level recovery logic tested below."""
+
+    def test_create_raises_integrity_error_on_duplicate_email(
+        self, test_engine, ensure_email_unique_constraint
+    ):
+        email = _unique_email("constraint-sanity")
+        session_a = SessionLocal()
+        session_b = SessionLocal()
+        try:
+            UserRepository(session_a).create(email, "First")
+
+            try:
+                UserRepository(session_b).create(email, "Second")
+                raised = False
+            except IntegrityError:
+                raised = True
+                session_b.rollback()
+
+            assert raised, (
+                "UserRepository.create must raise IntegrityError for a duplicate email "
+                "-- the uq_user_email constraint is missing or not enforced"
+            )
+        finally:
+            session_a.close()
+            session_b.close()
+            _cleanup(email)
+
+
+class TestGetOrCreateUserConcurrentRace:
+    """Reproduces the actual race: two separate sessions both miss the SELECT and race to
+    INSERT for the same brand-new email.
+
+    FAILS against the pre-fix ``get_or_create_user`` (plain SELECT-then-INSERT, no
+    try/except around the INSERT): the loser's real ``IntegrityError`` propagates straight
+    out of the call instead of being caught and recovered from.
+    """
+
+    def test_concurrent_calls_converge_to_single_user_row(
+        self, test_engine, ensure_email_unique_constraint
+    ):
+        email = _unique_email("concurrent")
+        session_a = SessionLocal()
+        session_b = SessionLocal()
+        try:
+            # Session B: elevate isolation *before* its first statement so its MVCC
+            # snapshot is fixed here -- simulating a request whose "user not found" read
+            # happened concurrently with (before) Session A's INSERT+commit.
+            session_b.execute(text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
+            repo_b = UserRepository(session_b)
+            assert repo_b.get_by_email(email) is None, "sanity: email must not pre-exist"
+
+            # Session A "wins" the race: creates and commits the user first.
+            user_a, created_a = UserService.get_or_create_user(session_a, email, name="Race Winner")
+            assert created_a is True
+
+            # Session B still cannot see Session A's commit (its snapshot predates it), so
+            # get_or_create_user's own internal SELECT returns None and it attempts the
+            # INSERT -- which now collides with the real uq_user_email constraint and
+            # raises IntegrityError. The fix must catch it, roll back, and converge on the
+            # winner's row rather than raising or leaving a duplicate.
+            user_b, created_b = UserService.get_or_create_user(session_b, email, name="Race Loser")
+
+            assert created_b is False, (
+                "Losing call must report created=False (converged on the existing row), "
+                "not create a second User row"
+            )
+            assert user_b.user_id == user_a.user_id, (
+                "Both concurrent calls must resolve to the SAME user_id"
+            )
+
+            # Exactly one row must exist for this email -- checked via a fresh, independent
+            # session so we're not relying on either racing session's own identity map.
+            verify_session = SessionLocal()
+            try:
+                count = verify_session.query(User).filter(User.email == email).count()
+            finally:
+                verify_session.close()
+            assert count == 1, f"Expected exactly 1 User row for {email}, found {count}"
+        finally:
+            session_a.close()
+            session_b.close()
+            _cleanup(email)

--- a/tests/integration/test_useremail001_migration_e2e.py
+++ b/tests/integration/test_useremail001_migration_e2e.py
@@ -1,0 +1,336 @@
+"""End-to-end test of the real ``useremail001`` Alembic migration.
+
+Unlike ``test_localauth001_migration.py`` / ``test_migration_domain_crawling.py`` /
+``test_migration_user_deletion.py`` (which only assert schema *state* on the shared,
+session-scoped ``test_engine`` fixture -- a schema built via ``Base.metadata.create_all()``,
+never through Alembic itself), and unlike ``test_oidc_duplicate_user_race.py`` (which
+tests the *application-level* race fix in ``UserService.get_or_create_user``), this test
+exercises the actual ``useremail001`` migration's ``upgrade()`` function by:
+
+  1. Creating a brand-new, uniquely-named ephemeral Postgres database on the ``db_test``
+     container (port 5433).
+  2. Running the real ``alembic upgrade`` CLI as a subprocess against it, stopping one
+     revision short of the fix (``20260717_conversation_starters`` -- ``useremail001``'s
+     ``down_revision``), reproducing the pre-fix schema (no ``uq_user_email`` constraint).
+  3. Inserting two duplicate ``User`` rows sharing an email, each owning 2 ``App`` rows
+     with 1 ``Agent`` each (4 Apps + 4 Agents total) -- the literal "duplicate users each
+     owning 2 apps with an agent" scenario.
+  4. Running the real ``alembic upgrade head`` subprocess, applying ``useremail001``'s
+     data merge + ``uq_user_email`` unique constraint.
+  5. Asserting, via raw SQL against the ephemeral DB (not the ORM, to stay decoupled from
+     any session/identity-map state), that the merge produced exactly the expected result.
+
+Runtime: this test is slower than a typical integration test (~10-20s) -- it creates a
+real database and shells out to the real ``alembic`` CLI twice. That tradeoff is
+intentional: it is the only way to prove the actual migration script (not a reimplementation
+of its SQL) behaves correctly end-to-end.
+
+Requires: the ``db_test`` docker-compose service on port 5433, started via
+``docker compose -f docker/docker-compose.yaml --profile test up -d db_test``. Its
+``POSTGRES_USER`` (``test_user``) is a Postgres superuser for that container, so it can
+freely ``CREATE DATABASE`` / ``DROP DATABASE`` on the shared cluster.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import psycopg2
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DB_HOST = "localhost"
+DB_PORT = "5433"
+# The db_test container's POSTGRES_USER is a cluster superuser (standard Postgres image
+# behavior), so it can CREATE DATABASE / DROP DATABASE freely -- confirmed in the task brief.
+DB_SUPERUSER = "test_user"
+DB_SUPERUSER_PASSWORD = "test_pass"  # pragma: allowlist secret
+MAINTENANCE_DB = "test_db"  # always-present DB used only to issue CREATE/DROP DATABASE
+EPHEMERAL_DB_NAME = "mattin_test_useremail001_e2e"
+
+# useremail001's down_revision -- the pre-fix schema (duplicates possible, no unique constraint).
+PRE_FIX_REVISION = "20260717_conversation_starters"
+POST_FIX_REVISION = "useremail001"
+
+DUPLICATE_EMAIL = "dup-e2e@mattin-test.com"
+
+
+# ---------------------------------------------------------------------------
+# Ephemeral database helpers
+# ---------------------------------------------------------------------------
+
+
+def _admin_connection() -> psycopg2.extensions.connection:
+    """Autocommit psycopg2 connection to the always-present maintenance DB.
+
+    CREATE DATABASE / DROP DATABASE cannot run inside a transaction block, so this
+    connection must be in autocommit mode and must NOT target the ephemeral DB itself.
+    """
+    conn = psycopg2.connect(
+        host=DB_HOST,
+        port=DB_PORT,
+        user=DB_SUPERUSER,
+        password=DB_SUPERUSER_PASSWORD,
+        dbname=MAINTENANCE_DB,
+    )
+    conn.autocommit = True
+    return conn
+
+
+def _drop_ephemeral_db() -> None:
+    conn = _admin_connection()
+    try:
+        with conn.cursor() as cur:
+            # WITH (FORCE) (pg13+, we're on pg17) terminates any lingering connections
+            # first -- Postgres refuses a plain DROP DATABASE while sessions are attached.
+            cur.execute(f'DROP DATABASE IF EXISTS "{EPHEMERAL_DB_NAME}" WITH (FORCE)')
+    finally:
+        conn.close()
+
+
+def _create_ephemeral_db() -> None:
+    _drop_ephemeral_db()  # guard: a prior crashed run may have left it behind
+    conn = _admin_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f'CREATE DATABASE "{EPHEMERAL_DB_NAME}"')
+    finally:
+        conn.close()
+
+
+def _run_alembic(revision: str) -> subprocess.CompletedProcess:
+    """Invoke the real ``alembic`` CLI as a subprocess against the ephemeral DB.
+
+    alembic/env.py builds its target URL from DATABASE_USER / DATABASE_PASSWORD /
+    DATABASE_HOST / DATABASE_PORT / DATABASE_NAME (NOT SQLALCHEMY_DATABASE_URI and NOT
+    TEST_DATABASE_URL) -- see alembic/env.py lines 53-55. We invoke via
+    ``sys.executable -m alembic`` (rather than relying on an ``alembic`` binary being on
+    PATH) so it always runs with the same interpreter/venv as pytest itself, from the
+    repo root so alembic.ini / alembic/ resolve normally.
+    """
+    env = dict(os.environ)
+    env.update(
+        DATABASE_USER=DB_SUPERUSER,
+        DATABASE_PASSWORD=DB_SUPERUSER_PASSWORD,
+        DATABASE_HOST=DB_HOST,
+        DATABASE_PORT=DB_PORT,
+        DATABASE_NAME=EPHEMERAL_DB_NAME,
+    )
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", revision],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+@pytest.fixture
+def ephemeral_pre_fix_db():
+    """
+    Creates a brand-new ephemeral Postgres database, runs the real ``alembic upgrade``
+    to the revision immediately BEFORE ``useremail001`` (pre-fix schema: duplicate emails
+    possible, no ``uq_user_email`` constraint), and yields a SQLAlchemy engine bound to
+    it. Always drops the database afterward, disposing the engine first so no lingering
+    connections block the DROP DATABASE.
+    """
+    _create_ephemeral_db()
+    engine = None
+    try:
+        result = _run_alembic(PRE_FIX_REVISION)
+        assert result.returncode == 0, (
+            f"alembic upgrade {PRE_FIX_REVISION} failed (rc={result.returncode}).\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
+
+        url = (
+            f"postgresql://{DB_SUPERUSER}:{DB_SUPERUSER_PASSWORD}"
+            f"@{DB_HOST}:{DB_PORT}/{EPHEMERAL_DB_NAME}"
+        )
+        engine = create_engine(url, pool_pre_ping=True)
+        yield engine
+    finally:
+        if engine is not None:
+            engine.dispose()  # release all pooled connections before DROP DATABASE
+        _drop_ephemeral_db()
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+class TestUseremail001MigrationEndToEnd:
+    """Genuine end-to-end coverage of the ``useremail001`` migration against a real,
+    Alembic-built database (not the ORM-metadata-built shared ``test_engine``)."""
+
+    def test_dedupes_users_reassigns_apps_and_adds_unique_constraint(
+        self, ephemeral_pre_fix_db
+    ):
+        engine = ephemeral_pre_fix_db
+
+        # Import ORM classes lazily (after backend/ is on sys.path via tests/conftest.py)
+        # and bind them to a fresh Session against the *ephemeral* engine -- these are the
+        # same declarative classes used app-wide, just pointed at a different database.
+        from models.user import User
+        from models.app import App
+        from models.agent import Agent
+
+        Session = sessionmaker(bind=engine)
+        setup_session = Session()
+        try:
+            # --- Seed the pre-fix duplicate-user scenario -----------------------------
+            user1 = User(email=DUPLICATE_EMAIL, name="Dup User One", is_active=True)
+            user2 = User(email=DUPLICATE_EMAIL, name="Dup User Two", is_active=True)
+            setup_session.add_all([user1, user2])
+            setup_session.flush()  # assign user_id (serial PK) without committing yet
+
+            # user1 is inserted first, so (barring sequence weirdness) user1.user_id <
+            # user2.user_id. Both users end up with an identical activity score (2 owned
+            # apps each, 0 API keys / collaborators / usage / marketplace-usage rows), so
+            # the migration's tie-break rule -- lowest user_id wins -- must pick user1 as
+            # canonical. We assert this explicitly below so the test is deterministic
+            # rather than accidentally passing due to insertion order.
+            assert user1.user_id < user2.user_id, (
+                "sanity: user1 must have the lower user_id for the canonical-tiebreak "
+                "assertion below to be meaningful"
+            )
+
+            apps_by_user = {}
+            agents_by_app = {}
+            for owner in (user1, user2):
+                owned_apps = []
+                for i in range(2):
+                    app_obj = App(
+                        name=f"E2E App {owner.user_id}-{i}",
+                        slug=f"e2e-useremail001-{owner.user_id}-{i}",
+                        owner_id=owner.user_id,
+                        agent_rate_limit=0,
+                        max_file_size_mb=10,
+                    )
+                    setup_session.add(app_obj)
+                    setup_session.flush()
+                    owned_apps.append(app_obj)
+
+                    agent_obj = Agent(
+                        name=f"E2E Agent {owner.user_id}-{i}",
+                        app_id=app_obj.app_id,
+                        type="agent",
+                    )
+                    setup_session.add(agent_obj)
+                    setup_session.flush()
+                    agents_by_app[app_obj.app_id] = agent_obj.agent_id
+
+                apps_by_user[owner.user_id] = [a.app_id for a in owned_apps]
+
+            setup_session.commit()
+
+            canonical_user_id = user1.user_id
+            loser_user_id = user2.user_id
+            all_app_ids = set(apps_by_user[canonical_user_id]) | set(apps_by_user[loser_user_id])
+            assert len(all_app_ids) == 4
+
+            # --- Reproduce-first checkpoint: confirm the pre-fix DB genuinely has 2 --
+            # duplicate rows (proves the setup above actually reproduces the bug state,
+            # and that nothing already enforces uniqueness at this revision) before we
+            # apply the fix and check it goes away.
+            dup_count_before = (
+                setup_session.query(User).filter(User.email == DUPLICATE_EMAIL).count()
+            )
+            assert dup_count_before == 2, (
+                "sanity: expected 2 duplicate User rows before useremail001 runs -- "
+                "if this fails, the test setup isn't reproducing the bug state"
+            )
+        finally:
+            setup_session.close()
+
+        # setup_session is closed and its transaction committed/finished, so no
+        # connections from our own engine hold locks on "User" going into the migration.
+        # Dispose the whole pool defensively before shelling out to alembic.
+        engine.dispose()
+
+        # --- Apply the real fix -------------------------------------------------------
+        result = _run_alembic(POST_FIX_REVISION)
+        assert result.returncode == 0, (
+            f"alembic upgrade {POST_FIX_REVISION} failed (rc={result.returncode}).\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
+
+        # --- Assertions: raw SQL only, decoupled from any ORM session state ----------
+        with engine.connect() as conn:
+            user_rows = conn.execute(
+                text('SELECT user_id, email FROM "User" WHERE email = :email'),
+                {"email": DUPLICATE_EMAIL},
+            ).fetchall()
+            assert len(user_rows) == 1, (
+                f"Expected exactly 1 User row for {DUPLICATE_EMAIL} after useremail001, "
+                f"found {len(user_rows)}: {user_rows}"
+            )
+            assert user_rows[0].user_id == canonical_user_id, (
+                "The surviving User row must be the tie-break winner (lowest user_id, "
+                f"{canonical_user_id}), got {user_rows[0].user_id}"
+            )
+
+            app_rows = conn.execute(
+                text('SELECT app_id, owner_id FROM "App" WHERE app_id = ANY(:ids)'),
+                {"ids": list(all_app_ids)},
+            ).fetchall()
+            assert len(app_rows) == 4, (
+                f"Expected all 4 App rows to survive untouched, found {len(app_rows)}"
+            )
+            assert all(row.owner_id == canonical_user_id for row in app_rows), (
+                "All 4 Apps (including the loser's 2) must now be owned by the "
+                f"canonical user_id {canonical_user_id}: {app_rows}"
+            )
+
+            agent_rows = conn.execute(
+                text('SELECT agent_id, app_id FROM "Agent" WHERE app_id = ANY(:ids)'),
+                {"ids": list(all_app_ids)},
+            ).fetchall()
+            assert len(agent_rows) == 4, (
+                f"Expected all 4 Agent rows to survive untouched, found {len(agent_rows)}"
+            )
+            actual_agent_to_app = {row.agent_id: row.app_id for row in agent_rows}
+            assert actual_agent_to_app == {
+                agent_id: app_id for app_id, agent_id in agents_by_app.items()
+            }, "Each Agent's app_id must be unchanged -- agents are only indirectly " \
+               "affected via their parent App's ownership."
+
+            # --- Schema assertion: uq_user_email constraint exists -----------------
+            constraint_row = conn.execute(
+                text(
+                    "SELECT constraint_name FROM information_schema.table_constraints "
+                    "WHERE table_name = 'User' AND constraint_type = 'UNIQUE' "
+                    "AND constraint_name = 'uq_user_email'"
+                )
+            ).fetchone()
+            assert constraint_row is not None, (
+                "uq_user_email UNIQUE constraint missing after useremail001 upgrade"
+            )
+
+        # --- Schema assertion: the constraint actually rejects a duplicate insert ----
+        # Run in its own connection/transaction so a rolled-back failure here doesn't
+        # taint the `with engine.connect()` block above.
+        with engine.connect() as conn:
+            trans = conn.begin()
+            try:
+                with pytest.raises(IntegrityError):
+                    conn.execute(
+                        text(
+                            'INSERT INTO "User" (email, name, is_active) '
+                            "VALUES (:email, :name, true)"
+                        ),
+                        {"email": DUPLICATE_EMAIL, "name": "Should Be Rejected"},
+                    )
+            finally:
+                trans.rollback()

--- a/tests/integration/tools/test_orchestrator_chat_filters_integration.py
+++ b/tests/integration/tools/test_orchestrator_chat_filters_integration.py
@@ -1,0 +1,266 @@
+"""Integration test for orchestrator-level metadata dropdown chat filters.
+
+Exercises the real Gate 1 -> Gate 2 -> Gate 3 pipeline (``create_agent`` ->
+``IACTTool.create`` -> ``_resolve_and_build_retriever_tool`` ->
+``resolve_search_params``) against real DB-backed Agent/Silo/OutputParser/AgentTool
+rows (real lazy-loaded relationships via the ``db`` fixture's savepoint-scoped
+session). No live LLM or embedding service is required or contacted:
+
+  - ``get_llm`` / ``create_langchain_agent`` / ``MCPClientManager.get_client`` are
+    mocked (pure scaffolding, no I/O).
+  - ``MetadataValuesCacheService.get_distinct_values`` is mocked to ``[]`` so tool
+    description/schema building never attempts a real vector store connection.
+  - ``SiloService.get_silo_retriever`` (the actual vector store entry point) is
+    mocked so we can assert on the filter dict it would have received — this is
+    the "correct backend filter dict was constructed and would be passed to the
+    vector store" scope-down called out in the test plan, since a full live
+    embedding/pgvector round-trip is impractical in this suite.
+
+Scenario: a 2-subagent orchestrator.
+  - Subagent A's silo declares ``machine_model`` (a real OutputParser-backed
+    metadata_definition).
+  - Subagent B's silo does NOT declare ``machine_model`` at all (different
+    metadata schema).
+  - Orchestrator.exposed_chat_filters = ["machine_model"].
+
+Verifies:
+  - A caller filter of ``{"machine_model": "X100"}`` reaches subagent A's
+    retrieval call scoped correctly (Gate 2 passes it through).
+  - Subagent B's retrieval runs unaffected — not silently zeroed out by a filter
+    on a field it doesn't have (Gate 2 drops it cleanly for B only, without
+    erroring).
+  - Subagent A's own ``rag_fixed_filters`` (when set) wins over the caller's
+    selection (Gate 3 — unchanged existing precedence, reached via the new path).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Fixture-building helpers (real, DB-flushed ORM rows within the test's
+# savepoint-scoped transaction — nothing is committed to the real DB).
+# ---------------------------------------------------------------------------
+
+
+def _make_output_parser(db, app_id, fields):
+    from models.output_parser import OutputParser
+
+    parser = OutputParser(name="Test Metadata Parser", fields=fields, app_id=app_id)
+    db.add(parser)
+    db.flush()
+    return parser
+
+
+def _make_silo(db, app_id, metadata_definition_id, vector_db_type="PGVECTOR"):
+    from models.silo import Silo
+
+    silo = Silo(
+        name=f"Test Silo {metadata_definition_id}",
+        silo_type="REPO",
+        app_id=app_id,
+        metadata_definition_id=metadata_definition_id,
+        vector_db_type=vector_db_type,
+    )
+    db.add(silo)
+    db.flush()
+    return silo
+
+
+def _make_subagent(db, app_id, silo_id, rag_fixed_filters=None, name="SubAgent"):
+    from models.agent import Agent
+
+    agent = Agent(
+        name=name,
+        description=f"{name} description",
+        system_prompt="",
+        app_id=app_id,
+        silo_id=silo_id,
+        is_tool=True,
+        rag_fixed_filters=rag_fixed_filters,
+    )
+    db.add(agent)
+    db.flush()
+    return agent
+
+
+def _make_orchestrator(db, app_id, exposed_chat_filters, sub_agents):
+    from models.agent import Agent, AgentTool
+
+    orchestrator = Agent(
+        name="Orchestrator",
+        description="Orchestrator description",
+        system_prompt="",
+        app_id=app_id,
+        silo_id=None,
+        has_memory=False,
+        exposed_chat_filters=exposed_chat_filters,
+    )
+    db.add(orchestrator)
+    db.flush()
+
+    for sub in sub_agents:
+        db.add(AgentTool(agent_id=orchestrator.agent_id, tool_id=sub.agent_id))
+    db.flush()
+    db.refresh(orchestrator)
+    return orchestrator
+
+
+def _retriever_tools(tools):
+    """Filter a sub-agent's tool list down to the dynamic retriever tool.
+
+    Distinguished by name convention (``search_{slug}_{silo_id}`` — see
+    ``build_retriever_tool_name``), which is more robust than filtering on
+    ``coroutine is not None`` alone.
+    """
+    return [t for t in tools if getattr(t, "name", "").startswith("search_")]
+
+
+class TestOrchestratorChatFiltersIntegration:
+    """2-subagent orchestrator: Gate 1 + Gate 2 (+ Gate 3) composed end-to-end."""
+
+    @pytest.mark.asyncio
+    async def test_scoped_filter_reaches_declaring_subagent_only(self, db, fake_app):
+        from tools import agentTools
+
+        parser_a = _make_output_parser(
+            db, fake_app.app_id, fields=[{"name": "machine_model", "type": "str"}]
+        )
+        parser_b = _make_output_parser(
+            db, fake_app.app_id, fields=[{"name": "other_field", "type": "str"}]
+        )
+        silo_a = _make_silo(db, fake_app.app_id, parser_a.parser_id)
+        silo_b = _make_silo(db, fake_app.app_id, parser_b.parser_id)
+
+        sub_a = _make_subagent(db, fake_app.app_id, silo_a.silo_id, name="SubA")
+        sub_b = _make_subagent(db, fake_app.app_id, silo_b.silo_id, name="SubB")
+
+        orchestrator = _make_orchestrator(
+            db,
+            fake_app.app_id,
+            exposed_chat_filters=["machine_model"],
+            sub_agents=[sub_a, sub_b],
+        )
+
+        fake_retriever = MagicMock()
+        fake_retriever.ainvoke = AsyncMock(return_value=[])
+        mock_get_silo_retriever = MagicMock(return_value=fake_retriever)
+
+        with (
+            patch("tools.agentTools.get_llm", return_value=object()),
+            patch(
+                "tools.agentTools.create_langchain_agent", return_value=MagicMock()
+            ) as mock_create,
+            patch.object(
+                agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)
+            ),
+            patch(
+                "services.silo_service.SiloService.get_silo_retriever",
+                new=mock_get_silo_retriever,
+            ),
+            patch(
+                "services.metadata_values_cache_service.MetadataValuesCacheService.get_distinct_values",
+                return_value=[],
+            ),
+        ):
+            await agentTools.create_agent(
+                orchestrator, search_params={"filter": {"machine_model": "X100"}}
+            )
+
+            # tool_associations loop order == insertion order (SubA, SubB); each
+            # IACTTool.create() call triggers its own create_langchain_agent call
+            # before the orchestrator's own (final) call.
+            sub_a_tools = mock_create.call_args_list[0].kwargs["tools"]
+            sub_b_tools = mock_create.call_args_list[1].kwargs["tools"]
+
+            retriever_tools_a = _retriever_tools(sub_a_tools)
+            retriever_tools_b = _retriever_tools(sub_b_tools)
+            assert len(retriever_tools_a) == 1
+            assert len(retriever_tools_b) == 1
+
+            await retriever_tools_a[0].coroutine(query="find machine")
+            await retriever_tools_b[0].coroutine(query="find something")
+
+        calls_by_silo_id = {
+            call.args[0]: call.args[1] for call in mock_get_silo_retriever.call_args_list
+        }
+
+        # Subagent A: the caller's whitelisted filter reached the vector store call.
+        sp_a = calls_by_silo_id[silo_a.silo_id]
+        assert sp_a is not None
+        assert sp_a.get("filter", {}).get("machine_model") == {"$eq": "X100"}
+
+        # Subagent B: unaffected — Gate 2 dropped the field cleanly since silo_b
+        # doesn't declare it; no filter key leaked through, retrieval still runs.
+        sp_b = calls_by_silo_id[silo_b.silo_id]
+        assert not (sp_b or {}).get("filter", {})
+
+    @pytest.mark.asyncio
+    async def test_subagent_fixed_filter_wins_over_caller_selection(self, db, fake_app):
+        """Gate 3 (unchanged existing resolve_search_params precedence) still
+        holds when reached via the new Gate 1/2 subagent path: subagent A's own
+        rag_fixed_filters pins machine_model=X200, beating the caller's X100
+        selection — an orchestrator caller can never loosen an admin scoping
+        floor set on a specific subagent.
+        """
+        from tools import agentTools
+
+        parser_a = _make_output_parser(
+            db, fake_app.app_id, fields=[{"name": "machine_model", "type": "str"}]
+        )
+        silo_a = _make_silo(db, fake_app.app_id, parser_a.parser_id)
+
+        sub_a = _make_subagent(
+            db,
+            fake_app.app_id,
+            silo_a.silo_id,
+            rag_fixed_filters=[{"field": "machine_model", "op": "$eq", "value": "X200"}],
+            name="SubA",
+        )
+
+        orchestrator = _make_orchestrator(
+            db,
+            fake_app.app_id,
+            exposed_chat_filters=["machine_model"],
+            sub_agents=[sub_a],
+        )
+
+        fake_retriever = MagicMock()
+        fake_retriever.ainvoke = AsyncMock(return_value=[])
+        mock_get_silo_retriever = MagicMock(return_value=fake_retriever)
+
+        with (
+            patch("tools.agentTools.get_llm", return_value=object()),
+            patch(
+                "tools.agentTools.create_langchain_agent", return_value=MagicMock()
+            ) as mock_create,
+            patch.object(
+                agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)
+            ),
+            patch(
+                "services.silo_service.SiloService.get_silo_retriever",
+                new=mock_get_silo_retriever,
+            ),
+            patch(
+                "services.metadata_values_cache_service.MetadataValuesCacheService.get_distinct_values",
+                return_value=[],
+            ),
+        ):
+            await agentTools.create_agent(
+                orchestrator, search_params={"filter": {"machine_model": "X100"}}
+            )
+
+            sub_a_tools = mock_create.call_args_list[0].kwargs["tools"]
+            retriever_tools_a = _retriever_tools(sub_a_tools)
+            assert len(retriever_tools_a) == 1
+
+            await retriever_tools_a[0].coroutine(query="find machine")
+
+        call = mock_get_silo_retriever.call_args_list[0]
+        call_search_params = call.args[1]
+        assert call_search_params["filter"]["machine_model"] == {"$eq": "X200"}

--- a/tests/unit/services/test_agent_service.py
+++ b/tests/unit/services/test_agent_service.py
@@ -538,6 +538,135 @@ class TestGetChatFilterValues:
         assert result == []
 
 
+class TestGetChatFilterFieldValues:
+    """Test AgentService.get_chat_filter_field_values() — the public-API, single-field lookup."""
+
+    def _make_orchestrator_with_subagents(self, exposed_chat_filters, sub_silo_ids):
+        agent = MagicMock()
+        agent.exposed_chat_filters = exposed_chat_filters
+        agent.silo_id = None
+        associations = []
+        for silo_id in sub_silo_ids:
+            assoc = MagicMock()
+            assoc.tool = MagicMock(silo_id=silo_id)
+            associations.append(assoc)
+        agent.tool_associations = associations
+        return agent
+
+    def test_returns_none_when_field_not_exposed(self, mocker):
+        """A field name absent from exposed_chat_filters is rejected with None,
+        regardless of whether some silo actually declares it — this is the
+        security boundary, never leak unexposed internal field names."""
+        db = MagicMock()
+        service = AgentService()
+        agent = self._make_orchestrator_with_subagents(
+            exposed_chat_filters=["machine_model"], sub_silo_ids=[101]
+        )
+
+        result = service.get_chat_filter_field_values(db, agent, "some_other_field")
+
+        assert result is None
+
+    def test_returns_sorted_values_when_field_exposed_and_declared(self, mocker):
+        db = MagicMock()
+        service = AgentService()
+        agent = self._make_orchestrator_with_subagents(
+            exposed_chat_filters=["machine_model"], sub_silo_ids=[101, 102]
+        )
+
+        def fake_silo_info(_db, silo_id):
+            if silo_id == 101:
+                return {"metadata_definition": {"fields": [{"name": "machine_model", "type": "str"}]}}
+            return {"metadata_definition": {"fields": [{"name": "other_field", "type": "str"}]}}
+
+        mocker.patch(
+            'services.agent_service.AgentRepository.get_silo_with_metadata_definition',
+            side_effect=fake_silo_info,
+        )
+        mock_get_values = mocker.patch(
+            'services.agent_service.MetadataValuesCacheService.get_distinct_values',
+            return_value=["X200", "X100"],
+        )
+
+        result = service.get_chat_filter_field_values(db, agent, "machine_model")
+
+        assert result == ["X100", "X200"]
+        called_silo_ids = {call.args[0] for call in mock_get_values.call_args_list}
+        assert called_silo_ids == {101}
+
+    def test_returns_empty_list_when_exposed_but_no_silo_declares_it(self, mocker):
+        db = MagicMock()
+        service = AgentService()
+        agent = self._make_orchestrator_with_subagents(
+            exposed_chat_filters=["machine_model"], sub_silo_ids=[101]
+        )
+
+        mocker.patch(
+            'services.agent_service.AgentRepository.get_silo_with_metadata_definition',
+            return_value={"metadata_definition": {"fields": [{"name": "other_field", "type": "str"}]}},
+        )
+
+        result = service.get_chat_filter_field_values(db, agent, "machine_model")
+
+        assert result == []
+
+    def test_never_raises_when_one_silos_lookup_fails(self, mocker):
+        db = MagicMock()
+        service = AgentService()
+        agent = self._make_orchestrator_with_subagents(
+            exposed_chat_filters=["machine_model"], sub_silo_ids=[101, 102]
+        )
+
+        mocker.patch(
+            'services.agent_service.AgentRepository.get_silo_with_metadata_definition',
+            return_value={"metadata_definition": {"fields": [{"name": "machine_model", "type": "str"}]}},
+        )
+
+        def fake_get_values(silo_id, field, db_arg):
+            if silo_id == 101:
+                raise RuntimeError("vector store unreachable")
+            return ["X200"]
+
+        mocker.patch(
+            'services.agent_service.MetadataValuesCacheService.get_distinct_values',
+            side_effect=fake_get_values,
+        )
+
+        result = service.get_chat_filter_field_values(db, agent, "machine_model")
+
+        assert result == ["X200"]
+
+    def test_get_chat_filter_values_still_works_after_refactor(self, mocker):
+        """Regression: extracting _collect_candidate_silo_ids must not change
+        get_chat_filter_values' existing behavior (own silo + subagents' silos)."""
+        db = MagicMock()
+        service = AgentService()
+        agent = self._make_orchestrator_with_subagents(
+            exposed_chat_filters=["machine_model"], sub_silo_ids=[101]
+        )
+        agent.silo_id = 999
+
+        def fake_silo_info(_db, silo_id):
+            if silo_id in (101, 999):
+                return {"metadata_definition": {"fields": [{"name": "machine_model", "type": "str"}]}}
+            return None
+
+        mocker.patch(
+            'services.agent_service.AgentRepository.get_silo_with_metadata_definition',
+            side_effect=fake_silo_info,
+        )
+        mock_get_values = mocker.patch(
+            'services.agent_service.MetadataValuesCacheService.get_distinct_values',
+            return_value=["X100"],
+        )
+
+        result = service.get_chat_filter_values(db, agent)
+
+        assert result == [{"field_name": "machine_model", "values": ["X100"]}]
+        called_silo_ids = {call.args[0] for call in mock_get_values.call_args_list}
+        assert called_silo_ids == {101, 999}
+
+
 # ---------------------------------------------------------------------------
 # create_or_update_agent
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_agent_service.py
+++ b/tests/unit/services/test_agent_service.py
@@ -328,6 +328,217 @@ class TestGetAgentDetail:
 
 
 # ---------------------------------------------------------------------------
+# get_available_chat_filter_fields
+# ---------------------------------------------------------------------------
+
+class TestGetAvailableChatFilterFields:
+    """Test AgentService.get_available_chat_filter_fields()"""
+
+    def test_unions_fields_across_candidate_silos(self, mocker):
+        """Fields from the own silo and every candidate tool's silo are unioned."""
+        db = MagicMock()
+        service = AgentService()
+
+        db.query.return_value.filter.return_value.all.return_value = [(2, 201)]
+
+        def fake_silo_info(_db, silo_id):
+            if silo_id == 100:  # own silo
+                return {"metadata_definition": {"fields": [{"name": "region", "type": "str"}]}}
+            if silo_id == 201:  # subagent silo
+                return {"metadata_definition": {"fields": [{"name": "machine_model", "type": "str"}]}}
+            return None
+
+        mocker.patch(
+            'services.agent_service.AgentRepository.get_silo_with_metadata_definition',
+            side_effect=fake_silo_info,
+        )
+
+        result = service.get_available_chat_filter_fields(db, tool_ids=[2], own_silo_id=100)
+
+        names = {f['name'] for f in result}
+        assert names == {'region', 'machine_model'}
+
+    def test_dedupes_field_name_across_silos_without_erroring(self, mocker):
+        """Two candidate silos declaring the same field name by different types
+        must be deduped into a single entry, not raise, and (per the current
+        implementation, which iterates a plain Python ``set`` of silo_ids —
+        NOT an ordered structure) the type kept is whichever silo is visited
+        first in that set's iteration order."""
+        db = MagicMock()
+        service = AgentService()
+
+        # tool_ids [2, 3] map to silo_ids 201 and 202 respectively.
+        db.query.return_value.filter.return_value.all.return_value = [(2, 201), (3, 202)]
+
+        def fake_silo_info(_db, silo_id):
+            if silo_id == 201:
+                return {"metadata_definition": {"fields": [{"name": "machine_model", "type": "str"}]}}
+            if silo_id == 202:
+                return {"metadata_definition": {"fields": [{"name": "machine_model", "type": "int"}]}}
+            return None
+
+        mocker.patch(
+            'services.agent_service.AgentRepository.get_silo_with_metadata_definition',
+            side_effect=fake_silo_info,
+        )
+
+        result = service.get_available_chat_filter_fields(db, tool_ids=[2, 3], own_silo_id=None)
+
+        # Deduped: exactly one "machine_model" entry, no exception raised.
+        matching = [f for f in result if f['name'] == 'machine_model']
+        assert len(matching) == 1
+        # CPython set iteration over small distinct ints is ascending in practice,
+        # so silo 201 (added first) is visited before 202 — asserting the actual
+        # observed behavior, not a documented contract.
+        assert matching[0]['type'] == 'str'
+
+    def test_broken_metadata_definition_for_one_silo_does_not_block_others(self, mocker):
+        """A silo lookup raising an exception contributes nothing but doesn't
+        prevent other candidate silos' fields from being included."""
+        db = MagicMock()
+        service = AgentService()
+
+        db.query.return_value.filter.return_value.all.return_value = [(2, 201), (3, 202)]
+
+        def fake_silo_info(_db, silo_id):
+            if silo_id == 201:
+                raise RuntimeError("boom")
+            if silo_id == 202:
+                return {"metadata_definition": {"fields": [{"name": "machine_model", "type": "str"}]}}
+            return None
+
+        mocker.patch(
+            'services.agent_service.AgentRepository.get_silo_with_metadata_definition',
+            side_effect=fake_silo_info,
+        )
+
+        result = service.get_available_chat_filter_fields(db, tool_ids=[2, 3], own_silo_id=None)
+
+        assert [f['name'] for f in result] == ['machine_model']
+
+    def test_returns_empty_list_with_no_candidates(self, mocker):
+        db = MagicMock()
+        service = AgentService()
+
+        result = service.get_available_chat_filter_fields(db, tool_ids=[], own_silo_id=None)
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_chat_filter_values
+# ---------------------------------------------------------------------------
+
+class TestGetChatFilterValues:
+    """Test AgentService.get_chat_filter_values()"""
+
+    def _make_orchestrator_with_subagents(self, exposed_chat_filters, sub_silo_ids):
+        agent = MagicMock()
+        agent.exposed_chat_filters = exposed_chat_filters
+        agent.silo_id = None
+        associations = []
+        for silo_id in sub_silo_ids:
+            assoc = MagicMock()
+            assoc.tool = MagicMock(silo_id=silo_id)
+            associations.append(assoc)
+        agent.tool_associations = associations
+        return agent
+
+    def test_aggregates_values_only_from_silos_that_declare_the_field(self, mocker):
+        """Only the subagent silo declaring ``machine_model`` contributes values;
+        the other subagent's silo (which lacks the field) causes no error and no
+        garbage entry."""
+        db = MagicMock()
+        service = AgentService()
+        agent = self._make_orchestrator_with_subagents(
+            exposed_chat_filters=["machine_model"], sub_silo_ids=[101, 102]
+        )
+
+        def fake_silo_info(_db, silo_id):
+            if silo_id == 101:
+                return {"metadata_definition": {"fields": [{"name": "machine_model", "type": "str"}]}}
+            if silo_id == 102:
+                return {"metadata_definition": {"fields": [{"name": "other_field", "type": "str"}]}}
+            return None
+
+        mocker.patch(
+            'services.agent_service.AgentRepository.get_silo_with_metadata_definition',
+            side_effect=fake_silo_info,
+        )
+        mock_get_values = mocker.patch(
+            'services.agent_service.MetadataValuesCacheService.get_distinct_values',
+            return_value=["X100", "X200"],
+        )
+
+        result = service.get_chat_filter_values(db, agent)
+
+        assert result == [{"field_name": "machine_model", "values": ["X100", "X200"]}]
+        # Only the declaring silo (101) was ever queried for distinct values.
+        called_silo_ids = {call.args[0] for call in mock_get_values.call_args_list}
+        assert called_silo_ids == {101}
+
+    def test_never_raises_when_one_silos_lookup_fails(self, mocker):
+        """A distinct-values lookup failure for one silo is swallowed; aggregation
+        for the other declaring silo still completes."""
+        db = MagicMock()
+        service = AgentService()
+        agent = self._make_orchestrator_with_subagents(
+            exposed_chat_filters=["machine_model"], sub_silo_ids=[101, 102]
+        )
+
+        def fake_silo_info(_db, silo_id):
+            # Both silos declare the field so both are queried for values.
+            return {"metadata_definition": {"fields": [{"name": "machine_model", "type": "str"}]}}
+
+        mocker.patch(
+            'services.agent_service.AgentRepository.get_silo_with_metadata_definition',
+            side_effect=fake_silo_info,
+        )
+
+        def fake_get_values(silo_id, field, db_arg):
+            if silo_id == 101:
+                raise RuntimeError("vector store unreachable")
+            return ["X200"]
+
+        mocker.patch(
+            'services.agent_service.MetadataValuesCacheService.get_distinct_values',
+            side_effect=fake_get_values,
+        )
+
+        result = service.get_chat_filter_values(db, agent)
+
+        # Never raises; the surviving silo's values are still returned.
+        assert result == [{"field_name": "machine_model", "values": ["X200"]}]
+
+    def test_returns_empty_list_when_no_exposed_filters(self, mocker):
+        db = MagicMock()
+        service = AgentService()
+        agent = self._make_orchestrator_with_subagents(exposed_chat_filters=[], sub_silo_ids=[101])
+
+        result = service.get_chat_filter_values(db, agent)
+
+        assert result == []
+
+    def test_field_omitted_when_no_silo_declares_it(self, mocker):
+        """A field in exposed_chat_filters with zero declaring silos is silently
+        omitted from the result, not an error."""
+        db = MagicMock()
+        service = AgentService()
+        agent = self._make_orchestrator_with_subagents(
+            exposed_chat_filters=["machine_model"], sub_silo_ids=[101]
+        )
+
+        mocker.patch(
+            'services.agent_service.AgentRepository.get_silo_with_metadata_definition',
+            return_value={"metadata_definition": {"fields": [{"name": "other_field", "type": "str"}]}},
+        )
+
+        result = service.get_chat_filter_values(db, agent)
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
 # create_or_update_agent
 # ---------------------------------------------------------------------------
 
@@ -401,8 +612,118 @@ class TestCreateOrUpdateAgent:
         mocker.patch('services.agent_service.AgentRepository.update', return_value=updated_agent)
         
         result = service.create_or_update_agent(db, agent_data, agent_type='agent')
-        
+
         assert result == 5  # Returns the agent ID
+
+    def test_rejects_exposed_chat_filters_referencing_unknown_field(self, mocker):
+        """An exposed_chat_filters entry absent from every candidate silo's
+        metadata fields is rejected with a ValueError, mirroring the existing
+        rag_fixed_filters unknown-field validation."""
+        db = MagicMock()
+        service = AgentService()
+        agent_data = {
+            'agent_id': 0,
+            'app_id': 1,
+            'name': 'Orchestrator',
+            'description': 'Test',
+            'system_prompt': '',
+            'prompt_template': None,
+            'status': None,
+            'service_id': None,
+            'silo_id': None,
+            'has_memory': False,
+            'output_parser_id': None,
+            'temperature': 0.7,
+            'is_tool': False,
+            'vision_service_id': None,
+            'vision_system_prompt': None,
+            'text_system_prompt': None,
+            'tool_ids': [2],
+            'exposed_chat_filters': ['bogus_field'],
+        }
+
+        mocker.patch('services.agent_service.AgentRepository.get_agent_by_id_and_type', return_value=None)
+        mocker.patch.object(
+            service,
+            'get_available_chat_filter_fields',
+            return_value=[{'name': 'machine_model', 'type': 'str', 'description': None}],
+        )
+
+        with pytest.raises(ValueError, match='exposed_chat_filters references unknown metadata fields'):
+            service.create_or_update_agent(db, agent_data, agent_type='agent')
+
+    def test_accepts_exposed_chat_filters_that_are_available(self, mocker):
+        """An exposed_chat_filters entry present in the available fields union is
+        accepted and the agent is persisted normally."""
+        db = MagicMock()
+        service = AgentService()
+        agent_data = {
+            'agent_id': 0,
+            'app_id': 1,
+            'name': 'Orchestrator',
+            'description': 'Test',
+            'system_prompt': '',
+            'prompt_template': None,
+            'status': None,
+            'service_id': None,
+            'silo_id': None,
+            'has_memory': False,
+            'output_parser_id': None,
+            'temperature': 0.7,
+            'is_tool': False,
+            'vision_service_id': None,
+            'vision_system_prompt': None,
+            'text_system_prompt': None,
+            'tool_ids': [2],
+            'exposed_chat_filters': ['machine_model'],
+        }
+
+        mocker.patch('services.agent_service.AgentRepository.get_agent_by_id_and_type', return_value=None)
+        mocker.patch.object(
+            service,
+            'get_available_chat_filter_fields',
+            return_value=[{'name': 'machine_model', 'type': 'str', 'description': None}],
+        )
+        created_agent = MagicMock()
+        created_agent.agent_id = 7
+        mocker.patch('services.agent_service.AgentRepository.create', return_value=created_agent)
+
+        result = service.create_or_update_agent(db, agent_data, agent_type='agent')
+
+        assert result == 7
+
+    def test_rejects_rag_fixed_filters_on_agent_without_silo(self, mocker):
+        """rag_fixed_filters requires a silo; setting it without one is rejected.
+
+        Mirrors the existing validation pattern this test class follows for
+        exposed_chat_filters, confirming the two validations are independent.
+        """
+        db = MagicMock()
+        service = AgentService()
+        agent_data = {
+            'agent_id': 0,
+            'app_id': 1,
+            'name': 'No Silo Agent',
+            'description': 'Test',
+            'system_prompt': '',
+            'prompt_template': None,
+            'status': None,
+            'service_id': None,
+            'silo_id': None,
+            'has_memory': False,
+            'output_parser_id': None,
+            'temperature': 0.7,
+            'is_tool': False,
+            'vision_service_id': None,
+            'vision_system_prompt': None,
+            'text_system_prompt': None,
+            'rag_fixed_filters': [{'field': 'machine_model', 'op': '$eq', 'value': 'X100'}],
+        }
+
+        mocker.patch('services.agent_service.AgentRepository.get_agent_by_id_and_type', return_value=None)
+
+        with pytest.raises(ValueError, match='rag_fixed_filters can only be set on an agent that has a silo'):
+            service.create_or_update_agent(db, agent_data, agent_type='agent')
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/tools/test_agent_tools.py
+++ b/tests/unit/tools/test_agent_tools.py
@@ -1,22 +1,51 @@
 """Unit tests for ``tools.agentTools.IACTTool`` (agent-as-tool wrapper).
 
 Focus: the async factory ``IACTTool.create`` must load the sub-agent's MCP tools
-(the bug being fixed), and must keep working when the MCP server fails.
+(the bug being fixed), and must keep working when the MCP server fails. Also
+covers the orchestrator-level metadata dropdown filter whitelisting (Gate 1 in
+``create_agent``, Gate 2 in ``_resolve_and_build_retriever_tool``).
 
 All external dependencies are mocked — no LLM, MCP server or database is touched.
 """
 
+import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from models.agent import Agent
+from models.agent import Agent, AgentTool
+from models.silo import Silo
 from tools import agentTools
 
 
 def _make_agent(name: str = "Sub Agent") -> Agent:
     """Build a transient (un-persisted) Agent suitable for IACTTool construction."""
     return Agent(name=name, description=f"{name} description", system_prompt="")
+
+
+def _make_orchestrator(exposed_chat_filters=None, tool_agents=None) -> Agent:
+    """Build a transient orchestrator Agent wired to *tool_agents* via ``tool_associations``.
+
+    ``tool_associations`` is a relationship collection; on a transient (never
+    session-attached) object it can be assigned directly without touching the DB.
+    """
+    orchestrator = Agent(
+        name="Orchestrator",
+        description="Orchestrator description",
+        system_prompt="",
+        output_parser_id=None,
+        silo_id=None,
+        has_memory=False,
+        enable_code_interpreter=False,
+    )
+    orchestrator.exposed_chat_filters = exposed_chat_filters or []
+    associations = []
+    for tool_agent in (tool_agents or []):
+        assoc = AgentTool()
+        assoc.tool = tool_agent
+        associations.append(assoc)
+    orchestrator.tool_associations = associations
+    return orchestrator
 
 
 @pytest.mark.asyncio
@@ -138,3 +167,240 @@ async def test_iact_tool_create_skips_retriever_without_silo():
 
     mock_resolve.assert_not_called()
     mock_get_ret.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Gate 1 — orchestrator-level whitelist, applied in create_agent()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_agent_gate1_whitelists_caller_filter_by_exposed_fields():
+    """Only fields listed in ``exposed_chat_filters`` reach ``IACTTool.create``.
+
+    A caller filter with an approved field (``machine_model``) and an
+    unapproved one (``not_exposed``) must have the unapproved field dropped
+    before it is ever forwarded to a sub-agent.
+    """
+    sub_agent = _make_agent("Sub Agent")
+    orchestrator = _make_orchestrator(
+        exposed_chat_filters=["machine_model"], tool_agents=[sub_agent]
+    )
+
+    with (
+        patch("tools.agentTools.get_llm", return_value=object()),
+        patch("tools.agentTools.create_langchain_agent", return_value=MagicMock()),
+        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+        patch.object(
+            agentTools.IACTTool, "create", new=AsyncMock(return_value=MagicMock())
+        ) as mock_iact_create,
+    ):
+        await agentTools.create_agent(
+            orchestrator,
+            search_params={"filter": {"machine_model": "X100", "not_exposed": "foo"}},
+        )
+
+    mock_iact_create.assert_awaited_once()
+    call = mock_iact_create.await_args
+    assert call.args[0] is sub_agent
+    assert call.kwargs["caller_filter"] == {"machine_model": "X100"}
+
+
+@pytest.mark.asyncio
+async def test_create_agent_gate1_drops_field_absent_from_exposed_chat_filters():
+    """A field not listed in ``exposed_chat_filters`` never reaches ``IACTTool.create``,
+    independent of whether any sub-agent's silo would otherwise declare it (Gate 2)."""
+    sub_agent = _make_agent("Sub Agent")
+    orchestrator = _make_orchestrator(exposed_chat_filters=[], tool_agents=[sub_agent])
+
+    with (
+        patch("tools.agentTools.get_llm", return_value=object()),
+        patch("tools.agentTools.create_langchain_agent", return_value=MagicMock()),
+        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+        patch.object(
+            agentTools.IACTTool, "create", new=AsyncMock(return_value=MagicMock())
+        ) as mock_iact_create,
+    ):
+        await agentTools.create_agent(
+            orchestrator,
+            search_params={"filter": {"machine_model": "X100"}},
+        )
+
+    mock_iact_create.assert_awaited_once()
+    assert mock_iact_create.await_args.kwargs["caller_filter"] == {}
+
+
+@pytest.mark.asyncio
+async def test_create_agent_gate1_empty_exposed_chat_filters_is_never_null():
+    """``exposed_chat_filters`` unset (None on a transient agent) degrades to an
+    empty whitelist, not a crash — orchestrator_caller_filter is always a dict."""
+    sub_agent = _make_agent("Sub Agent")
+    orchestrator = _make_orchestrator(exposed_chat_filters=None, tool_agents=[sub_agent])
+    orchestrator.exposed_chat_filters = None  # simulate an un-flushed column default
+
+    with (
+        patch("tools.agentTools.get_llm", return_value=object()),
+        patch("tools.agentTools.create_langchain_agent", return_value=MagicMock()),
+        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+        patch.object(
+            agentTools.IACTTool, "create", new=AsyncMock(return_value=MagicMock())
+        ) as mock_iact_create,
+    ):
+        await agentTools.create_agent(
+            orchestrator,
+            search_params={"filter": {"machine_model": "X100"}},
+        )
+
+    assert mock_iact_create.await_args.kwargs["caller_filter"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Gate 2 — per-subagent silo whitelist, applied in
+# _resolve_and_build_retriever_tool (reached via IACTTool.create)
+# ---------------------------------------------------------------------------
+
+
+def _make_silo_stub(fields: list, vector_db_type: str = "PGVECTOR") -> Silo:
+    """Build a transient (un-persisted) Silo with a fake metadata_definition.
+
+    Must be a real ``Silo`` ORM instance (not a bare SimpleNamespace): assigning
+    to ``Agent.silo`` fires a back_populates backref event that requires the
+    assigned object to carry SQLAlchemy instance state. ``metadata_definition``
+    itself has no back_populates, so a plain SimpleNamespace duck-type works
+    fine there (mirrors the ``test_resolve_search_params.py`` convention).
+    """
+    silo = Silo(vector_db_type=vector_db_type)
+    silo.metadata_definition = types.SimpleNamespace(fields=fields)
+    return silo
+
+
+@pytest.mark.asyncio
+async def test_iact_tool_create_gate2_forwards_filter_when_silo_declares_field():
+    """A caller_filter field declared by the sub-agent's own silo reaches
+    ``resolve_search_params`` scoped down to a flat {field: value} filter dict."""
+    agent = _make_agent("RAG Sub-Agent")
+    agent.silo_id = 99
+    agent.silo = _make_silo_stub(fields=[{"name": "machine_model", "type": "str"}])
+    agent.rag_max_retrieval_calls = 3
+
+    resolved_sp = {"k": 7}
+    resolved_pinned = {"machine_model": {"$eq": "X100"}}
+    sentinel_tool = MagicMock()
+
+    with (
+        patch("tools.agentTools.get_llm", return_value=object()),
+        patch("tools.agentTools.create_langchain_agent", return_value=MagicMock()),
+        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+        patch(
+            "services.silo_service.resolve_search_params",
+            return_value=(resolved_sp, resolved_pinned),
+        ) as mock_resolve,
+        patch("tools.agentTools.get_retriever_tool", return_value=sentinel_tool),
+    ):
+        await agentTools.IACTTool.create(agent, caller_filter={"machine_model": "X100"})
+
+    assert mock_resolve.call_args.args[0] is agent
+    assert mock_resolve.call_args.args[1] == {"filter": {"machine_model": "X100"}}
+
+
+@pytest.mark.asyncio
+async def test_iact_tool_create_gate2_drops_filter_when_silo_does_not_declare_field():
+    """A caller_filter field NOT declared by this sub-agent's silo is dropped for
+    this sub-agent only (Gate 2) — resolve_search_params receives no filter."""
+    agent = _make_agent("RAG Sub-Agent")
+    agent.silo_id = 99
+    # This silo's metadata schema declares a *different* field only.
+    agent.silo = _make_silo_stub(fields=[{"name": "other_field", "type": "str"}])
+    agent.rag_max_retrieval_calls = 3
+
+    resolved_sp = {"k": 7}
+    resolved_pinned = {}
+    sentinel_tool = MagicMock()
+
+    with (
+        patch("tools.agentTools.get_llm", return_value=object()),
+        patch("tools.agentTools.create_langchain_agent", return_value=MagicMock()),
+        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+        patch(
+            "services.silo_service.resolve_search_params",
+            return_value=(resolved_sp, resolved_pinned),
+        ) as mock_resolve,
+        patch("tools.agentTools.get_retriever_tool", return_value=sentinel_tool),
+    ):
+        await agentTools.IACTTool.create(agent, caller_filter={"machine_model": "X100"})
+
+    assert mock_resolve.call_args.args[0] is agent
+    # The whole caller_search_params collapses to None: scoped_filter was empty.
+    assert mock_resolve.call_args.args[1] is None
+
+
+@pytest.mark.asyncio
+async def test_iact_tool_create_no_caller_filter_never_touches_silo_or_scoping():
+    """caller_filter=None (default) is the existing, unchanged path: no scoping
+    work is attempted and resolve_search_params gets None, matching the
+    pre-existing ``test_iact_tool_create_uses_sub_agent_rag_config`` behavior."""
+    agent = _make_agent("RAG Sub-Agent")
+    agent.silo_id = 99
+    agent.rag_max_retrieval_calls = 3
+
+    resolved_sp = {"k": 7}
+    resolved_pinned = {}
+    sentinel_tool = MagicMock()
+
+    with (
+        patch("tools.agentTools.get_llm", return_value=object()),
+        patch("tools.agentTools.create_langchain_agent", return_value=MagicMock()),
+        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+        patch(
+            "services.silo_service.resolve_search_params",
+            return_value=(resolved_sp, resolved_pinned),
+        ) as mock_resolve,
+        patch("tools.agentTools.get_retriever_tool", return_value=sentinel_tool),
+    ):
+        await agentTools.IACTTool.create(agent)
+
+    assert mock_resolve.call_args.args[1] is None
+
+
+# ---------------------------------------------------------------------------
+# Nested tool-agents — caller_filter forwarded unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_iact_tool_create_forwards_caller_filter_to_nested_tool_agents():
+    """A nested sub-agent-of-a-sub-agent receives the same already-whitelisted
+    caller_filter unchanged — no re-derivation against a nested exposed_chat_filters.
+
+    Uses the real (unmocked) recursive ``IACTTool.create`` call and verifies the
+    filter reached the grandchild's own Gate 2 scoping via ``resolve_search_params``.
+    """
+    grandchild = _make_agent("Grandchild")
+    grandchild.silo_id = 99
+    grandchild.silo = _make_silo_stub(fields=[{"name": "machine_model", "type": "str"}])
+
+    child = _make_agent("Child")
+    child.silo_id = None  # no retriever of its own — just wraps the grandchild
+    assoc = AgentTool()
+    assoc.tool = grandchild
+    child.tool_associations = [assoc]
+
+    resolved_sp = {"k": 7}
+    resolved_pinned = {"machine_model": {"$eq": "X100"}}
+
+    with (
+        patch("tools.agentTools.get_llm", return_value=object()),
+        patch("tools.agentTools.create_langchain_agent", return_value=MagicMock()),
+        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+        patch(
+            "services.silo_service.resolve_search_params",
+            return_value=(resolved_sp, resolved_pinned),
+        ) as mock_resolve,
+        patch("tools.agentTools.get_retriever_tool", return_value=MagicMock()),
+    ):
+        await agentTools.IACTTool.create(child, caller_filter={"machine_model": "X100"})
+
+    # resolve_search_params was reached for the grandchild with the filter intact.
+    mock_resolve.assert_called_once()
+    assert mock_resolve.call_args.args[0] is grandchild
+    assert mock_resolve.call_args.args[1] == {"filter": {"machine_model": "X100"}}

--- a/tests/unit/tools/test_vector_store_delete.py
+++ b/tests/unit/tools/test_vector_store_delete.py
@@ -217,3 +217,63 @@ class TestPGVectorStoreStrForJsonb:
         PGVectorStore._operator_condition(0, "active", "$in", [True, False], params)
         assert params["in0_0"] == "true"
         assert params["in0_1"] == "false"
+
+
+class TestPGVectorStoreDistinctMetadataValues:
+    """PGVectorStore.get_distinct_metadata_values with a metadata filter.
+
+    This is the enumeration path that replaced a top-k similarity search for
+    "what does this target already hold?". Two things have to hold: the filter
+    reaches the SQL, and the embedding table keeps the alias `_build_filter_sql`
+    emits (`e`) — a mismatch there produces a SQL error at runtime only.
+    """
+
+    def _make_store(self):
+        from tools.vector_stores.pgvector_store import PGVectorStore
+
+        store = PGVectorStore.__new__(PGVectorStore)
+        store.db = MagicMock()
+        store.async_engine = None
+
+        # Reads use engine.connect(), not engine.begin().
+        self.mock_conn = MagicMock()
+        self.mock_conn.execute.return_value = [("https://wiki/A",), ("https://wiki/B",)]
+        mock_engine = MagicMock()
+        mock_engine.connect.return_value.__enter__.return_value = self.mock_conn
+        mock_engine.connect.return_value.__exit__.return_value = False
+        store.engine = mock_engine
+        return store
+
+    def test_filter_reaches_the_sql_with_the_expected_alias(self):
+        store = self._make_store()
+
+        values = store.get_distinct_metadata_values(
+            "silo_3",
+            "source_url",
+            limit=1000,
+            filter_metadata={"categoria": {"$eq": "LS5000"}},
+        )
+
+        assert values == ["https://wiki/A", "https://wiki/B"]
+        sql_arg, params = self.mock_conn.execute.call_args.args
+        sql = str(sql_arg)
+        assert "SELECT DISTINCT e.cmetadata->>:field" in sql
+        assert "FROM langchain_pg_embedding e" in sql
+        # _build_filter_sql always prefixes with `e.`; the join alias must match.
+        assert "e.cmetadata ->> :k0 = :v0" in sql
+        assert params["k0"] == "categoria"
+        assert params["v0"] == "LS5000"
+
+    def test_without_a_filter_the_where_stays_unchanged(self):
+        store = self._make_store()
+
+        store.get_distinct_metadata_values("silo_3", "source_url", limit=100)
+
+        sql = str(self.mock_conn.execute.call_args.args[0])
+        assert "cmetadata ->> :k0" not in sql
+
+    def test_failure_returns_empty_instead_of_raising(self):
+        store = self._make_store()
+        self.mock_conn.execute.side_effect = RuntimeError("boom")
+
+        assert store.get_distinct_metadata_values("silo_3", "source_url") == []


### PR DESCRIPTION
## Summary
- Lets an agent designer expose a whitelist of shared metadata field names (e.g. `machine_model`) as end-user, chat-time dropdown filters at the orchestrator level.
- Selected values propagate to every subagent whose silo declares that field name, via a two-gate whitelist: orchestrator's `exposed_chat_filters` (by field name) → each subagent's own silo schema (`validate_clauses`) — layered on top of the existing admin-pinned `rag_fixed_filters` precedence, which still wins on conflict.
- Wired into both the Playground and Marketplace chat, with a redesigned, collapsible filter UI (active-filter chips, humanized labels) placed consistently above the composer in both surfaces.
- `IACTTool.create()` previously hardcoded `caller_search_params=None` for subagents ("self-contained (FR-12)") — this is the core gap the whitelist propagation closes, without letting an orchestrator's caller inject arbitrary/unvalidated filters into subagent retrieval.

## Changes
- `backend/models/agent.py` + migration: new `Agent.exposed_chat_filters` JSON column.
- `backend/tools/agentTools.py`: `create_agent()` / `IACTTool.create()` whitelist-propagate a caller filter down to subagent retrievers (Gate 1: orchestrator field-name whitelist, Gate 2: per-subagent silo-schema whitelist).
- `backend/schemas/agent_schemas.py`, `backend/services/agent_service.py`: designer config CRUD + validation, plus new aggregation methods for available fields and live distinct values.
- `backend/routers/internal/agents.py`, `backend/routers/internal/marketplace.py`: new `available-chat-filter-fields` / `chat-filters` endpoints; Marketplace chat endpoints now accept/forward `search_params` (previously hardcoded to `None`).
- `frontend/src/components/forms/ExposedChatFiltersSection.tsx`: designer checkbox picker in the Agent form.
- `frontend/src/components/playground/OrchestratorFilterDropdowns.tsx`: end-user dropdown panel — collapsible, active-filter chips, humanized labels — wired into `ChatInterface.tsx` (Playground) and `MarketplaceChatPage.tsx` (Marketplace) in the same position above the composer.
- Unit tests (`test_agent_tools.py`, `test_agent_service.py`) and a new integration test (`test_orchestrator_chat_filters_integration.py`) covering the whitelist/precedence gates end-to-end.

## Test plan
- [x] Unit tests: `pytest tests/unit -k "agent"` — 216 passed, 2 skipped (pre-existing, unrelated).
- [x] Integration test: `pytest tests/integration/tools/test_orchestrator_chat_filters_integration.py -m integration` — 2 passed, exercising a real 2-subagent orchestrator (one subagent's silo declares the filtered field, the other doesn't) plus fixed-filter precedence.
- [x] Migration: `alembic upgrade head` / `downgrade -1` / `upgrade head` verified against a live dev DB.
- [x] Live end-to-end verification against the real Dibal app (`Orquestador Dibal`, real subagents/silos, real embedding + LLM services): designer checkbox correctly aggregates fields from subagent silos, Playground dropdown renders real distinct values, and a filtered chat message returned a response grounded exclusively in the selected machine model's document (confirmed via backend logs showing Gate 1/Gate 2 firing correctly).
- [x] Frontend lint + typecheck clean on all touched/new files (no new errors vs. baseline).