### PR TITLE
feat(output-parser): support optional fields

### DIFF
--- a/backend/schemas/export_schemas.py
+++ b/backend/schemas/export_schemas.py
@@ -62,6 +62,7 @@ class ExportOutputParserFieldSchema(BaseModel):
     name: str
     type: str  # 'str', 'int', 'float', 'bool', 'date', 'list', 'dict', 'parser'
     description: str
+    required: bool = True
     parser_name: Optional[str] = None  # For type='parser' (name-based reference)
     list_item_type: Optional[str] = None  # For type='list'
     list_item_parser_name: Optional[str] = None  # For list of parsers (name-based reference)

--- a/backend/schemas/output_parser_schemas.py
+++ b/backend/schemas/output_parser_schemas.py
@@ -19,6 +19,7 @@ class OutputParserFieldSchema(BaseModel):
     name: str
     type: str  # 'str', 'int', 'float', 'bool', 'date', 'list', 'dict', 'parser'
     description: str
+    required: bool = True
     parser_id: Optional[int] = None  # For type='parser'
     list_item_type: Optional[str] = None  # For type='list'
     list_item_parser_id: Optional[int] = None  # For list of parsers

--- a/backend/services/output_parser_export_service.py
+++ b/backend/services/output_parser_export_service.py
@@ -79,6 +79,7 @@ class OutputParserExportService(BaseExportService):
                         name=field_data.get("name", ""),
                         type=field_data.get("type", "str"),
                         description=field_data.get("description", ""),
+                        required=field_data.get("required", True),
                         parser_name=parser_name,
                         list_item_type=field_data.get("list_item_type"),
                         list_item_parser_name=list_item_parser_name,

--- a/backend/services/output_parser_import_service.py
+++ b/backend/services/output_parser_import_service.py
@@ -90,6 +90,7 @@ class OutputParserImportService:
                 "name": field.name,
                 "type": field.type,
                 "description": field.description,
+                "required": field.required,
             }
             if field.parser_name:
                 ref_parser = self.get_by_name_and_app(

--- a/backend/services/output_parser_service.py
+++ b/backend/services/output_parser_service.py
@@ -73,6 +73,7 @@ class OutputParserService:
                     name=field_data.get('name', ''),
                     type=field_data.get('type', 'str'),
                     description=field_data.get('description', ''),
+                    required=field_data.get('required', True),
                     parser_id=field_data.get('parser_id'),
                     list_item_type=field_data.get('list_item_type'),
                     list_item_parser_id=field_data.get('list_item_parser_id')
@@ -117,7 +118,8 @@ class OutputParserService:
             field_dict = {
                 'name': field_data.name,
                 'type': field_data.type,
-                'description': field_data.description
+                'description': field_data.description,
+                'required': field_data.required,
             }
             
             if field_data.type == 'parser' and field_data.parser_id:

--- a/backend/tools/outputParserTools.py
+++ b/backend/tools/outputParserTools.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Type, Dict, Any, List, get_origin, get_args
+from typing import Type, Dict, Any, List, Optional, get_origin, get_args
 from sqlalchemy.orm import Session
 from utils.schema_utils import sanitize_identifier
 from db.database import SessionLocal
@@ -29,7 +29,12 @@ def process_type(field_type):
         
     return field_type
 
-def build_fields_dict(field_names: list[str], field_types: list[type], field_descriptions: list[str]) -> Dict[str, tuple[type, str]]:
+def build_fields_dict(
+    field_names: list[str],
+    field_types: list[type],
+    field_descriptions: list[str],
+    field_required: list[bool],
+) -> Dict[str, tuple[type, str, bool]]:
     """
     Construye un diccionario de campos a partir de listas paralelas.
     
@@ -38,12 +43,14 @@ def build_fields_dict(field_names: list[str], field_types: list[type], field_des
     :param field_descriptions: Lista con las descripciones de los campos
     :return: Diccionario con la estructura requerida para crear el modelo
     """
-    if not (len(field_names) == len(field_types) == len(field_descriptions)):
+    if not (len(field_names) == len(field_types) == len(field_descriptions) == len(field_required)):
         raise ValueError("Todas las listas deben tener la misma longitud")
     
     fields_dict = {
-        field_name: (process_type(field_type), field_desc)
-        for field_name, field_type, field_desc in zip(field_names, field_types, field_descriptions)
+        field_name: (process_type(field_type), field_desc, required)
+        for field_name, field_type, field_desc, required in zip(
+            field_names, field_types, field_descriptions, field_required
+        )
     }
     print("fields_dict", fields_dict)
     return fields_dict
@@ -51,7 +58,8 @@ def build_fields_dict(field_names: list[str], field_types: list[type], field_des
 def create_dynamic_pydantic_model(model_name: str,
     field_names: list[str],
     field_types: list[type],
-    field_descriptions: list[str]
+    field_descriptions: list[str],
+    field_required: list[bool],
 ) -> Type[BaseModel]:
     """
     Crea un modelo Pydantic dinámicamente.
@@ -62,10 +70,13 @@ def create_dynamic_pydantic_model(model_name: str,
     :param field_descriptions: Lista con las descripciones de los campos
     :return: Una nueva clase que hereda de BaseModel con los campos especificados
     """
-    fields = build_fields_dict(field_names, field_types, field_descriptions)
+    fields = build_fields_dict(field_names, field_types, field_descriptions, field_required)
     model_fields = {
-        field_name: (field_type, Field(description=field_desc))
-        for field_name, (field_type, field_desc) in fields.items()
+        field_name: (
+            field_type if required else Optional[field_type],
+            Field(... if required else None, description=field_desc),
+        )
+        for field_name, (field_type, field_desc, required) in fields.items()
     }
     print("model_fields", model_fields)
     return type(model_name, (BaseModel,), {
@@ -115,6 +126,7 @@ def create_model_from_json_schema(schema_data: List[Dict[str, Any]], model_name:
     field_names = []
     field_types = []
     field_descriptions = []
+    field_required = []
     
     for field in schema_data:
         field_names.append(field['name'])
@@ -135,6 +147,7 @@ def create_model_from_json_schema(schema_data: List[Dict[str, Any]], model_name:
                 )
             field_types.append(tipo)
             field_descriptions.append(field['description'])
+            field_required.append(field.get('required', True))
             logging.info(f"Campo procesado: nombre='{field['name']}', tipo='{tipo}', descripción='{field['description']}'")
         except Exception as e:
             logging.error(f"Error procesando campo {field['name']}: {str(e)}")
@@ -144,7 +157,8 @@ def create_model_from_json_schema(schema_data: List[Dict[str, Any]], model_name:
         model_name,
         field_names,
         field_types,
-        field_descriptions
+        field_descriptions,
+        field_required,
     )
     logging.info(f"Modelo Pydantic creado: {model_name}")
     

--- a/frontend/src/components/forms/DataStructureForm.tsx
+++ b/frontend/src/components/forms/DataStructureForm.tsx
@@ -1,12 +1,13 @@
-import { useState, useEffect } from 'react';
-import { BarChart2 } from 'lucide-react';
-import FieldManager from './FieldManager';
-import FormActions from './FormActions';
+import { useState, useEffect } from "react";
+import { BarChart2 } from "lucide-react";
+import FieldManager from "./FieldManager";
+import FormActions from "./FormActions";
 
 interface FieldDefinition {
   name: string;
   type: string;
   description: string;
+  required?: boolean;
   parser_id?: number;
   list_item_type?: string;
   list_item_parser_id?: number;
@@ -25,7 +26,7 @@ interface DataStructure {
   description: string;
   fields: FieldDefinition[];
   created_at: string;
-  available_parsers: Array<{value: number, name: string}>;
+  available_parsers: Array<{ value: number; name: string }>;
 }
 
 interface DataStructureFormProps {
@@ -34,11 +35,15 @@ interface DataStructureFormProps {
   onCancel: () => void;
 }
 
-function DataStructureForm({ dataStructure, onSubmit, onCancel }: Readonly<DataStructureFormProps>) {
+function DataStructureForm({
+  dataStructure,
+  onSubmit,
+  onCancel,
+}: Readonly<DataStructureFormProps>) {
   const [formData, setFormData] = useState<DataStructureFormData>({
-    name: '',
-    description: '',
-    fields: []
+    name: "",
+    description: "",
+    fields: [],
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -49,55 +54,66 @@ function DataStructureForm({ dataStructure, onSubmit, onCancel }: Readonly<DataS
   useEffect(() => {
     if (dataStructure) {
       setFormData({
-        name: dataStructure.name || '',
-        description: dataStructure.description || '',
-        fields: (dataStructure.fields || []).map(f => ({ ...f, _key: Math.random().toString(36).slice(2) }))
+        name: dataStructure.name || "",
+        description: dataStructure.description || "",
+        fields: (dataStructure.fields || []).map((f) => ({
+          ...f,
+          _key: Math.random().toString(36).slice(2),
+        })),
       });
     }
   }, [dataStructure]);
 
-  const handleBasicFieldChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleBasicFieldChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
     const { name, value } = e.target;
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      [name]: value
+      [name]: value,
     }));
   };
 
   const handleFieldsChange = (fields: FieldDefinition[]) => {
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      fields
+      fields,
     }));
   };
 
   const validateForm = (): string | null => {
     if (!formData.name.trim()) {
-      return 'Data structure name is required';
+      return "Data structure name is required";
     }
 
     const namePattern = /^\w+$/;
     if (!namePattern.test(formData.name)) {
-      return 'Name can only contain letters, numbers, and underscores';
+      return "Name can only contain letters, numbers, and underscores";
     }
 
     // Validate fields
-    const fieldNames = formData.fields.map(f => f.name).filter(name => name.trim());
+    const fieldNames = formData.fields
+      .map((f) => f.name)
+      .filter((name) => name.trim());
     const uniqueNames = new Set(fieldNames);
     if (fieldNames.length !== uniqueNames.size) {
-      return 'Field names must be unique';
+      return "Field names must be unique";
     }
 
     for (const field of formData.fields) {
       if (field.name && !namePattern.test(field.name)) {
         return `Field name '${field.name}' can only contain letters, numbers, and underscores`;
       }
-      
-      if (field.type === 'parser' && !field.parser_id) {
+
+      if (field.type === "parser" && !field.parser_id) {
         return `Field '${field.name}' with parser type must have a parser selected`;
       }
-      
-      if (field.type === 'list' && field.list_item_type === 'parser' && !field.list_item_parser_id) {
+
+      if (
+        field.type === "list" &&
+        field.list_item_type === "parser" &&
+        !field.list_item_parser_id
+      ) {
         return `Field '${field.name}' with list of parsers must have a parser selected`;
       }
     }
@@ -107,7 +123,7 @@ function DataStructureForm({ dataStructure, onSubmit, onCancel }: Readonly<DataS
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     const validationError = validateForm();
     if (validationError) {
       setError(validationError);
@@ -116,7 +132,7 @@ function DataStructureForm({ dataStructure, onSubmit, onCancel }: Readonly<DataS
 
     // Filter out empty fields and strip internal _key
     const cleanedFields = formData.fields
-      .filter(field => field.name.trim())
+      .filter((field) => field.name.trim())
       .map(({ _key: _k, ...rest }) => rest);
 
     try {
@@ -124,10 +140,12 @@ function DataStructureForm({ dataStructure, onSubmit, onCancel }: Readonly<DataS
       setError(null);
       await onSubmit({
         ...formData,
-        fields: cleanedFields
+        fields: cleanedFields,
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save data structure');
+      setError(
+        err instanceof Error ? err.message : "Failed to save data structure",
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -147,7 +165,10 @@ function DataStructureForm({ dataStructure, onSubmit, onCancel }: Readonly<DataS
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Name */}
         <div>
-          <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
+          <label
+            htmlFor="name"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
             Data Structure Name *
           </label>
           <input
@@ -167,7 +188,10 @@ function DataStructureForm({ dataStructure, onSubmit, onCancel }: Readonly<DataS
 
         {/* Description */}
         <div>
-          <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-2">
+          <label
+            htmlFor="description"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
             Description
           </label>
           <textarea
@@ -204,8 +228,9 @@ function DataStructureForm({ dataStructure, onSubmit, onCancel }: Readonly<DataS
             </h3>
             <div className="mt-2 text-sm text-purple-700">
               <p className="mb-2">
-                Data structures define the schema for structured data extraction and processing. 
-                They generate Pydantic models that validate and parse AI agent outputs.
+                Data structures define the schema for structured data extraction
+                and processing. They generate Pydantic models that validate and
+                parse AI agent outputs.
               </p>
               <div>
                 <strong>Use cases:</strong>
@@ -226,11 +251,11 @@ function DataStructureForm({ dataStructure, onSubmit, onCancel }: Readonly<DataS
         onCancel={onCancel}
         isSubmitting={isSubmitting}
         isEditing={isEditing}
-        submitLabel={isEditing ? 'Update Structure' : 'Create Structure'}
+        submitLabel={isEditing ? "Update Structure" : "Create Structure"}
         submitButtonColor="purple"
       />
     </form>
   );
 }
 
-export default DataStructureForm; 
+export default DataStructureForm;

--- a/frontend/src/components/forms/FieldManager.tsx
+++ b/frontend/src/components/forms/FieldManager.tsx
@@ -2,6 +2,7 @@ interface FieldDefinition {
   name: string;
   type: string;
   description: string;
+  required?: boolean;
   parser_id?: number;
   list_item_type?: string;
   list_item_parser_id?: number;
@@ -11,32 +12,38 @@ interface FieldDefinition {
 interface FieldManagerProps {
   fields: FieldDefinition[];
   onChange: (fields: FieldDefinition[]) => void;
-  availableParsers: Array<{value: number, name: string}>;
+  availableParsers: Array<{ value: number; name: string }>;
   maxFields?: number;
 }
 
-function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Readonly<FieldManagerProps>) {
+function FieldManager({
+  fields,
+  onChange,
+  availableParsers,
+  maxFields = 20,
+}: Readonly<FieldManagerProps>) {
   const fieldTypes = [
-    { value: 'str', name: 'String' },
-    { value: 'int', name: 'Integer' },
-    { value: 'float', name: 'Float' },
-    { value: 'bool', name: 'Boolean' },
-    { value: 'date', name: 'Date' },
-    { value: 'dict', name: 'Dictionary (JSON Object)' },
-    { value: 'list', name: 'List' },
-    { value: 'parser', name: 'Parser Reference' }
+    { value: "str", name: "String" },
+    { value: "int", name: "Integer" },
+    { value: "float", name: "Float" },
+    { value: "bool", name: "Boolean" },
+    { value: "date", name: "Date" },
+    { value: "dict", name: "Dictionary (JSON Object)" },
+    { value: "list", name: "List" },
+    { value: "parser", name: "Parser Reference" },
   ];
 
   const addField = () => {
     if (fields.length >= maxFields) return;
-    
+
     const newField: FieldDefinition = {
       _key: Math.random().toString(36).slice(2),
-      name: '',
-      type: 'str',
-      description: ''
+      name: "",
+      type: "str",
+      description: "",
+      required: true,
     };
-    
+
     onChange([...fields, newField]);
   };
 
@@ -49,23 +56,23 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
     const newFields = fields.map((field, i) => {
       if (i === index) {
         const updatedField = { ...field, ...updates };
-        
+
         // Clear type-specific fields when type changes
         if (updates.type && updates.type !== field.type) {
-          if (updates.type !== 'parser') {
+          if (updates.type !== "parser") {
             updatedField.parser_id = undefined;
           }
-          if (updates.type !== 'list') {
+          if (updates.type !== "list") {
             updatedField.list_item_type = undefined;
             updatedField.list_item_parser_id = undefined;
           }
         }
-        
+
         return updatedField;
       }
       return field;
     });
-    
+
     onChange(newFields);
   };
 
@@ -75,20 +82,22 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
   };
 
   const getListItemTypes = () => [
-    { value: 'str', name: 'String' },
-    { value: 'int', name: 'Integer' },
-    { value: 'float', name: 'Float' },
-    { value: 'bool', name: 'Boolean' },
-    { value: 'date', name: 'Date' },
-    { value: 'dict', name: 'Dictionary (JSON Object)' },
-    { value: 'parser', name: 'Parser Reference' }
+    { value: "str", name: "String" },
+    { value: "int", name: "Integer" },
+    { value: "float", name: "Float" },
+    { value: "bool", name: "Boolean" },
+    { value: "date", name: "Date" },
+    { value: "dict", name: "Dictionary (JSON Object)" },
+    { value: "parser", name: "Parser Reference" },
   ];
 
   return (
     <div className="space-y-4">
       {/* Header */}
       <div className="flex justify-between items-center">
-        <h3 className="text-lg font-medium text-gray-900">Fields ({fields.length}/{maxFields})</h3>
+        <h3 className="text-lg font-medium text-gray-900">
+          Fields ({fields.length}/{maxFields})
+        </h3>
         <button
           type="button"
           onClick={addField}
@@ -126,11 +135,13 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
                     <input
                       type="text"
                       value={field.name}
-                      onChange={(e) => updateField(index, { name: e.target.value })}
+                      onChange={(e) =>
+                        updateField(index, { name: e.target.value })
+                      }
                       className={`w-full px-3 py-2 border rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                        field.name && !validateFieldName(field.name) 
-                          ? 'border-red-300 bg-red-50' 
-                          : 'border-gray-300'
+                        field.name && !validateFieldName(field.name)
+                          ? "border-red-300 bg-red-50"
+                          : "border-gray-300"
                       }`}
                       placeholder="field_name"
                     />
@@ -140,13 +151,15 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
                       </p>
                     )}
                   </td>
-                  
+
                   <td className="px-6 py-4 align-top">
                     <div className="space-y-3">
                       {/* Main Type Selector */}
                       <select
                         value={field.type}
-                        onChange={(e) => updateField(index, { type: e.target.value })}
+                        onChange={(e) =>
+                          updateField(index, { type: e.target.value })
+                        }
                         className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                       >
                         {fieldTypes.map((type) => (
@@ -155,17 +168,39 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
                           </option>
                         ))}
                       </select>
-                      
+
+                      <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200">
+                        <input
+                          type="checkbox"
+                          checked={field.required !== false}
+                          onChange={(event) =>
+                            updateField(index, {
+                              required: event.target.checked,
+                            })
+                          }
+                          className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                        />
+                        <span>Required</span>
+                      </label>
+
                       {/* Parser Reference Selector */}
-                      {field.type === 'parser' && (
+                      {field.type === "parser" && (
                         <div>
-                          <label htmlFor={`parser_ref_${index}`} className="block text-xs font-medium text-gray-700 mb-1">
+                          <label
+                            htmlFor={`parser_ref_${index}`}
+                            className="block text-xs font-medium text-gray-700 mb-1"
+                          >
                             Reference Parser:
                           </label>
                           <select
                             id={`parser_ref_${index}`}
-                            value={field.parser_id || ''}
-                            onChange={(e) => updateField(index, { parser_id: Number.parseInt(e.target.value) || undefined })}
+                            value={field.parser_id || ""}
+                            onChange={(e) =>
+                              updateField(index, {
+                                parser_id:
+                                  Number.parseInt(e.target.value) || undefined,
+                              })
+                            }
                             className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                           >
                             <option value="">Select parser...</option>
@@ -177,17 +212,24 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
                           </select>
                         </div>
                       )}
-                      
+
                       {/* List Type Selectors */}
-                      {field.type === 'list' && (
+                      {field.type === "list" && (
                         <div className="space-y-2">
-                          <label htmlFor={`list_item_type_${index}`} className="block text-xs font-medium text-gray-700 mb-1">
+                          <label
+                            htmlFor={`list_item_type_${index}`}
+                            className="block text-xs font-medium text-gray-700 mb-1"
+                          >
                             List Item Type:
                           </label>
                           <select
                             id={`list_item_type_${index}`}
-                            value={field.list_item_type || 'str'}
-                            onChange={(e) => updateField(index, { list_item_type: e.target.value })}
+                            value={field.list_item_type || "str"}
+                            onChange={(e) =>
+                              updateField(index, {
+                                list_item_type: e.target.value,
+                              })
+                            }
                             className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                           >
                             {getListItemTypes().map((type) => (
@@ -196,21 +238,33 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
                               </option>
                             ))}
                           </select>
-                          
-                          {field.list_item_type === 'parser' && (
+
+                          {field.list_item_type === "parser" && (
                             <div>
-                              <label htmlFor={`list_item_parser_${index}`} className="block text-xs font-medium text-gray-700 mb-1">
+                              <label
+                                htmlFor={`list_item_parser_${index}`}
+                                className="block text-xs font-medium text-gray-700 mb-1"
+                              >
                                 List Item Parser:
                               </label>
                               <select
                                 id={`list_item_parser_${index}`}
-                                value={field.list_item_parser_id || ''}
-                                onChange={(e) => updateField(index, { list_item_parser_id: Number.parseInt(e.target.value) || undefined })}
+                                value={field.list_item_parser_id || ""}
+                                onChange={(e) =>
+                                  updateField(index, {
+                                    list_item_parser_id:
+                                      Number.parseInt(e.target.value) ||
+                                      undefined,
+                                  })
+                                }
                                 className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                               >
                                 <option value="">Select parser...</option>
                                 {availableParsers.map((parser) => (
-                                  <option key={parser.value} value={parser.value}>
+                                  <option
+                                    key={parser.value}
+                                    value={parser.value}
+                                  >
                                     {parser.name}
                                   </option>
                                 ))}
@@ -221,17 +275,19 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
                       )}
                     </div>
                   </td>
-                  
+
                   <td className="px-6 py-4 align-top">
                     <textarea
                       value={field.description}
-                      onChange={(e) => updateField(index, { description: e.target.value })}
+                      onChange={(e) =>
+                        updateField(index, { description: e.target.value })
+                      }
                       rows={3}
                       className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
                       placeholder="Describe this field..."
                     />
                   </td>
-                  
+
                   <td className="px-6 py-4 align-top">
                     <button
                       type="button"
@@ -239,8 +295,18 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
                       className="text-red-600 hover:text-red-900 transition-colors p-2"
                       title="Remove field"
                     >
-                      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+                      <svg
+                        className="w-5 h-5"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="2"
+                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                        ></path>
                       </svg>
                     </button>
                   </td>
@@ -264,19 +330,36 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
 
       {/* Field Types Help */}
       <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-        <h4 className="text-sm font-medium text-blue-800 mb-2">Field Types Reference</h4>
+        <h4 className="text-sm font-medium text-blue-800 mb-2">
+          Field Types Reference
+        </h4>
         <div className="text-xs text-blue-700 space-y-1">
-          <p><strong>String:</strong> Text data (e.g., "hello world")</p>
-          <p><strong>Integer:</strong> Whole numbers (e.g., 42)</p>
-          <p><strong>Float:</strong> Decimal numbers (e.g., 3.14)</p>
-          <p><strong>Boolean:</strong> True/False values</p>
-          <p><strong>Date:</strong> Date values (e.g., 2024-01-15)</p>
-          <p><strong>List:</strong> Array of items with specified type</p>
-          <p><strong>Parser Reference:</strong> Reference to another data structure</p>
+          <p>
+            <strong>String:</strong> Text data (e.g., "hello world")
+          </p>
+          <p>
+            <strong>Integer:</strong> Whole numbers (e.g., 42)
+          </p>
+          <p>
+            <strong>Float:</strong> Decimal numbers (e.g., 3.14)
+          </p>
+          <p>
+            <strong>Boolean:</strong> True/False values
+          </p>
+          <p>
+            <strong>Date:</strong> Date values (e.g., 2024-01-15)
+          </p>
+          <p>
+            <strong>List:</strong> Array of items with specified type
+          </p>
+          <p>
+            <strong>Parser Reference:</strong> Reference to another data
+            structure
+          </p>
         </div>
       </div>
     </div>
   );
 }
 
-export default FieldManager; 
+export default FieldManager;

--- a/tests/integration/export_import/test_output_parser_export_import_integration.py
+++ b/tests/integration/export_import/test_output_parser_export_import_integration.py
@@ -146,6 +146,7 @@ class TestOutputParserExportIntegration:
         assert "username" in field_names
         assert "age" in field_names
         assert "email" in field_names
+        assert all(field.required for field in export_data.output_parser.fields)
 
     def test_export_parser_not_found(self, db_session: Session, test_app: App):
         """Test export with non-existent parser ID."""
@@ -272,7 +273,8 @@ class TestOutputParserImportIntegration:
                     {
                         "name": "field1",
                         "type": "str",
-                        "description": "First field"
+                        "description": "First field",
+                        "required": False,
                     },
                     {
                         "name": "field2",
@@ -304,7 +306,9 @@ class TestOutputParserImportIntegration:
         assert imported_parser.description == export_data.output_parser.description
         assert len(imported_parser.fields) == 2
         assert imported_parser.fields[0]["name"] == "field1"
+        assert imported_parser.fields[0]["required"] is False
         assert imported_parser.fields[1]["type"] == "int"
+        assert imported_parser.fields[1]["required"] is True
 
         # Cleanup
         db_session.delete(imported_parser)

--- a/tests/unit/schemas/test_output_parser_export_import_schemas.py
+++ b/tests/unit/schemas/test_output_parser_export_import_schemas.py
@@ -41,6 +41,17 @@ class TestExportOutputParserFieldSchema:
         assert field.description == "User's username"
         assert field.parser_name is None
         assert field.list_item_type is None
+        assert field.required is True
+
+    def test_optional_field_is_preserved(self):
+        field = ExportOutputParserFieldSchema(
+            name="nickname",
+            type="str",
+            description="Optional nickname",
+            required=False,
+        )
+
+        assert field.required is False
 
     def test_field_with_parser_reference(self):
         """Test field with parser reference."""
@@ -238,6 +249,7 @@ class TestOutputParserExportFileSchema:
         assert len(data['output_parser']['fields']) == 2
         assert data['output_parser']['fields'][0]['name'] == "sku"
         assert data['output_parser']['fields'][1]['type'] == "float"
+        assert data['output_parser']['fields'][0]['required'] is True
     
     def test_deserialization_from_json(self):
         """Test deserialization from JSON dict."""


### PR DESCRIPTION
## Summary

- allow Output Parser fields to be marked required or optional in the editor
- preserve field requirement metadata through schemas, services, and export/import handling
- generate output parser schemas that honor optional fields

## Validation

- C:\iaCoreTools\aict-env\Scripts\python.exe -m pytest tests\unit\tools\test_output_parser_tools.py tests\unit\schemas\test_output_parser_export_import_schemas.py -q

Closes #199