### PR TITLE
Add tool function to ocr

### DIFF
--- a/backend/schemas/conversation_schemas.py
+++ b/backend/schemas/conversation_schemas.py
@@ -24,7 +24,7 @@ class ConversationResponse(ConversationBase):
     """Schema for conversation response"""
     conversation_id: int
     agent_id: int
-    app_id: int
+    app_id: Optional[int] = None
     user_id: Optional[int] = None
     session_id: str
     created_at: datetime

--- a/backend/services/agent_execution_service.py
+++ b/backend/services/agent_execution_service.py
@@ -112,6 +112,7 @@ class AgentExecutionService:
                 ctx.session_id_for_cache,
                 ctx.user_context,
                 ctx.image_files,
+                processed_files=ctx.processed_files,
                 working_dir=ctx.working_dir,
             )
 
@@ -975,6 +976,7 @@ class AgentExecutionService:
         session_id_for_cache: str = None,
         user_context: Dict = None,
         image_files: List[Dict] = None,
+        processed_files: List[Dict] = None,
         working_dir: Optional[str] = None
     ) -> Any:
         """Execute agent in FastAPI's event loop using shared checkpointer pool.
@@ -993,7 +995,7 @@ class AgentExecutionService:
         try:
             # Create the agent chain with all tools and capabilities
             agent_chain, mcp_client = await create_agent(
-                fresh_agent, search_params, session_id_for_cache, user_context, working_dir
+                fresh_agent, search_params, session_id_for_cache, user_context, working_dir, attached_files=processed_files
             )
 
             # Prepare configuration

--- a/backend/services/agent_streaming_service.py
+++ b/backend/services/agent_streaming_service.py
@@ -125,6 +125,7 @@ class AgentStreamingService:
                 ctx.session_id_for_cache,
                 ctx.user_context,
                 ctx.working_dir,
+                attached_files=ctx.processed_files
             )
 
             config = prepare_agent_config(ctx.fresh_agent)

--- a/backend/services/ocr_service.py
+++ b/backend/services/ocr_service.py
@@ -1,0 +1,157 @@
+import os
+from typing import Dict, Any
+from sqlalchemy.orm import Session
+
+from models.ocr_agent import OCRAgent
+from tools.PDFTools import extract_text_from_pdf, convert_pdf_to_images, check_pdf_has_text
+from tools.ocrAgentTools import (
+    convert_image_to_base64,
+    extract_text_from_image,
+    format_data_with_text_llm,
+    get_data_from_extracted_text,
+    get_document_data_from_pages
+)
+from tools.aiServiceTools import get_llm
+from tools.outputParserTools import create_model_from_json_schema
+from utils.logger import get_logger
+from utils.config import get_app_config
+
+logger = get_logger(__name__)
+
+class OCRService:
+    """Service for handling OCR agent processing logic"""
+
+    def process_pdf(self, agent: OCRAgent, pdf_path: str, db: Session) -> Dict[str, Any]:
+        """
+        Process PDF using OCR workflow respecting output parser/data structure.
+        This is a synchronous method intended to be run in a thread pool.
+        """
+        try:
+            # Ensure we have the agent with relationships (assuming the caller provided a fresh agent or we reload)
+            # For simplicity in this service, we assume a fresh agent is passed or we use the provided one.
+            # If we need to ensure relationships, we might need to reload from DB.
+
+            # Get output parser if configured
+            pydantic_class = None
+            if agent.output_parser_id:
+                try:
+                    # Using a direct query or repository here would be better, 
+                    # but let's see how it was done in AgentExecutionService.
+                    # We'll need to pass the repository or use SessionLocal.
+                    from repositories.agent_execution_repository import AgentExecutionRepository
+                    repo = AgentExecutionRepository()
+                    output_parser = repo.get_output_parser_by_id(db, agent.output_parser_id)
+
+                    if output_parser and output_parser.fields:
+                        pydantic_class = create_model_from_json_schema(
+                            output_parser.fields,
+                            output_parser.name
+                        )
+                except Exception as e:
+                    logger.warning(f"Failed to load output parser: {str(e)}")
+
+            # Check if PDF has text
+            has_text = check_pdf_has_text(pdf_path)
+
+            if has_text:
+                text_content = extract_text_from_pdf(pdf_path)
+
+                if agent.text_system_prompt and agent.service_id and pydantic_class:
+                    try:
+                        text_model = get_llm(agent, is_vision=False)
+                        if text_model:
+                            structured_data = get_data_from_extracted_text(
+                                text_content,
+                                text_model,
+                                pydantic_class,
+                                agent.text_system_prompt,
+                                text_content,
+                                os.path.basename(pdf_path)
+                            )
+                            return {
+                                "method": "text_extraction_with_llm",
+                                "content": structured_data,
+                                "extracted_text": text_content,
+                                "confidence": 0.9
+                            }
+                    except Exception as e:
+                        logger.error(f"Error processing with LLM and output parser: {str(e)}", exc_info=True)
+
+                return {
+                    "method": "text_extraction",
+                    "content": text_content,
+                    "extracted_text": text_content,
+                    "confidence": 0.9
+                }
+            else:
+                app_config = get_app_config()
+                images_dir = app_config['IMAGES_PATH']
+                os.makedirs(images_dir, exist_ok=True)
+
+                image_paths = convert_pdf_to_images(pdf_path, images_dir)
+
+                vision_results = []
+                for i, image_path in enumerate(image_paths):
+                    try:
+                        base64_image = convert_image_to_base64(image_path)
+                        vision_model = get_llm(agent, is_vision=True)
+                        if not vision_model:
+                            raise ValueError("Vision model not found")
+
+                        vision_result = extract_text_from_image(
+                            base64_image, 
+                            agent.vision_system_prompt, 
+                            vision_model, 
+                            f"Page {i+1}"
+                        )
+                        vision_results.append({
+                            "page": i + 1,
+                            "extracted_text": vision_result
+                        })
+
+                        try:
+                            os.remove(image_path)
+                        except OSError:
+                            pass
+                    except Exception as e:
+                        logger.warning(f"Error processing image {i+1}: {str(e)}")
+                        continue
+
+                if agent.text_system_prompt and agent.service_id and vision_results:
+                    try:
+                        text_model = get_llm(agent, is_vision=False)
+                        if text_model:
+                            formatted_result = format_data_with_text_llm(
+                                vision_results, 
+                                text_model, 
+                                pydantic_class, 
+                                agent.text_system_prompt, 
+                                "", 
+                                os.path.basename(pdf_path)
+                            )
+                            final_result = get_document_data_from_pages(
+                                agent.text_system_prompt,
+                                formatted_result,
+                                pydantic_class,
+                                text_model,
+                                "",
+                                os.path.basename(pdf_path)
+                            )
+                            return {
+                                "method": "vision_and_text",
+                                "content": final_result,
+                                "extracted_text": vision_results,
+                                "confidence": 0.8
+                            }
+                    except Exception as e:
+                        logger.warning(f"Error processing with text model: {str(e)}")
+
+                return {
+                    "method": "vision_only",
+                    "content": vision_results,
+                    "extracted_text": vision_results,
+                    "confidence": 0.7
+                }
+        except Exception as e:
+            logger.error(f"Error in OCRService.process_pdf: {str(e)}")
+            raise

--- a/backend/tools/agentTools.py
+++ b/backend/tools/agentTools.py
@@ -113,7 +113,7 @@ class MCPClientManager:
         if self._client is not None:
             self._client = None
 
-async def create_agent(agent: Agent, search_params=None, session_id=None, user_context: Optional[Dict] = None, working_dir: Optional[str] = None):
+async def create_agent(agent: Agent, search_params=None, session_id=None, user_context: Optional[Dict] = None, working_dir: Optional[str] = None, attached_files: Optional[List[Dict]] = None):
     """Create a new agent instance with cached checkpointer if memory is enabled.
     
     Args:
@@ -121,6 +121,7 @@ async def create_agent(agent: Agent, search_params=None, session_id=None, user_c
         search_params: Optional search parameters for silo-based retrieval
         session_id: Optional session ID for memory-enabled agents (used to cache checkpointer)
         user_context: Optional user context containing authentication tokens for MCP
+        attached_files: Optional list of attached files to pass to the agent chain
     """
     llm = get_llm(agent)
     if llm is None:
@@ -232,7 +233,7 @@ async def create_agent(agent: Agent, search_params=None, session_id=None, user_c
 
     for tool in agent.tool_associations:
         sub_agent = tool.tool
-        tools.append(await discover_tool(sub_agent, user_context=user_context))
+        tools.append(await discover_tool(sub_agent, user_context=user_context, attached_files=attached_files))
 
     # Base tools — always available for every agent
     if working_dir:
@@ -519,25 +520,6 @@ class AgentToolInput(BaseModel):
     query: str = Field(description="The question or instruction to send to the sub-agent.")
 
 
-class AgentOCRToolInput(BaseModel):
-    """Input schema for an OCR agent-as-tool.
-
-    Extends the standard agent tool schema with an optional ``file_paths``
-    parameter so the caller can provide one or more PDF files for
-    optical-character-recognition processing.  When no files are given the
-    OCR tool falls back to a plain-text chat response.
-    """
-
-    query: str = Field(description="The question or instruction to send to the OCR sub-agent.")
-    file_paths: Optional[List[str]] = Field(
-        default=None,
-        description=(
-            "Optional list of file paths or base64-encoded PDF binary data to process. "
-            "Only PDF files are supported. If omitted, the tool returns a text-only response."
-        ),
-    )
-
-
 class IACTTool(BaseTool):
     name: str = "agent_tool"
     description: str = "Search for a repository"
@@ -547,12 +529,14 @@ class IACTTool(BaseTool):
     react_agent: Any = None
     mcp_client: Any = None
     llm: Any = None
+    attached_files: Optional[List[Dict]] = None
 
-    def __init__(self, agent: Agent, user_context: Optional[Dict] = None) -> None:
+    def __init__(self, agent: Agent, user_context: Optional[Dict] = None, attached_files: Optional[List[Dict]] = None) -> None:
         super().__init__(agent=agent, user_context=user_context)
 
         self.agent = agent
         self.user_context = user_context
+        self.attached_files = attached_files or []
         self.name = sanitize_identifier(agent.name)
         self.description = agent.description or "Agent tool"
         self.llm = get_llm(agent)
@@ -562,20 +546,20 @@ class IACTTool(BaseTool):
         self.mcp_client = None
 
     @classmethod
-    async def create(cls, agent: Agent, user_context: Optional[Dict] = None) -> "IACTTool":
+    async def create(cls, agent: Agent, user_context: Optional[Dict] = None, attached_files: Optional[List[Dict]] = None) -> "IACTTool":
         """Build an agent-as-tool, including the sub-agent's MCP tools.
 
         MCP tools are loaded with an awaited MultiServerMCPClient, which is not
         possible inside a synchronous ``__init__``; hence this async factory. It
         is the only supported way to obtain a ready-to-use ``IACTTool``.
         """
-        instance = cls(agent, user_context=user_context)
+        instance = cls(agent, user_context=user_context, attached_files=attached_files)
 
         tools = []
         # Add nested tool agents recursively
         for t in agent.tool_associations:
             sub_agent = t.tool
-            tools.append(await discover_tool(sub_agent, user_context=user_context))
+            tools.append(await discover_tool(sub_agent, user_context=user_context, attached_files=attached_files))
 
         # Add base useful tools
         tools.append(fetch_file_in_base64)
@@ -759,129 +743,24 @@ async def _execute_tool_agent_ocr(
     finally:
         db.close()
 
-
-def _resolve_file(file_spec: str) -> str:
-    """Resolve *file_spec* to an absolute filesystem path.
-
-    Handles three cases:
-
-    1. **Absolute path that exists** → returned as-is
-    2. **Relative path or bare filename under ``tmp_base_folder/``** → appended
-    3. **Bare filename** → searched recursively under ephemeral & persistent
-       session directories (same layout used by :class:`FileManagementService`)
-
-    Returns the absolute path to the resolved file.
-
-    Raises ``FileNotFoundError`` when the file cannot be found.
-    """
-    import pathlib
-
-    tmp_base = get_app_config()["TMP_BASE_FOLDER"]
-    fs = pathlib.Path(file_spec)
-    abs_fs = fs.resolve()
-
-    if abs_fs.is_file():
-        return str(abs_fs)
-
-    relative = fs.relative_to(tmp_base) if str(abs_fs).startswith(str(tmp_base)) else fs
-    joined = pathlib.Path(tmp_base, relative)
-    if joined.is_file():
-        return str(joined.resolve())
-
-    # Bare filename — search the same directory tree that FileManagementService
-    # uses (ephemeral/ and persistent/ directories under tmp_base).
-    tmp_path = pathlib.Path(tmp_base).resolve()
-    name = fs.name
-    for root_dir in (tmp_path / "ephemeral", tmp_path / "persistent"):
-        if not root_dir.is_dir():
-            continue
-        for p in root_dir.rglob(name):
-            if p.is_file():
-                return str(p.resolve())
-
-    raise FileNotFoundError(f"File not found: {file_spec}")
-
-
-async def _validate_and_save_pdf(file_spec: str, tmp_dir: str) -> str:
-    """Validate file_spec is a PDF and save it to tmp_dir.
-
-    * Supports **absolute paths** (read directly).
-    * Supports **relative paths** or **bare filenames** that exist under
-      ``TMP_BASE_FOLDER`` (resolved via :func:`_resolve_file`).
-    * If it starts with ``base64:`` it is decoded and saved as a ``.pdf`` file.
-
-    Returns the path to the saved PDF.
-    """
-    # Early rejection of known non-PDF extensions.
-    # Bare filenames (e.g. "image.pdf") are allowed through; they are resolved
-    # later by _resolve_file().
-    known_non_pdf_ext = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".txt",
-                         ".md", ".json", ".csv", ".html", ".htm", ".xml", ".doc",
-                         ".docx", ".xls", ".xlsx", ".zip", ".rar", ".7z"}
-    _, ext = os.path.splitext(file_spec)
-    if ext.lower() in known_non_pdf_ext:
-        raise ValueError(
-            f"Only PDF files are supported. Received: {file_spec}"
-        )
-
-    if file_spec.startswith("base64:"):
-        b64_data = file_spec[len("base64:"):]
-        content = base64.b64decode(b64_data)
-        suffix = ".pdf"
-    elif file_spec.lower().endswith(".pdf"):
-        content = None  # will be read directly from disk later
-        suffix = ".pdf"
-    else:
-        # Bare filename — defer resolution; _resolve_file will search
-        # ephemeral/persistent dirs.
-        content = None
-        suffix = ".pdf"
-
-    import tempfile
-    fd, path = tempfile.mkstemp(suffix=suffix, dir=tmp_dir)
-    try:
-        if content is not None:
-            os.write(fd, content)
-        else:
-            try:
-                actual_path = _resolve_file(file_spec)
-            except FileNotFoundError:
-                os.close(fd)
-                raise ValueError(
-                    f"File '{file_spec}' not found. Make sure the file has been uploaded to this conversation before referencing it in the OCR tool."
-                )
-            with open(actual_path, "rb") as src:
-                os.write(fd, src.read())
-    finally:
-        os.close(fd)
-
-    # Final validation: check the file actually looks like a PDF
-    with open(path, "rb") as f:
-        header = f.read(5)
-    if header != b"%PDF-":
-        os.remove(path)
-        raise ValueError(
-            f"Only PDF files are supported. File '{file_spec}' is not a valid PDF."
-        )
-    return path
+        if upload is not None:
+            upload.file.close()
 
 
 class IACTOCRTool(BaseTool):
-    """Tool wrapper for an OCR agent that processes PDF files.
+    """
+    Tool wrapper for OCR agents.
 
-    Accepts a ``query`` plus an optional ``file_paths`` list. Each entry in
-    ``file_paths`` may be:
+    PDF documents are discovered automatically from
+    self.attached_files.
 
-    * A file system path ending in ``.pdf``.
-    * A base64-encoded PDF string prefixed with ``base64:``.
-
-    When no files are given the tool falls back to a plain-text chat
-    response using the agent's own LLM (non-vision path).
+    When one or more PDFs are attached, OCR processing is executed.
+    Otherwise the tool falls back to normal chat behaviour.
     """
 
     name: str = "ocr_agent_tool"
     description: str = "OCR agent tool for extracting text from PDF documents"
-    args_schema: Type[BaseModel] = AgentOCRToolInput
+    args_schema: Type[BaseModel] = AgentToolInput
     agent: Agent
     user_context: Optional[Dict] = None
     react_agent: Any = None
@@ -893,15 +772,18 @@ class IACTOCRTool(BaseTool):
     memory_summarize_threshold: int = DEFAULT_MEMORY_SUMMARIZE_THRESHOLD
     output_parser_id: Optional[int] = None
     temperature: float = DEFAULT_AGENT_TEMPERATURE
+    attached_files: Optional[List[Dict]] = None
 
     def __init__(
         self,
         agent: Agent,
         user_context: Optional[Dict] = None,
+        attached_files: Optional[List[Dict]] = None,
     ) -> None:
         super().__init__(agent=agent, user_context=user_context)
         self.agent = agent
         self.user_context = user_context
+        self.attached_files = attached_files or []
         self.name = sanitize_identifier(agent.name)
         self.description = agent.description or "OCR agent tool"
         try:
@@ -930,6 +812,7 @@ class IACTOCRTool(BaseTool):
         cls,
         agent: Agent,
         user_context: Optional[Dict] = None,
+        attached_files: Optional[List[Dict]] = None,
     ) -> "IACTOCRTool":
         """Build an OCR agent-as-tool with MCP support.
 
@@ -937,15 +820,14 @@ class IACTOCRTool(BaseTool):
         and tools.  A failing MCP server degrades the sub-agent but never
         breaks construction.
         """
-        instance = cls(agent, user_context=user_context)
+        instance = cls(agent, user_context=user_context, attached_files=attached_files)
 
         tools: list = [fetch_file_in_base64]
 
         # Nested tool agents — only recurse into non-OCR agents, because
-        # OCR agents should not be nested inside other agents as tools.
         for t in agent.tool_associations:
             sub_agent = t.tool
-            nested = await discover_tool(sub_agent, user_context=user_context)
+            nested = await discover_tool(sub_agent, user_context=user_context, attached_files=attached_files)
             tools.append(nested)
 
         # MCP tools
@@ -983,12 +865,12 @@ class IACTOCRTool(BaseTool):
         )
         return instance
 
-    def _run(self, query: str, file_paths: Optional[List[str]] = None, **kwargs: Any) -> str:
+    def _run(self, query: str, **kwargs: Any) -> str:
         """Synchronous execution of the OCR agent tool."""
         loop = asyncio.new_event_loop()
         try:
             return loop.run_until_complete(
-                self._arun(query=query, file_paths=file_paths)
+                self._arun(query=query)
             )
         finally:
             loop.close()
@@ -996,92 +878,101 @@ class IACTOCRTool(BaseTool):
     async def _arun(
         self,
         query: str,
-        file_paths: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> str:
         """Asynchronous execution of the OCR agent tool."""
+
         if self.react_agent is None:
             raise RuntimeError(
                 "IACTOCRTool must be built via 'await IACTOCRTool.create(...)' before use."
             )
 
-        tmp_base_folder = get_app_config()["TMP_BASE_FOLDER"]
-        uploads_dir = os.path.join(tmp_base_folder, "uploads")
-        os.makedirs(uploads_dir, exist_ok=True)
+        pdf_files = [
+            f for f in self.attached_files
+            if f.get("type") == "pdf"
+        ]
 
-        processed_pdfs: List[str] = []
+        #
+        # OCR PATH
+        #
+        if pdf_files:
 
-        if file_paths:
-            for fspec in file_paths:
+            results = []
+
+            for pdf_file in pdf_files:
+
+                pdf_path = pdf_file.get("file_path")
+                filename = pdf_file.get("filename", "unknown.pdf")
+
+                if not pdf_path:
+                    results.append({
+                        "file": filename,
+                        "error": "PDF file path not found"
+                    })
+                    continue
+
+                if not os.path.isabs(pdf_path):
+                    pdf_path = os.path.join(
+                        get_app_config()["TMP_BASE_FOLDER"],
+                        pdf_path
+                    )
+
+                if not os.path.exists(pdf_path):
+                    results.append({
+                        "file": filename,
+                        "error": f"PDF file not found: {pdf_path}"
+                    })
+                    continue
+
                 try:
-                    pdf_path = await _validate_and_save_pdf(fspec, uploads_dir)
-                    processed_pdfs.append(pdf_path)
-                except ValueError as exc:
-                    return f"Error: {exc}"
+
+                    ocr_result = await _execute_tool_agent_ocr(
+                        agent_id=self.agent.agent_id,
+                        pdf_path=pdf_path,
+                        user_context=self.user_context,
+                    )
+
+                    results.append({
+                        "file": filename,
+                        "content": (
+                            ocr_result.get("content")
+                            if isinstance(ocr_result, dict)
+                            else ocr_result
+                        )
+                    })
+
                 except Exception as exc:
-                    logger.error("Error preparing PDF for OCR tool: %s", exc, exc_info=True)
-                    return f"Error processing file: {exc}"
 
-        if processed_pdfs:
-            # Combine all PDFs into a single file for the OCR pipeline
-            if len(processed_pdfs) > 1:
-                try:
-                    combined_path = os.path.join(uploads_dir, f"combined_{self.agent.agent_id}_{id(self)}.pdf")
-                    from pypdf import PdfReader, PdfWriter
-                    writer = PdfWriter()
-                    for pdf_path in processed_pdfs:
-                        reader = PdfReader(pdf_path)
-                        for page in reader.pages:
-                            writer.add_page(page)
-                    with open(combined_path, "wb") as f:
-                        writer.write(f)
-                    pdf_path_to_process = combined_path
-                except Exception as exc:
-                    logger.error("Error combining PDFs for OCR tool: %s", exc, exc_info=True)
-                    for p in processed_pdfs:
-                        if os.path.exists(p):
-                            os.remove(p)
-                    return f"Error combining PDFs: {exc}"
-            else:
-                pdf_path_to_process = processed_pdfs[0]
+                    logger.exception(
+                        "OCR failed for %s",
+                        filename
+                    )
 
-            try:
-                ocr_result = await _execute_tool_agent_ocr(
-                    agent_id=self.agent.agent_id,
-                    pdf_path=pdf_path_to_process,
-                    user_context=self.user_context,
-                )
+                    results.append({
+                        "file": filename,
+                        "error": str(exc)
+                    })
 
-                if isinstance(ocr_result, dict):
-                    content = ocr_result.get("content", ocr_result)
-                elif isinstance(ocr_result, list):
-                    content = ocr_result
-                else:
-                    content = str(ocr_result)
+            return json.dumps(
+                results,
+                indent=2,
+                ensure_ascii=False,
+                default=str,
+            )
 
-                if isinstance(content, (dict, list)):
-                    import json
-                    return json.dumps(content, indent=2, ensure_ascii=False)
-                return str(content)
-            except Exception as exc:
-                logger.error("OCR execution failed for tool: %s", exc, exc_info=True)
-                return f"Error executing OCR: {exc}"
-            finally:
-                for p in processed_pdfs:
-                    if os.path.exists(p):
-                        os.remove(p)
-                # Remove combined file if it exists
-                if len(processed_pdfs) > 1 and "combined_path" in dir():
-                    if os.path.exists(combined_path):
-                        os.remove(combined_path)
-
-        # No PDFs — fall back to plain-text chat using the sub-agent's LLM
+        #
+        # CHAT FALLBACK PATH
+        #
         if self.agent.prompt_template:
             try:
-                formatted_prompt = self.agent.prompt_template.format(question=query)
+                formatted_prompt = self.agent.prompt_template.format(
+                    question=query
+                )
             except KeyError:
                 try:
-                    formatted_prompt = self.agent.prompt_template.format(query=query)
+                    formatted_prompt = self.agent.prompt_template.format(
+                        query=query
+                    )
                 except KeyError:
                     logger.warning(
                         "Could not format prompt_template for OCR agent %s, using query directly",
@@ -1091,28 +982,49 @@ class IACTOCRTool(BaseTool):
         else:
             formatted_prompt = query
 
-        messages = [HumanMessage(content=formatted_prompt)]
+        messages = [
+            HumanMessage(content=formatted_prompt)
+        ]
+
         try:
-            result = self.react_agent.invoke({"messages": messages})
+
+            result = await self.react_agent.ainvoke(
+                {"messages": messages}
+            )
 
             if isinstance(result, dict) and "messages" in result:
+
                 messages_list = result["messages"]
+
                 for msg in reversed(messages_list):
                     if hasattr(msg, "content") and msg.content:
                         return str(msg.content)
+
                 if messages_list:
                     last_msg = messages_list[-1]
-                    return str(last_msg.content) if hasattr(last_msg, "content") else str(last_msg)
+
+                    return (
+                        str(last_msg.content)
+                        if hasattr(last_msg, "content")
+                        else str(last_msg)
+                    )
 
             return str(result)
+
         except Exception as e:
-            logger.error("Error executing OCR chat fallback: %s", e)
+
+            logger.error(
+                "Error executing OCR chat fallback: %s",
+                e,
+            )
+
             return f"Error executing agent tool: {str(e)}"
 
 
 async def discover_tool(
     agent: Agent,
     user_context: Optional[Dict] = None,
+    attached_files: Optional[List[Dict]] = None,
 ) -> BaseTool:
     """Return the appropriate tool wrapper for *agent*.
 
@@ -1120,8 +1032,8 @@ async def discover_tool(
     (``type == 'ocr_agent'``), otherwise to :class:`IACTTool`.
     """
     if agent.type == "ocr_agent":
-        return await IACTOCRTool.create(agent, user_context=user_context)
-    return await IACTTool.create(agent, user_context=user_context)
+        return await IACTOCRTool.create(agent, user_context=user_context, attached_files=attached_files)
+    return await IACTTool.create(agent, user_context=user_context, attached_files=attached_files)
 
 
 _SEARCH_ERROR_MSG = "The knowledge base search failed; try rephrasing or removing filters."

--- a/backend/tools/agentTools.py
+++ b/backend/tools/agentTools.py
@@ -1051,8 +1051,15 @@ class IACTOCRTool(BaseTool):
                     pdf_path=pdf_path_to_process,
                     user_context=self.user_context,
                 )
-                content = ocr_result.get("content", ocr_result)
-                if isinstance(content, dict):
+
+                if isinstance(ocr_result, dict):
+                    content = ocr_result.get("content", ocr_result)
+                elif isinstance(ocr_result, list):
+                    content = ocr_result
+                else:
+                    content = str(ocr_result)
+
+                if isinstance(content, (dict, list)):
                     import json
                     return json.dumps(content, indent=2, ensure_ascii=False)
                 return str(content)

--- a/backend/tools/agentTools.py
+++ b/backend/tools/agentTools.py
@@ -2,7 +2,7 @@ from langchain.messages import HumanMessage, SystemMessage, AnyMessage
 from langchain.agents import create_agent as create_langchain_agent, AgentState
 from langchain.agents.middleware import SummarizationMiddleware
 from utils.schema_utils import sanitize_identifier, ensure_json_schema_types
-from models.agent import Agent
+from models.agent import Agent, DEFAULT_AGENT_TEMPERATURE, DEFAULT_MEMORY_SUMMARIZE_THRESHOLD
 from models.silo import Silo
 from langchain.tools import BaseTool, tool
 from tools.outputParserTools import get_parser_model_by_id
@@ -25,6 +25,7 @@ import base64
 import mimetypes
 from datetime import datetime
 from utils.logger import get_logger
+from utils.config import get_app_config
 from utils.mcp_auth_utils import prepare_mcp_headers, get_user_token_from_context
 from utils.mcp_ssl_utils import inject_ssl_config
 from tools.skill_tools import create_skill_loader_tool, generate_skills_system_prompt_section
@@ -231,7 +232,7 @@ async def create_agent(agent: Agent, search_params=None, session_id=None, user_c
 
     for tool in agent.tool_associations:
         sub_agent = tool.tool
-        tools.append(await IACTTool.create(sub_agent, user_context=user_context))
+        tools.append(await discover_tool(sub_agent, user_context=user_context))
 
     # Base tools — always available for every agent
     if working_dir:
@@ -518,6 +519,25 @@ class AgentToolInput(BaseModel):
     query: str = Field(description="The question or instruction to send to the sub-agent.")
 
 
+class AgentOCRToolInput(BaseModel):
+    """Input schema for an OCR agent-as-tool.
+
+    Extends the standard agent tool schema with an optional ``file_paths``
+    parameter so the caller can provide one or more PDF files for
+    optical-character-recognition processing.  When no files are given the
+    OCR tool falls back to a plain-text chat response.
+    """
+
+    query: str = Field(description="The question or instruction to send to the OCR sub-agent.")
+    file_paths: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Optional list of file paths or base64-encoded PDF binary data to process. "
+            "Only PDF files are supported. If omitted, the tool returns a text-only response."
+        ),
+    )
+
+
 class IACTTool(BaseTool):
     name: str = "agent_tool"
     description: str = "Search for a repository"
@@ -553,9 +573,9 @@ class IACTTool(BaseTool):
 
         tools = []
         # Add nested tool agents recursively
-        for tool in agent.tool_associations:
-            sub_agent = tool.tool
-            tools.append(await IACTTool.create(sub_agent, user_context=user_context))
+        for t in agent.tool_associations:
+            sub_agent = t.tool
+            tools.append(await discover_tool(sub_agent, user_context=user_context))
 
         # Add base useful tools
         tools.append(fetch_file_in_base64)
@@ -699,6 +719,341 @@ class IACTTool(BaseTool):
         except Exception as e:
             logger.error(f"Error executing agent tool {self.name} (async): {str(e)}")
             return f"Error executing agent tool: {str(e)}"
+
+
+async def _execute_tool_agent_ocr(
+    agent_id: int,
+    pdf_path: str,
+    user_context: Dict,
+) -> Dict[str, Any]:
+    """Delegate to AgentExecutionService.execute_agent_ocr synchronously."""
+    from sqlalchemy.orm import Session
+    from db.database import SessionLocal
+    from services.agent_execution_service import AgentExecutionService
+    from fastapi import UploadFile as FastAPIUploadFile
+
+    db: Session = SessionLocal()
+    try:
+        # Wrap pdf_path in an in-memory UploadFile so we can reuse
+        # AgentExecutionService.execute_agent_ocr without duplicating OCR logic.
+        class _PathUploadFile(FastAPIUploadFile):
+            """Thin UploadFile wrapper backed by a file path."""
+            _file: Any = None
+
+            def __init__(self, file_path: str) -> None:
+                super().__init__(
+                    filename=os.path.basename(file_path),
+                    file=open(file_path, "rb"),
+                )
+                self._file = self.file  # keep reference alive
+
+        upload = _PathUploadFile(pdf_path)
+        exec_svc = AgentExecutionService()
+        return await exec_svc.execute_agent_ocr(
+            agent_id=agent_id,
+            pdf_file=upload,
+            user_context=user_context,
+            for_api=True,
+            db=db,
+        )
+    finally:
+        db.close()
+
+
+async def _validate_and_save_pdf(file_spec: str, tmp_dir: str) -> str:
+    """Validate file_spec is a PDF and save it to tmp_dir.
+
+    * If it looks like a file path that ends with ``.pdf`` it is validated as-is.
+    * If it starts with ``base64:`` it is decoded and saved as a ``.pdf`` file.
+    * Anything else raises ValueError.
+
+    Returns the path to the saved PDF.
+    """
+    if file_spec.startswith("base64:"):
+        b64_data = file_spec[len("base64:"):]
+        content = base64.b64decode(b64_data)
+        suffix = ".pdf"
+    elif file_spec.lower().endswith(".pdf"):
+        content = None  # will be read directly from disk later
+        suffix = ".pdf" if file_spec.lower().endswith(".pdf") else ""
+    else:
+        raise ValueError(
+            f"Only PDF files are supported. Received: {file_spec}"
+        )
+
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=suffix, dir=tmp_dir)
+    try:
+        if content is not None:
+            os.write(fd, content)
+        else:
+            # Read from the source path and write to the temp file
+            with open(file_spec, "rb") as src:
+                os.write(fd, src.read())
+    finally:
+        os.close(fd)
+
+    # Final validation: check the file actually looks like a PDF
+    with open(path, "rb") as f:
+        header = f.read(5)
+    if header != b"%PDF-":
+        os.remove(path)
+        raise ValueError(
+            f"Only PDF files are supported. File '{file_spec}' is not a valid PDF."
+        )
+    return path
+
+
+class IACTOCRTool(BaseTool):
+    """Tool wrapper for an OCR agent that processes PDF files.
+
+    Accepts a ``query`` plus an optional ``file_paths`` list. Each entry in
+    ``file_paths`` may be:
+
+    * A file system path ending in ``.pdf``.
+    * A base64-encoded PDF string prefixed with ``base64:``.
+
+    When no files are given the tool falls back to a plain-text chat
+    response using the agent's own LLM (non-vision path).
+    """
+
+    name: str = "ocr_agent_tool"
+    description: str = "OCR agent tool for extracting text from PDF documents"
+    args_schema: Type[BaseModel] = AgentOCRToolInput
+    agent: Agent
+    user_context: Optional[Dict] = None
+    react_agent: Any = None
+    mcp_client: Any = None
+    llm: Any = None
+    has_memory: bool = False
+    memory_max_messages: int = 20
+    memory_max_tokens: int = 4000
+    memory_summarize_threshold: int = DEFAULT_MEMORY_SUMMARIZE_THRESHOLD
+    output_parser_id: Optional[int] = None
+    temperature: float = DEFAULT_AGENT_TEMPERATURE
+
+    def __init__(
+        self,
+        agent: Agent,
+        user_context: Optional[Dict] = None,
+    ) -> None:
+        super().__init__(agent=agent, user_context=user_context)
+        self.agent = agent
+        self.user_context = user_context
+        self.name = sanitize_identifier(agent.name)
+        self.description = agent.description or "OCR agent tool"
+        try:
+            self.llm = get_llm(agent, is_vision=False)
+        except Exception:
+            self.llm = None
+        if self.llm is None:
+            logger.warning(
+                "OCR agent %s has no configured LLM; OCR will not work until service_id is set",
+                agent.name,
+            )
+        self.react_agent = None
+        self.mcp_client = None
+        self.has_memory = getattr(agent, "has_memory", False) or False
+        self.memory_max_messages = getattr(agent, "memory_max_messages", 20) or 20
+        self.memory_max_tokens = getattr(agent, "memory_max_tokens", 4000)
+        self.memory_summarize_threshold = (
+            getattr(agent, "memory_summarize_threshold", DEFAULT_MEMORY_SUMMARIZE_THRESHOLD)
+            or DEFAULT_MEMORY_SUMMARIZE_THRESHOLD
+        )
+        self.output_parser_id = getattr(agent, "output_parser_id", None)
+        self.temperature = getattr(agent, "temperature", DEFAULT_AGENT_TEMPERATURE) or DEFAULT_AGENT_TEMPERATURE
+
+    @classmethod
+    async def create(
+        cls,
+        agent: Agent,
+        user_context: Optional[Dict] = None,
+    ) -> "IACTOCRTool":
+        """Build an OCR agent-as-tool with MCP support.
+
+        Similar to ``IACTTool.create`` but adds OCR-specific validation
+        and tools.  A failing MCP server degrades the sub-agent but never
+        breaks construction.
+        """
+        instance = cls(agent, user_context=user_context)
+
+        tools: list = [fetch_file_in_base64]
+
+        # Nested tool agents — only recurse into non-OCR agents, because
+        # OCR agents should not be nested inside other agents as tools.
+        for t in agent.tool_associations:
+            sub_agent = t.tool
+            nested = await discover_tool(sub_agent, user_context=user_context)
+            tools.append(nested)
+
+        # MCP tools
+        try:
+            logger.info(f"Starting MCP tools loading for OCR sub-agent {agent.agent_id}...")
+            instance.mcp_client = await MCPClientManager().get_client(agent, user_context)
+            if instance.mcp_client:
+                mcp_tools = await instance.mcp_client.get_tools()
+                logger.info(
+                    f"MCP tools loaded successfully for OCR sub-agent {agent.agent_id}: "
+                    f"{len(mcp_tools)} tools"
+                )
+                if mcp_tools:
+                    tools.extend(mcp_tools)
+        except Exception as e:
+            logger.error(
+                f"Error loading MCP tools for OCR sub-agent {agent.agent_id}: {e}",
+                exc_info=True,
+            )
+            instance.mcp_client = None
+
+        # System prompt — same pattern as IACTTool
+        tool_system_prompt = agent.system_prompt or ""
+        current_date = datetime.now().strftime("%Y-%m-%d")
+        tool_system_prompt += f"\n\nToday's date is {current_date}."
+        if agent.system_prompt and hasattr(agent, "skill_associations") and agent.skill_associations:
+            skills_section = generate_skills_system_prompt_section(agent.skill_associations)
+            if skills_section:
+                tool_system_prompt = tool_system_prompt + "\n" + skills_section
+
+        instance.react_agent = create_langchain_agent(
+            model=instance.llm,
+            tools=tools,
+            system_prompt=tool_system_prompt if tool_system_prompt else None,
+        )
+        return instance
+
+    def _run(self, query: str, file_paths: Optional[List[str]] = None, **kwargs: Any) -> str:
+        """Synchronous execution of the OCR agent tool."""
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(
+                self._arun(query=query, file_paths=file_paths)
+            )
+        finally:
+            loop.close()
+
+    async def _arun(
+        self,
+        query: str,
+        file_paths: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Asynchronous execution of the OCR agent tool."""
+        if self.react_agent is None:
+            raise RuntimeError(
+                "IACTOCRTool must be built via 'await IACTOCRTool.create(...)' before use."
+            )
+
+        tmp_base_folder = get_app_config()["TMP_BASE_FOLDER"]
+        uploads_dir = os.path.join(tmp_base_folder, "uploads")
+        os.makedirs(uploads_dir, exist_ok=True)
+
+        processed_pdfs: List[str] = []
+
+        if file_paths:
+            for fspec in file_paths:
+                try:
+                    pdf_path = await _validate_and_save_pdf(fspec, uploads_dir)
+                    processed_pdfs.append(pdf_path)
+                except ValueError as exc:
+                    return f"Error: {exc}"
+                except Exception as exc:
+                    logger.error("Error preparing PDF for OCR tool: %s", exc, exc_info=True)
+                    return f"Error processing file: {exc}"
+
+        if processed_pdfs:
+            # Combine all PDFs into a single file for the OCR pipeline
+            if len(processed_pdfs) > 1:
+                try:
+                    combined_path = os.path.join(uploads_dir, f"combined_{self.agent.agent_id}_{id(self)}.pdf")
+                    from pypdf import PdfReader, PdfWriter
+                    writer = PdfWriter()
+                    for pdf_path in processed_pdfs:
+                        reader = PdfReader(pdf_path)
+                        for page in reader.pages:
+                            writer.add_page(page)
+                    with open(combined_path, "wb") as f:
+                        writer.write(f)
+                    pdf_path_to_process = combined_path
+                except Exception as exc:
+                    logger.error("Error combining PDFs for OCR tool: %s", exc, exc_info=True)
+                    for p in processed_pdfs:
+                        if os.path.exists(p):
+                            os.remove(p)
+                    return f"Error combining PDFs: {exc}"
+            else:
+                pdf_path_to_process = processed_pdfs[0]
+
+            try:
+                ocr_result = await _execute_tool_agent_ocr(
+                    agent_id=self.agent.agent_id,
+                    pdf_path=pdf_path_to_process,
+                    user_context=self.user_context,
+                )
+                content = ocr_result.get("content", ocr_result)
+                if isinstance(content, dict):
+                    import json
+                    return json.dumps(content, indent=2, ensure_ascii=False)
+                return str(content)
+            except Exception as exc:
+                logger.error("OCR execution failed for tool: %s", exc, exc_info=True)
+                return f"Error executing OCR: {exc}"
+            finally:
+                for p in processed_pdfs:
+                    if os.path.exists(p):
+                        os.remove(p)
+                # Remove combined file if it exists
+                if len(processed_pdfs) > 1 and "combined_path" in dir():
+                    if os.path.exists(combined_path):
+                        os.remove(combined_path)
+
+        # No PDFs — fall back to plain-text chat using the sub-agent's LLM
+        if self.agent.prompt_template:
+            try:
+                formatted_prompt = self.agent.prompt_template.format(question=query)
+            except KeyError:
+                try:
+                    formatted_prompt = self.agent.prompt_template.format(query=query)
+                except KeyError:
+                    logger.warning(
+                        "Could not format prompt_template for OCR agent %s, using query directly",
+                        self.agent.name,
+                    )
+                    formatted_prompt = query
+        else:
+            formatted_prompt = query
+
+        messages = [HumanMessage(content=formatted_prompt)]
+        try:
+            result = self.react_agent.invoke({"messages": messages})
+
+            if isinstance(result, dict) and "messages" in result:
+                messages_list = result["messages"]
+                for msg in reversed(messages_list):
+                    if hasattr(msg, "content") and msg.content:
+                        return str(msg.content)
+                if messages_list:
+                    last_msg = messages_list[-1]
+                    return str(last_msg.content) if hasattr(last_msg, "content") else str(last_msg)
+
+            return str(result)
+        except Exception as e:
+            logger.error("Error executing OCR chat fallback: %s", e)
+            return f"Error executing agent tool: {str(e)}"
+
+
+async def discover_tool(
+    agent: Agent,
+    user_context: Optional[Dict] = None,
+) -> BaseTool:
+    """Return the appropriate tool wrapper for *agent*.
+
+    Routes to :class:`IACTOCRTool` when the agent is an OCR agent
+    (``type == 'ocr_agent'``), otherwise to :class:`IACTTool`.
+    """
+    if agent.type == "ocr_agent":
+        return await IACTOCRTool.create(agent, user_context=user_context)
+    return await IACTTool.create(agent, user_context=user_context)
+
 
 _SEARCH_ERROR_MSG = "The knowledge base search failed; try rephrasing or removing filters."
 

--- a/backend/tools/agentTools.py
+++ b/backend/tools/agentTools.py
@@ -760,26 +760,82 @@ async def _execute_tool_agent_ocr(
         db.close()
 
 
+def _resolve_file(file_spec: str) -> str:
+    """Resolve *file_spec* to an absolute filesystem path.
+
+    Handles three cases:
+
+    1. **Absolute path that exists** → returned as-is
+    2. **Relative path or bare filename under ``tmp_base_folder/``** → appended
+    3. **Bare filename** → searched recursively under ephemeral & persistent
+       session directories (same layout used by :class:`FileManagementService`)
+
+    Returns the absolute path to the resolved file.
+
+    Raises ``FileNotFoundError`` when the file cannot be found.
+    """
+    import pathlib
+
+    tmp_base = get_app_config()["TMP_BASE_FOLDER"]
+    fs = pathlib.Path(file_spec)
+    abs_fs = fs.resolve()
+
+    if abs_fs.is_file():
+        return str(abs_fs)
+
+    relative = fs.relative_to(tmp_base) if str(abs_fs).startswith(str(tmp_base)) else fs
+    joined = pathlib.Path(tmp_base, relative)
+    if joined.is_file():
+        return str(joined.resolve())
+
+    # Bare filename — search the same directory tree that FileManagementService
+    # uses (ephemeral/ and persistent/ directories under tmp_base).
+    tmp_path = pathlib.Path(tmp_base).resolve()
+    name = fs.name
+    for root_dir in (tmp_path / "ephemeral", tmp_path / "persistent"):
+        if not root_dir.is_dir():
+            continue
+        for p in root_dir.rglob(name):
+            if p.is_file():
+                return str(p.resolve())
+
+    raise FileNotFoundError(f"File not found: {file_spec}")
+
+
 async def _validate_and_save_pdf(file_spec: str, tmp_dir: str) -> str:
     """Validate file_spec is a PDF and save it to tmp_dir.
 
-    * If it looks like a file path that ends with ``.pdf`` it is validated as-is.
+    * Supports **absolute paths** (read directly).
+    * Supports **relative paths** or **bare filenames** that exist under
+      ``TMP_BASE_FOLDER`` (resolved via :func:`_resolve_file`).
     * If it starts with ``base64:`` it is decoded and saved as a ``.pdf`` file.
-    * Anything else raises ValueError.
 
     Returns the path to the saved PDF.
     """
+    # Early rejection of known non-PDF extensions.
+    # Bare filenames (e.g. "image.pdf") are allowed through; they are resolved
+    # later by _resolve_file().
+    known_non_pdf_ext = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".txt",
+                         ".md", ".json", ".csv", ".html", ".htm", ".xml", ".doc",
+                         ".docx", ".xls", ".xlsx", ".zip", ".rar", ".7z"}
+    _, ext = os.path.splitext(file_spec)
+    if ext.lower() in known_non_pdf_ext:
+        raise ValueError(
+            f"Only PDF files are supported. Received: {file_spec}"
+        )
+
     if file_spec.startswith("base64:"):
         b64_data = file_spec[len("base64:"):]
         content = base64.b64decode(b64_data)
         suffix = ".pdf"
     elif file_spec.lower().endswith(".pdf"):
         content = None  # will be read directly from disk later
-        suffix = ".pdf" if file_spec.lower().endswith(".pdf") else ""
+        suffix = ".pdf"
     else:
-        raise ValueError(
-            f"Only PDF files are supported. Received: {file_spec}"
-        )
+        # Bare filename — defer resolution; _resolve_file will search
+        # ephemeral/persistent dirs.
+        content = None
+        suffix = ".pdf"
 
     import tempfile
     fd, path = tempfile.mkstemp(suffix=suffix, dir=tmp_dir)
@@ -787,8 +843,14 @@ async def _validate_and_save_pdf(file_spec: str, tmp_dir: str) -> str:
         if content is not None:
             os.write(fd, content)
         else:
-            # Read from the source path and write to the temp file
-            with open(file_spec, "rb") as src:
+            try:
+                actual_path = _resolve_file(file_spec)
+            except FileNotFoundError:
+                os.close(fd)
+                raise ValueError(
+                    f"File '{file_spec}' not found. Make sure the file has been uploaded to this conversation before referencing it in the OCR tool."
+                )
+            with open(actual_path, "rb") as src:
                 os.write(fd, src.read())
     finally:
         os.close(fd)

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -1121,7 +1121,6 @@ function AgentFormPage() {
                   </div>
                 </>
               )}
-
               {/* Configuration for OCR agents */}
               {formData.type === 'ocr_agent' && (
                 <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8">
@@ -1131,7 +1130,43 @@ function AgentFormPage() {
                     </div>
                     <h3 className="text-xl font-semibold text-gray-900">OCR Configuration</h3>
                   </div>
-                  
+
+                  {/* Agent Capabilities Card for OCR agents — Tool Agent checkbox */}
+                  <div className="bg-gray-50 rounded-xl border border-gray-200 p-6 mb-6">
+                    <div className="flex items-center mb-4">
+                      <div className="w-8 h-8 bg-green-100 rounded-lg flex items-center justify-center mr-3">
+                        <Zap className="w-4 h-4 text-green-600" />
+                      </div>
+                      <h4 className="text-base font-semibold text-gray-900">Capabilities</h4>
+                    </div>
+                    <div className="space-y-4">
+                      <div className="flex items-center p-3 bg-white rounded-lg border border-gray-200">
+                        <input
+                          id="is_tool_ocr"
+                          type="checkbox"
+                          checked={formData.is_tool}
+                          onChange={(e) => {
+                            if (!e.target.checked && mcpUsage && mcpUsage.mcp_servers.length > 0) {
+                              setShowMcpWarning(true);
+                            } else {
+                              handleInputChange('is_tool', e.target.checked);
+                            }
+                          }}
+                          className="w-5 h-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                        />
+                        <div className="ml-3">
+                          <label htmlFor="is_tool_ocr" className="text-sm font-medium text-gray-900">Tool Agent</label>
+                          <p className="text-xs text-gray-500">Can be used by other agents (including OCR tools)</p>
+                          {mcpUsage && mcpUsage.mcp_servers.length > 0 && formData.is_tool && (
+                            <p className="text-xs text-purple-600 mt-1">
+                              Used in {mcpUsage.mcp_servers.length} MCP server{mcpUsage.mcp_servers.length === 1 ? '' : 's'}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
                   {/* No AI Services Warning */}
                   {agent?.ai_services.length === 0 && renderNoAIServicesWarning(true)}
 

--- a/tests/unit/tools/test_agent_tools.py
+++ b/tests/unit/tools/test_agent_tools.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from models.agent import Agent
+from models.ocr_agent import OCRAgent
 from tools import agentTools
 
 
@@ -138,3 +139,89 @@ async def test_iact_tool_create_skips_retriever_without_silo():
 
     mock_resolve.assert_not_called()
     mock_get_ret.assert_not_called()
+
+
+# === OCR Agent-as-tool tests ===
+
+
+def _make_ocr_agent(name: str = "OCR Tool") -> OCRAgent:
+    """Build a transient (un-persisted) OCRAgent suitable for IACTOCRTool construction."""
+    ocr = OCRAgent(name=name, description=f"{name} description", system_prompt="")
+    ocr.type = "ocr_agent"
+    return ocr
+
+
+@pytest.mark.asyncio
+async def test_iact_ocr_tool_detects_ocr_agent():
+    """discover_tool should return IACTOCRTool when given an OCRAgent."""
+    ocr_agent = _make_ocr_agent()
+
+    tool_instance = await agentTools.discover_tool(ocr_agent, user_context=None)
+    assert isinstance(tool_instance, agentTools.IACTOCRTool)
+
+
+@pytest.mark.asyncio
+async def test_iact_ocr_tool_falls_back_to_chat_when_no_files():
+    """IACTOCRTool should delegate to chat agents when no PDF file was provided."""
+    ocr_agent = _make_ocr_agent()
+
+    fake_llm = object()
+    fake_react = MagicMock()
+    fake_react.invoke.return_value = {"messages": [MagicMock(content="plain chat response")]}
+
+    with (
+        patch("tools.agentTools.get_llm", return_value=fake_llm),
+        patch("tools.agentTools.create_langchain_agent", return_value=fake_react),
+        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+    ):
+        tool_instance = await agentTools.IACTOCRTool.create(ocr_agent)
+
+    # Should have invoked the react agent when no file_paths given
+    assert tool_instance.react_agent is not None
+    tool_result = await tool_instance._arun(query="hello", file_paths=None)
+    assert tool_result == "plain chat response"
+
+
+@pytest.mark.asyncio
+async def test_iact_ocr_tool_rejects_non_pdf_file():
+    """IACTOCRTool should return a controlled error when receiving a non-PDF file."""
+    ocr_agent = _make_ocr_agent()
+
+    fake_llm = object()
+
+    with (
+        patch("tools.agentTools.get_llm", return_value=fake_llm),
+        patch("tools.agentTools.create_langchain_agent", return_value=MagicMock()),
+        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+    ):
+        tool_instance = await agentTools.IACTOCRTool.create(ocr_agent)
+
+    tool_result = await tool_instance._arun(query="process", file_paths=["document.docx"])
+    assert "Only PDF files are supported" in tool_result
+
+
+@pytest.mark.asyncio
+async def test_iact_ocr_tool_validates_pdf_extension():
+    """IACTOCRTool should validate that file_paths point to PDF files."""
+    ocr_agent = _make_ocr_agent()
+
+    fake_llm = object()
+
+    with (
+        patch("tools.agentTools.get_llm", return_value=fake_llm),
+        patch("tools.agentTools.create_langchain_agent", return_value=MagicMock()),
+        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+    ):
+        tool_instance = await agentTools.IACTOCRTool.create(ocr_agent)
+
+    # .txt — should be rejected during PDF validation
+    result = await tool_instance._arun(query="test", file_paths=["notes.txt"])
+    assert "Only PDF files are supported" in result
+
+    # .docx — should be rejected during PDF validation
+    result = await tool_instance._arun(query="test", file_paths=["document.docx"])
+    assert "Only PDF files are supported" in result
+
+    # PDF that doesn't exist on disk — should be rejected with an error (file can't be read)
+    result = await tool_instance._arun(query="test", file_paths=["document.pdf"])
+    assert "Error" in result or "not a valid PDF" in result

--- a/tests/unit/tools/test_agent_tools.py
+++ b/tests/unit/tools/test_agent_tools.py
@@ -156,7 +156,20 @@ async def test_iact_ocr_tool_detects_ocr_agent():
     """discover_tool should return IACTOCRTool when given an OCRAgent."""
     ocr_agent = _make_ocr_agent()
 
-    tool_instance = await agentTools.discover_tool(ocr_agent, user_context=None)
+    with (
+        patch("tools.agentTools.get_llm", return_value=object()),
+        patch("tools.agentTools.create_langchain_agent", return_value=MagicMock()),
+        patch.object(
+            agentTools.MCPClientManager,
+            "get_client",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        tool_instance = await agentTools.discover_tool(
+            ocr_agent,
+            user_context=None,
+        )
+
     assert isinstance(tool_instance, agentTools.IACTOCRTool)
 
 
@@ -165,63 +178,147 @@ async def test_iact_ocr_tool_falls_back_to_chat_when_no_files():
     """IACTOCRTool should delegate to chat agents when no PDF file was provided."""
     ocr_agent = _make_ocr_agent()
 
-    fake_llm = object()
     fake_react = MagicMock()
-    fake_react.invoke.return_value = {"messages": [MagicMock(content="plain chat response")]}
+    fake_react.ainvoke = AsyncMock(
+        return_value={
+            "messages": [
+                MagicMock(content="plain chat response")
+            ]
+        }
+    )
 
     with (
-        patch("tools.agentTools.get_llm", return_value=fake_llm),
-        patch("tools.agentTools.create_langchain_agent", return_value=fake_react),
-        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+        patch("tools.agentTools.get_llm", return_value=object()),
+        patch(
+            "tools.agentTools.create_langchain_agent",
+            return_value=fake_react,
+        ),
+        patch.object(
+            agentTools.MCPClientManager,
+            "get_client",
+            new=AsyncMock(return_value=None),
+        ),
     ):
         tool_instance = await agentTools.IACTOCRTool.create(ocr_agent)
 
-    # Should have invoked the react agent when no file_paths given
-    assert tool_instance.react_agent is not None
-    tool_result = await tool_instance._arun(query="hello", file_paths=None)
-    assert tool_result == "plain chat response"
+    result = await tool_instance._arun(query="hello")
+
+    assert result == "plain chat response"
 
 
 @pytest.mark.asyncio
-async def test_iact_ocr_tool_rejects_non_pdf_file():
-    """IACTOCRTool should return a controlled error when receiving a non-PDF file."""
+async def test_iact_ocr_tool_uses_attached_pdf_files():
     ocr_agent = _make_ocr_agent()
 
-    fake_llm = object()
+    attached_files = [
+        {
+            "filename": "invoice.pdf",
+            "type": "pdf",
+            "file_path": "/tmp/invoice.pdf",
+        }
+    ]
 
     with (
-        patch("tools.agentTools.get_llm", return_value=fake_llm),
-        patch("tools.agentTools.create_langchain_agent", return_value=MagicMock()),
-        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+        patch("tools.agentTools.get_llm", return_value=object()),
+        patch(
+            "tools.agentTools._execute_tool_agent_ocr",
+            new=AsyncMock(return_value={"amount": 100}),
+        ) as mock_exec,
+        patch(
+            "tools.agentTools.create_langchain_agent",
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            agentTools.MCPClientManager,
+            "get_client",
+            new=AsyncMock(return_value=None),
+        ),
+        patch("os.path.exists", return_value=True),
     ):
-        tool_instance = await agentTools.IACTOCRTool.create(ocr_agent)
+        tool = await agentTools.IACTOCRTool.create(
+            ocr_agent,
+            attached_files=attached_files,
+        )
 
-    tool_result = await tool_instance._arun(query="process", file_paths=["document.docx"])
-    assert "Only PDF files are supported" in tool_result
+        await tool._arun(query="extract")
+
+    mock_exec.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_iact_ocr_tool_validates_pdf_extension():
-    """IACTOCRTool should validate that file_paths point to PDF files."""
+async def test_iact_ocr_tool_reports_missing_pdf():
     ocr_agent = _make_ocr_agent()
 
-    fake_llm = object()
+    attached_files = [
+        {
+            "filename": "missing.pdf",
+            "type": "pdf",
+            "file_path": "/tmp/missing.pdf",
+        }
+    ]
 
     with (
-        patch("tools.agentTools.get_llm", return_value=fake_llm),
-        patch("tools.agentTools.create_langchain_agent", return_value=MagicMock()),
-        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+        patch("tools.agentTools.get_llm", return_value=object()),
+        patch(
+            "tools.agentTools.create_langchain_agent",
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            agentTools.MCPClientManager,
+            "get_client",
+            new=AsyncMock(return_value=None),
+        ),
+        patch("os.path.exists", return_value=False),
     ):
-        tool_instance = await agentTools.IACTOCRTool.create(ocr_agent)
+        tool = await agentTools.IACTOCRTool.create(
+            ocr_agent,
+            attached_files=attached_files,
+        )
 
-    # .txt — should be rejected during PDF validation
-    result = await tool_instance._arun(query="test", file_paths=["notes.txt"])
-    assert "Only PDF files are supported" in result
+        result = await tool._arun(query="extract")
 
-    # .docx — should be rejected during PDF validation
-    result = await tool_instance._arun(query="test", file_paths=["document.docx"])
-    assert "Only PDF files are supported" in result
+    assert "PDF file not found" in result
 
-    # PDF that doesn't exist on disk — should be rejected with an error (file can't be read)
-    result = await tool_instance._arun(query="test", file_paths=["document.pdf"])
-    assert "Error" in result or "not a valid PDF" in result
+
+@pytest.mark.asyncio
+async def test_iact_ocr_tool_processes_multiple_pdfs():
+    ocr_agent = _make_ocr_agent()
+
+    attached_files = [
+        {
+            "filename": "a.pdf",
+            "type": "pdf",
+            "file_path": "/tmp/a.pdf",
+        },
+        {
+            "filename": "b.pdf",
+            "type": "pdf",
+            "file_path": "/tmp/b.pdf",
+        },
+    ]
+
+    with (
+        patch("tools.agentTools.get_llm", return_value=object()),
+        patch(
+            "tools.agentTools._execute_tool_agent_ocr",
+            new=AsyncMock(return_value={"ok": True}),
+        ) as mock_exec,
+        patch(
+            "tools.agentTools.create_langchain_agent",
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            agentTools.MCPClientManager,
+            "get_client",
+            new=AsyncMock(return_value=None),
+        ),
+        patch("os.path.exists", return_value=True),
+    ):
+        tool = await agentTools.IACTOCRTool.create(
+            ocr_agent,
+            attached_files=attached_files,
+        )
+
+        await tool._arun(query="extract")
+
+    assert mock_exec.await_count == 2


### PR DESCRIPTION
## Description

This PR adds full Agent-as-Tool support for OCR agents.

Previously, OCR agents could not be used as tools by other agents through the existing Agent-as-Tool framework. With this implementation, OCR agents can now be discovered, instantiated, and invoked as tools, enabling chat agents to delegate document processing tasks to OCR-specialized agents.

The implementation includes support for forwarding PDF attachments to OCR tool agents, preserving normal conversational behaviour when OCR processing is not required, and exposing OCR agents as selectable tools within the agent configuration UI.

Unit tests have also been added and updated to validate the OCR Agent-as-Tool workflow and ensure compatibility with existing Agent-as-Tool functionality.

## Type of Change

* [ ] Bug fix (a change that does not break existing functionality and fixes an issue)
* [x] Feature (a change that does not break existing functionality and adds new functionality)
* [ ] Documentation (updates or adds documentation only)
* [ ] Refactor (code change that neither fixes a bug nor adds a feature)
* [ ] Performance improvement
* [x] Test (adding or updating tests)
* [ ] Build or infrastructure (changes to tooling, deployment scripts, CI/CD, etc.)

## Affected Components

### Backend (FastAPI)

Affected areas include:

- `tools.agentTools`
- `IACTTool`
- `IACTOCRTool`
- OCR Agent-as-Tool execution flow
- Agent discovery and tool resolution
- File forwarding from parent agents to OCR agents
- Unit tests

### Frontend (React)

Affected areas include:

- `AgentFormPage.tsx`
- Agent configuration UI
- OCR agent tool selection

OCR agents can now be selected and configured as tools through the UI in the same way as standard chat agents.

## Implementation Details

This PR extends the existing Agent-as-Tool architecture to support OCR agents.

Key changes include:

- Introduction of OCR-specific Agent-as-Tool support through `IACTOCRTool`.
- Automatic detection of OCR agents during tool discovery.
- Support for invoking OCR agents from chat agents.
- Forwarding of attached PDF files to OCR tool agents.
- OCR processing execution through the Agent-as-Tool workflow.
- Preservation of standard conversational behaviour when no OCR processing is required.
- Frontend updates to allow OCR agents to be selected as tools within agent configuration screens.
- Addition and update of unit tests covering OCR Agent-as-Tool scenarios.

No database migrations or configuration changes are required.

## How to Test

### Automated Testing

Run OCR-related tests:

```bash
pytest tests/unit/tools/test_agent_tools.py -k ocr -vv
```

Run the complete Agent-as-Tool test suite:

```bash
pytest tests/unit/tools/test_agent_tools.py -vv
```

### Manual Verification

1. Create an OCR agent.
2. Create a chat agent.
3. Configure the OCR agent as a tool of the chat agent.
4. Save the configuration.
5. Start a conversation with the chat agent.
6. Upload a PDF document.
7. Verify that the OCR agent is invoked and processes the PDF.
8. Verify that OCR results are correctly returned to the parent agent.
9. Verify that the chat agent behaves normally when no files are attached.

## Checklist

* [ ] Commit messages follow Conventional Commits (`type(scope): description`).
* [x] I have read the contributing guidelines and my change adheres to the coding standards of this project (see `docs/README.md#contributing`).
* [x] I have added tests that prove my fix or feature works, or confirm that tests are not needed for this change.
* [ ] I have run all existing tests and they all pass locally.
* [ ] I have updated any relevant documentation, configuration files, or environment examples as needed.
* [x] I have considered backwards compatibility and ensured that my change does not break existing functionality.
* [ ] For UI changes, I have included relevant screenshots or screencasts.

## Additional Notes

This PR enables OCR agents to participate in multi-agent workflows through the existing Agent-as-Tool infrastructure.

The primary use case is allowing chat agents to delegate PDF and document processing tasks to specialized OCR agents while maintaining a consistent tool invocation experience across agent types.