### PR TITLE
fix(oidc): resolve duplicate user creation race condition with unique…

### DIFF
--- a/alembic/versions/useremail001_dedupe_users_add_unique_email.py
+++ b/alembic/versions/useremail001_dedupe_users_add_unique_email.py
@@ -1,0 +1,212 @@
+"""Merge duplicate User rows (same email) and add a unique constraint on User.email.
+
+Fixes the OIDC first-login race in ``UserService.get_or_create_user`` (check-then-insert
+with no DB-level uniqueness) that could create 2-3 ``User`` rows sharing the same email.
+The application-level race fix lives in a separate change; this migration only repairs
+existing data and closes the schema gap that let it happen.
+
+Data-merge strategy (irreversible - see downgrade note below):
+
+For every email with more than one ``User`` row, we pick a canonical row using an
+activity score - ``count(owned App) + count(APIKey) + count(AppCollaborator)
++ count(usage_records) + count(MarketplaceUsage)`` - tie-broken by the lowest
+``user_id`` (oldest row). All "loser" rows for that email are then folded into the
+canonical row before being deleted:
+
+- ``App.owner_id``, ``APIKey.user_id`` (NO ACTION FKs) - reassigned to canonical.
+- ``AppCollaborator.user_id`` (NO ACTION FK) - reassigned to canonical unless canonical
+  already has a collaborator row for the same ``app_id``, in which case the loser's row
+  is dropped instead (avoids a duplicate collaborator entry).
+- ``AppCollaborator.invited_by`` (SET NULL FK, not in the original FK table but found via
+  grep for ``ForeignKey('User.user_id')`` across backend/models/) - reassigned to
+  canonical to preserve "who invited" attribution instead of relying on SET NULL.
+- ``subscriptions.user_id`` / ``user_credentials.user_id`` (CASCADE, 1:1 unique) -
+  reassigned only if canonical doesn't already have one; otherwise the loser's row is
+  left in place and is removed by the CASCADE when the loser ``User`` row is deleted
+  (logged via RAISE NOTICE - rare edge case).
+- ``usage_records`` (CASCADE, unique on ``(user_id, billing_period_start)``) and
+  ``MarketplaceUsage`` (CASCADE, unique on ``(user_id, year, month)``) - overlapping
+  periods are summed (``call_count``) into canonical's row and the loser's row dropped;
+  non-overlapping periods are reassigned.
+- ``AgentMarketplaceRating`` (CASCADE, unique on ``(profile_id, user_id)``) - if both
+  duplicates rated the same profile, the more recently ``updated_at`` rating wins and
+  the other is dropped; otherwise reassigned.
+- ``Conversation.user_id`` and ``crawl_job.triggered_by_user_id`` (SET NULL, nullable) -
+  reassigned explicitly rather than relying on SET NULL, so chat history / crawl
+  attribution isn't orphaned.
+- ``refresh_tokens.user_id`` (CASCADE, no uniqueness) - left untouched; stale sessions on
+  the loser row are simply cascade-deleted with it.
+
+Revision ID: useremail001
+Revises: 20260717_conversation_starters
+Create Date: 2026-07-24
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'useremail001'
+down_revision = '20260717_conversation_starters'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- Data fix: merge duplicate User rows sharing the same email -----------------
+    # NOTE: this data merge is NOT reversible (rows are combined/deleted). See the
+    # downgrade() docstring below.
+    op.execute("""
+    DO $$
+    DECLARE
+        dup_email   RECORD;
+        canonical_id INTEGER;
+        loser       RECORD;
+    BEGIN
+        FOR dup_email IN
+            SELECT email
+            FROM "User"
+            WHERE email IS NOT NULL
+            GROUP BY email
+            HAVING COUNT(*) > 1
+        LOOP
+            -- Canonical = highest activity score, tie-broken by lowest (oldest) user_id.
+            SELECT u.user_id INTO canonical_id
+            FROM "User" u
+            WHERE u.email = dup_email.email
+            ORDER BY
+                (
+                    (SELECT COUNT(*) FROM "App" a WHERE a.owner_id = u.user_id) +
+                    (SELECT COUNT(*) FROM "APIKey" k WHERE k.user_id = u.user_id) +
+                    (SELECT COUNT(*) FROM "AppCollaborator" c WHERE c.user_id = u.user_id) +
+                    (SELECT COUNT(*) FROM usage_records ur WHERE ur.user_id = u.user_id) +
+                    (SELECT COUNT(*) FROM "MarketplaceUsage" mu WHERE mu.user_id = u.user_id)
+                ) DESC,
+                u.user_id ASC
+            LIMIT 1;
+
+            FOR loser IN
+                SELECT user_id FROM "User" WHERE email = dup_email.email AND user_id <> canonical_id
+            LOOP
+                -- App.owner_id (NO ACTION FK) -- reassign
+                UPDATE "App" SET owner_id = canonical_id WHERE owner_id = loser.user_id;
+
+                -- APIKey.user_id (NO ACTION FK) -- reassign
+                UPDATE "APIKey" SET user_id = canonical_id WHERE user_id = loser.user_id;
+
+                -- AppCollaborator.user_id (NO ACTION FK) -- reassign unless canonical
+                -- already collaborates on the same app, then drop the loser's duplicate row.
+                UPDATE "AppCollaborator" ac
+                SET user_id = canonical_id
+                WHERE ac.user_id = loser.user_id
+                  AND NOT EXISTS (
+                      SELECT 1 FROM "AppCollaborator" ac2
+                      WHERE ac2.app_id = ac.app_id AND ac2.user_id = canonical_id
+                  );
+
+                DELETE FROM "AppCollaborator" WHERE user_id = loser.user_id;
+
+                -- AppCollaborator.invited_by (SET NULL FK) -- reassign attribution explicitly
+                UPDATE "AppCollaborator" SET invited_by = canonical_id WHERE invited_by = loser.user_id;
+
+                -- subscriptions (CASCADE, 1:1 unique) -- reassign only if canonical has none
+                IF NOT EXISTS (SELECT 1 FROM subscriptions WHERE user_id = canonical_id) THEN
+                    UPDATE subscriptions SET user_id = canonical_id WHERE user_id = loser.user_id;
+                ELSIF EXISTS (SELECT 1 FROM subscriptions WHERE user_id = loser.user_id) THEN
+                    RAISE NOTICE 'user email-merge: subscription row for loser user_id % (email %) left in place to cascade-delete; canonical user_id % already has one.', loser.user_id, dup_email.email, canonical_id;
+                END IF;
+
+                -- user_credentials (CASCADE, 1:1 unique) -- reassign only if canonical has none
+                IF NOT EXISTS (SELECT 1 FROM user_credentials WHERE user_id = canonical_id) THEN
+                    UPDATE user_credentials SET user_id = canonical_id WHERE user_id = loser.user_id;
+                ELSIF EXISTS (SELECT 1 FROM user_credentials WHERE user_id = loser.user_id) THEN
+                    RAISE NOTICE 'user email-merge: user_credentials row for loser user_id % (email %) left in place to cascade-delete; canonical user_id % already has one.', loser.user_id, dup_email.email, canonical_id;
+                END IF;
+
+                -- usage_records (CASCADE, unique on user_id+billing_period_start) --
+                -- sum overlapping periods into canonical, then drop loser's dupes, then reassign the rest.
+                UPDATE usage_records ur_c
+                SET call_count = ur_c.call_count + ur_l.call_count,
+                    updated_at = GREATEST(ur_c.updated_at, ur_l.updated_at)
+                FROM usage_records ur_l
+                WHERE ur_c.user_id = canonical_id
+                  AND ur_l.user_id = loser.user_id
+                  AND ur_c.billing_period_start = ur_l.billing_period_start;
+
+                DELETE FROM usage_records ur_l
+                WHERE ur_l.user_id = loser.user_id
+                  AND EXISTS (
+                      SELECT 1 FROM usage_records ur_c
+                      WHERE ur_c.user_id = canonical_id
+                        AND ur_c.billing_period_start = ur_l.billing_period_start
+                  );
+
+                UPDATE usage_records SET user_id = canonical_id WHERE user_id = loser.user_id;
+
+                -- MarketplaceUsage (CASCADE, unique on user_id+year+month) -- same aggregate-or-reassign logic
+                UPDATE "MarketplaceUsage" mu_c
+                SET call_count = mu_c.call_count + mu_l.call_count,
+                    updated_at = GREATEST(mu_c.updated_at, mu_l.updated_at)
+                FROM "MarketplaceUsage" mu_l
+                WHERE mu_c.user_id = canonical_id
+                  AND mu_l.user_id = loser.user_id
+                  AND mu_c.year = mu_l.year
+                  AND mu_c.month = mu_l.month;
+
+                DELETE FROM "MarketplaceUsage" mu_l
+                WHERE mu_l.user_id = loser.user_id
+                  AND EXISTS (
+                      SELECT 1 FROM "MarketplaceUsage" mu_c
+                      WHERE mu_c.user_id = canonical_id
+                        AND mu_c.year = mu_l.year
+                        AND mu_c.month = mu_l.month
+                  );
+
+                UPDATE "MarketplaceUsage" SET user_id = canonical_id WHERE user_id = loser.user_id;
+
+                -- AgentMarketplaceRating (CASCADE, unique on profile_id+user_id) -- keep the
+                -- most-recently-updated rating on conflict, then reassign the rest.
+                UPDATE "AgentMarketplaceRating" r_c
+                SET rating = r_l.rating,
+                    updated_at = r_l.updated_at
+                FROM "AgentMarketplaceRating" r_l
+                WHERE r_c.user_id = canonical_id
+                  AND r_l.user_id = loser.user_id
+                  AND r_c.profile_id = r_l.profile_id
+                  AND r_l.updated_at > r_c.updated_at;
+
+                DELETE FROM "AgentMarketplaceRating" r_l
+                WHERE r_l.user_id = loser.user_id
+                  AND EXISTS (
+                      SELECT 1 FROM "AgentMarketplaceRating" r_c
+                      WHERE r_c.user_id = canonical_id
+                        AND r_c.profile_id = r_l.profile_id
+                  );
+
+                UPDATE "AgentMarketplaceRating" SET user_id = canonical_id WHERE user_id = loser.user_id;
+
+                -- Conversation.user_id (SET NULL, nullable) -- reassign explicitly, don't orphan chat history
+                UPDATE "Conversation" SET user_id = canonical_id WHERE user_id = loser.user_id;
+
+                -- crawl_job.triggered_by_user_id (SET NULL, nullable) -- reassign explicitly
+                UPDATE crawl_job SET triggered_by_user_id = canonical_id WHERE triggered_by_user_id = loser.user_id;
+
+                -- refresh_tokens.user_id (CASCADE, no uniqueness) -- intentionally left alone;
+                -- stale sessions on the loser row cascade-delete with it below.
+            END LOOP;
+
+            -- All loser rows for this email are now safe to delete.
+            DELETE FROM "User" WHERE email = dup_email.email AND user_id <> canonical_id;
+        END LOOP;
+    END $$;
+    """)
+
+    # --- Schema fix: prevent this from ever happening again --------------------------
+    op.create_unique_constraint('uq_user_email', 'User', ['email'])
+
+
+def downgrade() -> None:
+    # The row merge performed in upgrade() is NOT reversible -- duplicate rows were
+    # combined (usage/rating data summed, FKs repointed) and the loser rows deleted.
+    # There is no data to restore. Downgrade only removes the schema constraint so a
+    # subsequent upgrade path (or manual recovery) isn't blocked by it.
+    op.drop_constraint('uq_user_email', 'User', type_='unique')

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,5 +1,5 @@
 import enum
-from sqlalchemy import Column, Integer, String, DateTime, Boolean
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, UniqueConstraint
 from sqlalchemy.orm import relationship
 from db.database import Base
 from datetime import datetime
@@ -13,6 +13,11 @@ class PlatformRole(str, enum.Enum):
 
 class User(Base):
     __tablename__ = 'User'
+    # Named to match the constraint added by alembic/versions/useremail001_dedupe_users_add_unique_email.py
+    # -- keeps ORM metadata and the real migration-managed schema in agreement (autogenerate-safe).
+    __table_args__ = (
+        UniqueConstraint('email', name='uq_user_email'),
+    )
     user_id = Column(Integer, primary_key=True)
     email = Column(String(255))
     name = Column(String(255))

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import Session
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from models.user import User, PlatformRole
 from models.api_key import APIKey
 from models.app import App
@@ -54,7 +55,14 @@ class UserService:
 
     @staticmethod
     def get_or_create_user(db: Session, email: str, name: str = None) -> Tuple[User, bool]:
-        """Get existing user or create one. Returns (user, created)."""
+        """Get existing user or create one. Returns (user, created).
+
+        Race-safe against concurrent first-login requests (e.g. parallel OIDC-protected
+        calls firing on initial login): if two calls both miss the SELECT and race to
+        INSERT, the `uq_user_email` unique constraint rejects the loser's INSERT with an
+        IntegrityError. That loser rolls back and re-fetches the winner's row instead of
+        propagating the error, so callers never see a spurious 500 or duplicate user.
+        """
         user_repo = UserRepository(db)
 
         user = user_repo.get_by_email(email)
@@ -63,8 +71,15 @@ class UserService:
             user = user_repo.update(user, name)
             return user, False
 
-        new_user = user_repo.create(email, name)
-        return new_user, True
+        try:
+            new_user = user_repo.create(email, name)
+            return new_user, True
+        except IntegrityError:
+            db.rollback()
+            user = user_repo.get_by_email(email)
+            if user:
+                return user_repo.update(user, name), False
+            raise
 
     @staticmethod
     def get_user_by_id(db: Session, user_id: int) -> User:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,17 @@ os.environ.setdefault("AICT_LOGIN", "LOCAL")
 os.environ.setdefault("AICT_OMNIADMINS", "admin@test.com")
 os.environ.setdefault("AICT_MODE", "SELF-HOSTED")
 os.environ.setdefault("FRONTEND_URL", "http://localhost:5173")
+# The `client` fixture reruns the full app lifespan (incl. omniadmin_bootstrap) on every
+# test. bootstrap_omniadmins provisions AICT_OMNIADMINS via its own real, auto-committing
+# SessionLocal() -- a separate connection from the `db` fixture's rolled-back outer
+# transaction. Several tests' `admin_headers` fixtures monkeypatch AICT_OMNIADMINS to
+# fake_user's email (already flushed-but-uncommitted in the `db` session); bootstrap's
+# separate session then tries to INSERT that same email and blocks waiting for the `db`
+# session's transaction to finish -- which can't happen until the test body runs, which
+# can't start until `client` setup (running bootstrap) finishes. Disabling the default
+# here avoids that deadlock; tests that exercise bootstrap_omniadmins directly already
+# monkeypatch this flag to "true" themselves (see test_local_auth_provisioning.py).
+os.environ.setdefault("AUTH_BOOTSTRAP_OMNIADMINS", "false")
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/integration/export_import/test_silo_export_import_integration.py
+++ b/tests/integration/export_import/test_silo_export_import_integration.py
@@ -24,9 +24,15 @@ from repositories.silo_repository import SiloRepository
 
 @pytest.fixture
 def test_user(db_session: Session) -> User:
-    """Create test user."""
+    """Create test user.
+
+    Email must be unique per invocation: db_session.commit() is a real commit
+    against the module-session-scoped `engine` fixture (not the rolled-back
+    per-test transaction other suites use), so a hardcoded email would collide
+    across the many tests in this file once User.email has a unique constraint.
+    """
     user = User(
-        email="test_silo@example.com",
+        email=f"test_silo-{datetime.now().timestamp()}@example.com",
         name="Test Silo User",
     )
     db_session.add(user)

--- a/tests/integration/test_oidc_duplicate_user_race.py
+++ b/tests/integration/test_oidc_duplicate_user_race.py
@@ -17,11 +17,10 @@ Fix (two parts, both already landed on this branch):
 These tests require the REAL Postgres unique constraint to be present -- a pure unit test
 with a mocked session cannot trigger a genuine ``IntegrityError`` -- so they live here in
 ``tests/integration/`` against the real test DB (port 5433) rather than in ``tests/unit/``.
-The two tests that actually need the constraint to fire bring it up themselves via the
-``ensure_email_unique_constraint`` fixture (see its docstring below) rather than assuming
-it is already present -- this repo's test-DB schema is built from ORM metadata
-(``Base.metadata.create_all()``), not from the Alembic migration, so the constraint is
-NOT guaranteed to exist on a fresh/ephemeral test DB.
+``models/user.py`` declares ``uq_user_email`` via ``__table_args__`` (matching the name
+used by the ``useremail001`` migration), so this repo's test-DB schema -- built from ORM
+metadata via ``Base.metadata.create_all()`` -- already carries the real constraint; no
+test-local workaround is needed to bring it up.
 
 Concurrency strategy (deterministic -- no real threads, no flaky timing):
   Two real ``SessionLocal()`` sessions are used directly (mirroring two separate FastAPI
@@ -47,79 +46,13 @@ Concurrency strategy (deterministic -- no real threads, no flaky timing):
 
 import uuid
 
-import pytest
-from sqlalchemy import inspect, text
+from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 
 from db.database import SessionLocal
 from models.user import User
 from repositories.user_repository import UserRepository
 from services.user_service import UserService
-
-_TEST_SCOPED_CONSTRAINT_NAME = "uq_user_email_test_scoped"
-
-
-@pytest.fixture
-def ensure_email_unique_constraint(test_engine):
-    """Guarantees a real UNIQUE constraint on ``User.email`` exists for the duration of
-    a single test, then removes it again immediately afterward.
-
-    Why this fixture exists (rather than relying on ambient DB state or a permanent
-    model change):
-
-    - The session-scoped ``test_engine`` fixture builds the schema via
-      ``Base.metadata.create_all()`` (ORM metadata), NOT by running the ``useremail001``
-      Alembic migration -- see ``tests/integration/test_localauth001_migration.py``'s
-      docstring for the same caveat about this repo's test-DB schema strategy. So
-      whether the real ``uq_user_email`` constraint exists here depends entirely on
-      whatever state the target Postgres database happened to be in beforehand -- it is
-      NOT guaranteed on a fresh/ephemeral test DB. This was confirmed while writing this
-      test: a from-scratch schema built purely from ``create_all()`` has no such
-      constraint, since ``models/user.py``'s ``email`` column does not declare
-      ``unique=True``.
-    - Adding ``unique=True`` directly to ``User.email`` in ``backend/models/user.py``
-      would make ``create_all()`` always include the constraint -- but this was tried
-      and reverted during development of this test: it turns the ``fake_user`` fixture's
-      shared, hardcoded email (``"testuser@mattin-test.com"``, reused by dozens of
-      unrelated tests across the suite) into a permanent, session-wide lock-contention
-      hazard. If any other test's session is ever left open (e.g. a hung fixture
-      teardown) while holding that email, every subsequent ``fake_user``-based test
-      would then block waiting on the Postgres row lock instead of harmlessly
-      coexisting in separate, never-committed transactions like they do today -- this
-      produced a full test-suite deadlock, observed firsthand while developing this fix.
-
-    Instead, this fixture adds the constraint (under its own distinct name, if not
-    already present) immediately before the single test that needs it runs, and drops
-    it again immediately after -- a window of a few milliseconds -- so it cannot collide
-    with any other test's use of the shared ``fake_user`` email.
-    """
-    inspector = inspect(test_engine)
-    already_present = any(
-        c["name"] == "uq_user_email" for c in inspector.get_unique_constraints("User")
-    )
-
-    added_here = False
-    if not already_present:
-        with test_engine.begin() as conn:
-            conn.execute(
-                text(
-                    f'ALTER TABLE "User" ADD CONSTRAINT {_TEST_SCOPED_CONSTRAINT_NAME} '
-                    "UNIQUE (email)"
-                )
-            )
-        added_here = True
-
-    try:
-        yield
-    finally:
-        if added_here:
-            with test_engine.begin() as conn:
-                conn.execute(
-                    text(
-                        f'ALTER TABLE "User" DROP CONSTRAINT IF EXISTS '
-                        f"{_TEST_SCOPED_CONSTRAINT_NAME}"
-                    )
-                )
 
 
 def _unique_email(label: str) -> str:
@@ -172,9 +105,7 @@ class TestUserRepositoryUniqueConstraint:
     """Sanity check that the real DB constraint is present and fires -- isolates the
     schema half of the fix from the service-level recovery logic tested below."""
 
-    def test_create_raises_integrity_error_on_duplicate_email(
-        self, test_engine, ensure_email_unique_constraint
-    ):
+    def test_create_raises_integrity_error_on_duplicate_email(self, test_engine):
         email = _unique_email("constraint-sanity")
         session_a = SessionLocal()
         session_b = SessionLocal()
@@ -207,9 +138,7 @@ class TestGetOrCreateUserConcurrentRace:
     out of the call instead of being caught and recovered from.
     """
 
-    def test_concurrent_calls_converge_to_single_user_row(
-        self, test_engine, ensure_email_unique_constraint
-    ):
+    def test_concurrent_calls_converge_to_single_user_row(self, test_engine):
         email = _unique_email("concurrent")
         session_a = SessionLocal()
         session_b = SessionLocal()

--- a/tests/integration/test_oidc_duplicate_user_race.py
+++ b/tests/integration/test_oidc_duplicate_user_race.py
@@ -1,0 +1,254 @@
+"""Integration regression tests for the OIDC duplicate-user-creation race.
+
+Bug: two concurrent OIDC first-login requests for a brand-new email could both miss the
+SELECT in ``UserService.get_or_create_user`` (plain check-then-insert, no DB-level
+uniqueness, no locking) and both proceed to INSERT, creating 2 (or up to 3, if a third
+request also raced in) ``User`` rows sharing the same email.
+
+Fix (two parts, both already landed on this branch):
+  1. ``alembic/versions/useremail001_dedupe_users_add_unique_email.py`` adds a
+     ``uq_user_email`` UNIQUE constraint on ``User.email`` (plus a one-time dedupe of any
+     pre-existing duplicate rows).
+  2. ``UserService.get_or_create_user`` (``backend/services/user_service.py``) now catches
+     the ``IntegrityError`` raised by that constraint when the INSERT loses the race,
+     rolls back, and re-fetches the winner's row instead of propagating a 500 or leaving a
+     duplicate.
+
+These tests require the REAL Postgres unique constraint to be present -- a pure unit test
+with a mocked session cannot trigger a genuine ``IntegrityError`` -- so they live here in
+``tests/integration/`` against the real test DB (port 5433) rather than in ``tests/unit/``.
+The two tests that actually need the constraint to fire bring it up themselves via the
+``ensure_email_unique_constraint`` fixture (see its docstring below) rather than assuming
+it is already present -- this repo's test-DB schema is built from ORM metadata
+(``Base.metadata.create_all()``), not from the Alembic migration, so the constraint is
+NOT guaranteed to exist on a fresh/ephemeral test DB.
+
+Concurrency strategy (deterministic -- no real threads, no flaky timing):
+  Two real ``SessionLocal()`` sessions are used directly (mirroring two separate FastAPI
+  requests, each with its own ``Depends(get_db)`` session) rather than the standard
+  savepoint-rollback ``db`` fixture: the race must be visible as a genuine UNIQUE-constraint
+  conflict across two independent DB transactions, which a single shared connection/
+  savepoint cannot reproduce.
+
+  Session B is bumped to ``REPEATABLE READ`` *before* its first statement, fixing its MVCC
+  snapshot at that point (while the email definitely does not exist yet). Session A ("A"
+  wins the race) then runs ``get_or_create_user`` to completion, fully creating and
+  committing a new user for that same email. Postgres enforces UNIQUE constraints against
+  the actual committed data regardless of a transaction's MVCC snapshot, so when Session
+  B's ``get_or_create_user`` re-does its own SELECT (still returns None -- per its frozen
+  snapshot, A's commit is invisible to it) and attempts the INSERT, it collides with the
+  real ``uq_user_email`` constraint and raises ``IntegrityError`` -- exactly the path the
+  fix's ``except IntegrityError`` block exists to recover from.
+
+  Each test commits real rows to the test DB (bypassing the savepoint-rollback fixture,
+  same pattern as ``tests/integration/test_crawl_worker_concurrency.py``) and cleans up
+  manually in a ``finally`` block.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import inspect, text
+from sqlalchemy.exc import IntegrityError
+
+from db.database import SessionLocal
+from models.user import User
+from repositories.user_repository import UserRepository
+from services.user_service import UserService
+
+_TEST_SCOPED_CONSTRAINT_NAME = "uq_user_email_test_scoped"
+
+
+@pytest.fixture
+def ensure_email_unique_constraint(test_engine):
+    """Guarantees a real UNIQUE constraint on ``User.email`` exists for the duration of
+    a single test, then removes it again immediately afterward.
+
+    Why this fixture exists (rather than relying on ambient DB state or a permanent
+    model change):
+
+    - The session-scoped ``test_engine`` fixture builds the schema via
+      ``Base.metadata.create_all()`` (ORM metadata), NOT by running the ``useremail001``
+      Alembic migration -- see ``tests/integration/test_localauth001_migration.py``'s
+      docstring for the same caveat about this repo's test-DB schema strategy. So
+      whether the real ``uq_user_email`` constraint exists here depends entirely on
+      whatever state the target Postgres database happened to be in beforehand -- it is
+      NOT guaranteed on a fresh/ephemeral test DB. This was confirmed while writing this
+      test: a from-scratch schema built purely from ``create_all()`` has no such
+      constraint, since ``models/user.py``'s ``email`` column does not declare
+      ``unique=True``.
+    - Adding ``unique=True`` directly to ``User.email`` in ``backend/models/user.py``
+      would make ``create_all()`` always include the constraint -- but this was tried
+      and reverted during development of this test: it turns the ``fake_user`` fixture's
+      shared, hardcoded email (``"testuser@mattin-test.com"``, reused by dozens of
+      unrelated tests across the suite) into a permanent, session-wide lock-contention
+      hazard. If any other test's session is ever left open (e.g. a hung fixture
+      teardown) while holding that email, every subsequent ``fake_user``-based test
+      would then block waiting on the Postgres row lock instead of harmlessly
+      coexisting in separate, never-committed transactions like they do today -- this
+      produced a full test-suite deadlock, observed firsthand while developing this fix.
+
+    Instead, this fixture adds the constraint (under its own distinct name, if not
+    already present) immediately before the single test that needs it runs, and drops
+    it again immediately after -- a window of a few milliseconds -- so it cannot collide
+    with any other test's use of the shared ``fake_user`` email.
+    """
+    inspector = inspect(test_engine)
+    already_present = any(
+        c["name"] == "uq_user_email" for c in inspector.get_unique_constraints("User")
+    )
+
+    added_here = False
+    if not already_present:
+        with test_engine.begin() as conn:
+            conn.execute(
+                text(
+                    f'ALTER TABLE "User" ADD CONSTRAINT {_TEST_SCOPED_CONSTRAINT_NAME} '
+                    "UNIQUE (email)"
+                )
+            )
+        added_here = True
+
+    try:
+        yield
+    finally:
+        if added_here:
+            with test_engine.begin() as conn:
+                conn.execute(
+                    text(
+                        f'ALTER TABLE "User" DROP CONSTRAINT IF EXISTS '
+                        f"{_TEST_SCOPED_CONSTRAINT_NAME}"
+                    )
+                )
+
+
+def _unique_email(label: str) -> str:
+    return f"oidc-race-{label}-{uuid.uuid4().hex}@mattin-test.com"
+
+
+def _cleanup(email: str) -> None:
+    """Delete any User row(s) left behind for `email` (real commit, real cleanup).
+
+    Uses a brand-new session/connection so it works regardless of the state the
+    racing sessions were left in (including a rolled-back or aborted transaction).
+    """
+    cleanup_session = SessionLocal()
+    try:
+        cleanup_session.query(User).filter(User.email == email).delete()
+        cleanup_session.commit()
+    finally:
+        cleanup_session.close()
+
+
+class TestGetOrCreateUserSequential:
+    """Basic (non-racing) regression coverage: the IntegrityError handling added for the
+    race fix must not have broken the normal, uncontested get-or-create path."""
+
+    def test_second_call_returns_existing_user_not_a_duplicate(self, test_engine):
+        email = _unique_email("sequential")
+        try:
+            session = SessionLocal()
+            try:
+                user1, created1 = UserService.get_or_create_user(session, email, name="First Login")
+                user2, created2 = UserService.get_or_create_user(session, email, name="First Login")
+            finally:
+                session.close()
+
+            assert created1 is True, "First call for a brand-new email must create the user"
+            assert created2 is False, "Second call for the same email must not create a duplicate"
+            assert user1.user_id == user2.user_id
+
+            verify_session = SessionLocal()
+            try:
+                count = verify_session.query(User).filter(User.email == email).count()
+            finally:
+                verify_session.close()
+            assert count == 1
+        finally:
+            _cleanup(email)
+
+
+class TestUserRepositoryUniqueConstraint:
+    """Sanity check that the real DB constraint is present and fires -- isolates the
+    schema half of the fix from the service-level recovery logic tested below."""
+
+    def test_create_raises_integrity_error_on_duplicate_email(
+        self, test_engine, ensure_email_unique_constraint
+    ):
+        email = _unique_email("constraint-sanity")
+        session_a = SessionLocal()
+        session_b = SessionLocal()
+        try:
+            UserRepository(session_a).create(email, "First")
+
+            try:
+                UserRepository(session_b).create(email, "Second")
+                raised = False
+            except IntegrityError:
+                raised = True
+                session_b.rollback()
+
+            assert raised, (
+                "UserRepository.create must raise IntegrityError for a duplicate email "
+                "-- the uq_user_email constraint is missing or not enforced"
+            )
+        finally:
+            session_a.close()
+            session_b.close()
+            _cleanup(email)
+
+
+class TestGetOrCreateUserConcurrentRace:
+    """Reproduces the actual race: two separate sessions both miss the SELECT and race to
+    INSERT for the same brand-new email.
+
+    FAILS against the pre-fix ``get_or_create_user`` (plain SELECT-then-INSERT, no
+    try/except around the INSERT): the loser's real ``IntegrityError`` propagates straight
+    out of the call instead of being caught and recovered from.
+    """
+
+    def test_concurrent_calls_converge_to_single_user_row(
+        self, test_engine, ensure_email_unique_constraint
+    ):
+        email = _unique_email("concurrent")
+        session_a = SessionLocal()
+        session_b = SessionLocal()
+        try:
+            # Session B: elevate isolation *before* its first statement so its MVCC
+            # snapshot is fixed here -- simulating a request whose "user not found" read
+            # happened concurrently with (before) Session A's INSERT+commit.
+            session_b.execute(text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
+            repo_b = UserRepository(session_b)
+            assert repo_b.get_by_email(email) is None, "sanity: email must not pre-exist"
+
+            # Session A "wins" the race: creates and commits the user first.
+            user_a, created_a = UserService.get_or_create_user(session_a, email, name="Race Winner")
+            assert created_a is True
+
+            # Session B still cannot see Session A's commit (its snapshot predates it), so
+            # get_or_create_user's own internal SELECT returns None and it attempts the
+            # INSERT -- which now collides with the real uq_user_email constraint and
+            # raises IntegrityError. The fix must catch it, roll back, and converge on the
+            # winner's row rather than raising or leaving a duplicate.
+            user_b, created_b = UserService.get_or_create_user(session_b, email, name="Race Loser")
+
+            assert created_b is False, (
+                "Losing call must report created=False (converged on the existing row), "
+                "not create a second User row"
+            )
+            assert user_b.user_id == user_a.user_id, (
+                "Both concurrent calls must resolve to the SAME user_id"
+            )
+
+            # Exactly one row must exist for this email -- checked via a fresh, independent
+            # session so we're not relying on either racing session's own identity map.
+            verify_session = SessionLocal()
+            try:
+                count = verify_session.query(User).filter(User.email == email).count()
+            finally:
+                verify_session.close()
+            assert count == 1, f"Expected exactly 1 User row for {email}, found {count}"
+        finally:
+            session_a.close()
+            session_b.close()
+            _cleanup(email)

--- a/tests/integration/test_useremail001_migration_e2e.py
+++ b/tests/integration/test_useremail001_migration_e2e.py
@@ -1,0 +1,336 @@
+"""End-to-end test of the real ``useremail001`` Alembic migration.
+
+Unlike ``test_localauth001_migration.py`` / ``test_migration_domain_crawling.py`` /
+``test_migration_user_deletion.py`` (which only assert schema *state* on the shared,
+session-scoped ``test_engine`` fixture -- a schema built via ``Base.metadata.create_all()``,
+never through Alembic itself), and unlike ``test_oidc_duplicate_user_race.py`` (which
+tests the *application-level* race fix in ``UserService.get_or_create_user``), this test
+exercises the actual ``useremail001`` migration's ``upgrade()`` function by:
+
+  1. Creating a brand-new, uniquely-named ephemeral Postgres database on the ``db_test``
+     container (port 5433).
+  2. Running the real ``alembic upgrade`` CLI as a subprocess against it, stopping one
+     revision short of the fix (``20260717_conversation_starters`` -- ``useremail001``'s
+     ``down_revision``), reproducing the pre-fix schema (no ``uq_user_email`` constraint).
+  3. Inserting two duplicate ``User`` rows sharing an email, each owning 2 ``App`` rows
+     with 1 ``Agent`` each (4 Apps + 4 Agents total) -- the literal "duplicate users each
+     owning 2 apps with an agent" scenario.
+  4. Running the real ``alembic upgrade head`` subprocess, applying ``useremail001``'s
+     data merge + ``uq_user_email`` unique constraint.
+  5. Asserting, via raw SQL against the ephemeral DB (not the ORM, to stay decoupled from
+     any session/identity-map state), that the merge produced exactly the expected result.
+
+Runtime: this test is slower than a typical integration test (~10-20s) -- it creates a
+real database and shells out to the real ``alembic`` CLI twice. That tradeoff is
+intentional: it is the only way to prove the actual migration script (not a reimplementation
+of its SQL) behaves correctly end-to-end.
+
+Requires: the ``db_test`` docker-compose service on port 5433, started via
+``docker compose -f docker/docker-compose.yaml --profile test up -d db_test``. Its
+``POSTGRES_USER`` (``test_user``) is a Postgres superuser for that container, so it can
+freely ``CREATE DATABASE`` / ``DROP DATABASE`` on the shared cluster.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import psycopg2
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DB_HOST = "localhost"
+DB_PORT = "5433"
+# The db_test container's POSTGRES_USER is a cluster superuser (standard Postgres image
+# behavior), so it can CREATE DATABASE / DROP DATABASE freely -- confirmed in the task brief.
+DB_SUPERUSER = "test_user"
+DB_SUPERUSER_PASSWORD = "test_pass"  # pragma: allowlist secret
+MAINTENANCE_DB = "test_db"  # always-present DB used only to issue CREATE/DROP DATABASE
+EPHEMERAL_DB_NAME = "mattin_test_useremail001_e2e"
+
+# useremail001's down_revision -- the pre-fix schema (duplicates possible, no unique constraint).
+PRE_FIX_REVISION = "20260717_conversation_starters"
+POST_FIX_REVISION = "useremail001"
+
+DUPLICATE_EMAIL = "dup-e2e@mattin-test.com"
+
+
+# ---------------------------------------------------------------------------
+# Ephemeral database helpers
+# ---------------------------------------------------------------------------
+
+
+def _admin_connection() -> psycopg2.extensions.connection:
+    """Autocommit psycopg2 connection to the always-present maintenance DB.
+
+    CREATE DATABASE / DROP DATABASE cannot run inside a transaction block, so this
+    connection must be in autocommit mode and must NOT target the ephemeral DB itself.
+    """
+    conn = psycopg2.connect(
+        host=DB_HOST,
+        port=DB_PORT,
+        user=DB_SUPERUSER,
+        password=DB_SUPERUSER_PASSWORD,
+        dbname=MAINTENANCE_DB,
+    )
+    conn.autocommit = True
+    return conn
+
+
+def _drop_ephemeral_db() -> None:
+    conn = _admin_connection()
+    try:
+        with conn.cursor() as cur:
+            # WITH (FORCE) (pg13+, we're on pg17) terminates any lingering connections
+            # first -- Postgres refuses a plain DROP DATABASE while sessions are attached.
+            cur.execute(f'DROP DATABASE IF EXISTS "{EPHEMERAL_DB_NAME}" WITH (FORCE)')
+    finally:
+        conn.close()
+
+
+def _create_ephemeral_db() -> None:
+    _drop_ephemeral_db()  # guard: a prior crashed run may have left it behind
+    conn = _admin_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f'CREATE DATABASE "{EPHEMERAL_DB_NAME}"')
+    finally:
+        conn.close()
+
+
+def _run_alembic(revision: str) -> subprocess.CompletedProcess:
+    """Invoke the real ``alembic`` CLI as a subprocess against the ephemeral DB.
+
+    alembic/env.py builds its target URL from DATABASE_USER / DATABASE_PASSWORD /
+    DATABASE_HOST / DATABASE_PORT / DATABASE_NAME (NOT SQLALCHEMY_DATABASE_URI and NOT
+    TEST_DATABASE_URL) -- see alembic/env.py lines 53-55. We invoke via
+    ``sys.executable -m alembic`` (rather than relying on an ``alembic`` binary being on
+    PATH) so it always runs with the same interpreter/venv as pytest itself, from the
+    repo root so alembic.ini / alembic/ resolve normally.
+    """
+    env = dict(os.environ)
+    env.update(
+        DATABASE_USER=DB_SUPERUSER,
+        DATABASE_PASSWORD=DB_SUPERUSER_PASSWORD,
+        DATABASE_HOST=DB_HOST,
+        DATABASE_PORT=DB_PORT,
+        DATABASE_NAME=EPHEMERAL_DB_NAME,
+    )
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", revision],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+@pytest.fixture
+def ephemeral_pre_fix_db():
+    """
+    Creates a brand-new ephemeral Postgres database, runs the real ``alembic upgrade``
+    to the revision immediately BEFORE ``useremail001`` (pre-fix schema: duplicate emails
+    possible, no ``uq_user_email`` constraint), and yields a SQLAlchemy engine bound to
+    it. Always drops the database afterward, disposing the engine first so no lingering
+    connections block the DROP DATABASE.
+    """
+    _create_ephemeral_db()
+    engine = None
+    try:
+        result = _run_alembic(PRE_FIX_REVISION)
+        assert result.returncode == 0, (
+            f"alembic upgrade {PRE_FIX_REVISION} failed (rc={result.returncode}).\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
+
+        url = (
+            f"postgresql://{DB_SUPERUSER}:{DB_SUPERUSER_PASSWORD}"
+            f"@{DB_HOST}:{DB_PORT}/{EPHEMERAL_DB_NAME}"
+        )
+        engine = create_engine(url, pool_pre_ping=True)
+        yield engine
+    finally:
+        if engine is not None:
+            engine.dispose()  # release all pooled connections before DROP DATABASE
+        _drop_ephemeral_db()
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+class TestUseremail001MigrationEndToEnd:
+    """Genuine end-to-end coverage of the ``useremail001`` migration against a real,
+    Alembic-built database (not the ORM-metadata-built shared ``test_engine``)."""
+
+    def test_dedupes_users_reassigns_apps_and_adds_unique_constraint(
+        self, ephemeral_pre_fix_db
+    ):
+        engine = ephemeral_pre_fix_db
+
+        # Import ORM classes lazily (after backend/ is on sys.path via tests/conftest.py)
+        # and bind them to a fresh Session against the *ephemeral* engine -- these are the
+        # same declarative classes used app-wide, just pointed at a different database.
+        from models.user import User
+        from models.app import App
+        from models.agent import Agent
+
+        Session = sessionmaker(bind=engine)
+        setup_session = Session()
+        try:
+            # --- Seed the pre-fix duplicate-user scenario -----------------------------
+            user1 = User(email=DUPLICATE_EMAIL, name="Dup User One", is_active=True)
+            user2 = User(email=DUPLICATE_EMAIL, name="Dup User Two", is_active=True)
+            setup_session.add_all([user1, user2])
+            setup_session.flush()  # assign user_id (serial PK) without committing yet
+
+            # user1 is inserted first, so (barring sequence weirdness) user1.user_id <
+            # user2.user_id. Both users end up with an identical activity score (2 owned
+            # apps each, 0 API keys / collaborators / usage / marketplace-usage rows), so
+            # the migration's tie-break rule -- lowest user_id wins -- must pick user1 as
+            # canonical. We assert this explicitly below so the test is deterministic
+            # rather than accidentally passing due to insertion order.
+            assert user1.user_id < user2.user_id, (
+                "sanity: user1 must have the lower user_id for the canonical-tiebreak "
+                "assertion below to be meaningful"
+            )
+
+            apps_by_user = {}
+            agents_by_app = {}
+            for owner in (user1, user2):
+                owned_apps = []
+                for i in range(2):
+                    app_obj = App(
+                        name=f"E2E App {owner.user_id}-{i}",
+                        slug=f"e2e-useremail001-{owner.user_id}-{i}",
+                        owner_id=owner.user_id,
+                        agent_rate_limit=0,
+                        max_file_size_mb=10,
+                    )
+                    setup_session.add(app_obj)
+                    setup_session.flush()
+                    owned_apps.append(app_obj)
+
+                    agent_obj = Agent(
+                        name=f"E2E Agent {owner.user_id}-{i}",
+                        app_id=app_obj.app_id,
+                        type="agent",
+                    )
+                    setup_session.add(agent_obj)
+                    setup_session.flush()
+                    agents_by_app[app_obj.app_id] = agent_obj.agent_id
+
+                apps_by_user[owner.user_id] = [a.app_id for a in owned_apps]
+
+            setup_session.commit()
+
+            canonical_user_id = user1.user_id
+            loser_user_id = user2.user_id
+            all_app_ids = set(apps_by_user[canonical_user_id]) | set(apps_by_user[loser_user_id])
+            assert len(all_app_ids) == 4
+
+            # --- Reproduce-first checkpoint: confirm the pre-fix DB genuinely has 2 --
+            # duplicate rows (proves the setup above actually reproduces the bug state,
+            # and that nothing already enforces uniqueness at this revision) before we
+            # apply the fix and check it goes away.
+            dup_count_before = (
+                setup_session.query(User).filter(User.email == DUPLICATE_EMAIL).count()
+            )
+            assert dup_count_before == 2, (
+                "sanity: expected 2 duplicate User rows before useremail001 runs -- "
+                "if this fails, the test setup isn't reproducing the bug state"
+            )
+        finally:
+            setup_session.close()
+
+        # setup_session is closed and its transaction committed/finished, so no
+        # connections from our own engine hold locks on "User" going into the migration.
+        # Dispose the whole pool defensively before shelling out to alembic.
+        engine.dispose()
+
+        # --- Apply the real fix -------------------------------------------------------
+        result = _run_alembic(POST_FIX_REVISION)
+        assert result.returncode == 0, (
+            f"alembic upgrade {POST_FIX_REVISION} failed (rc={result.returncode}).\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
+
+        # --- Assertions: raw SQL only, decoupled from any ORM session state ----------
+        with engine.connect() as conn:
+            user_rows = conn.execute(
+                text('SELECT user_id, email FROM "User" WHERE email = :email'),
+                {"email": DUPLICATE_EMAIL},
+            ).fetchall()
+            assert len(user_rows) == 1, (
+                f"Expected exactly 1 User row for {DUPLICATE_EMAIL} after useremail001, "
+                f"found {len(user_rows)}: {user_rows}"
+            )
+            assert user_rows[0].user_id == canonical_user_id, (
+                "The surviving User row must be the tie-break winner (lowest user_id, "
+                f"{canonical_user_id}), got {user_rows[0].user_id}"
+            )
+
+            app_rows = conn.execute(
+                text('SELECT app_id, owner_id FROM "App" WHERE app_id = ANY(:ids)'),
+                {"ids": list(all_app_ids)},
+            ).fetchall()
+            assert len(app_rows) == 4, (
+                f"Expected all 4 App rows to survive untouched, found {len(app_rows)}"
+            )
+            assert all(row.owner_id == canonical_user_id for row in app_rows), (
+                "All 4 Apps (including the loser's 2) must now be owned by the "
+                f"canonical user_id {canonical_user_id}: {app_rows}"
+            )
+
+            agent_rows = conn.execute(
+                text('SELECT agent_id, app_id FROM "Agent" WHERE app_id = ANY(:ids)'),
+                {"ids": list(all_app_ids)},
+            ).fetchall()
+            assert len(agent_rows) == 4, (
+                f"Expected all 4 Agent rows to survive untouched, found {len(agent_rows)}"
+            )
+            actual_agent_to_app = {row.agent_id: row.app_id for row in agent_rows}
+            assert actual_agent_to_app == {
+                agent_id: app_id for app_id, agent_id in agents_by_app.items()
+            }, "Each Agent's app_id must be unchanged -- agents are only indirectly " \
+               "affected via their parent App's ownership."
+
+            # --- Schema assertion: uq_user_email constraint exists -----------------
+            constraint_row = conn.execute(
+                text(
+                    "SELECT constraint_name FROM information_schema.table_constraints "
+                    "WHERE table_name = 'User' AND constraint_type = 'UNIQUE' "
+                    "AND constraint_name = 'uq_user_email'"
+                )
+            ).fetchone()
+            assert constraint_row is not None, (
+                "uq_user_email UNIQUE constraint missing after useremail001 upgrade"
+            )
+
+        # --- Schema assertion: the constraint actually rejects a duplicate insert ----
+        # Run in its own connection/transaction so a rolled-back failure here doesn't
+        # taint the `with engine.connect()` block above.
+        with engine.connect() as conn:
+            trans = conn.begin()
+            try:
+                with pytest.raises(IntegrityError):
+                    conn.execute(
+                        text(
+                            'INSERT INTO "User" (email, name, is_active) '
+                            "VALUES (:email, :name, true)"
+                        ),
+                        {"email": DUPLICATE_EMAIL, "name": "Should Be Rejected"},
+                    )
+            finally:
+                trans.rollback()


### PR DESCRIPTION
# Pull Request Template for Mattin AI Repository

## Description

Fixes a race condition where a user's first OIDC (Entra ID) login could create 2-3 duplicate `User` rows for the same email, making them appear multiple times in the user list.

**Root cause:** there is no dedicated backend "OIDC login" endpoint — token exchange happens client-side, and the backend only provisions the DB user as a side effect of a shared FastAPI dependency (`get_current_user_oidc`) used by every protected route. On first login, the SPA fires several protected requests in parallel (e.g. `/internal/me`, `/internal/capabilities`), each hitting `UserService.get_or_create_user`, which did a plain **SELECT-then-INSERT** with no locking. Since `User.email` had no unique constraint, concurrent requests could all pass the "does this user exist?" check before any of them committed its INSERT, so each one created its own row.

This PR closes the race at both layers:
1. A migration merges any duplicate `User` rows already created by this bug (reassigning their apps, API keys, collaborations, subscriptions, and usage data to a single canonical row) and adds a `uq_user_email` unique constraint so it can't happen again.
2. `UserService.get_or_create_user` now catches the `IntegrityError` a losing concurrent request gets from that constraint, rolls back, and returns the winner's row instead of creating a duplicate.

## Related Issue(s)

Fixes the reported bug: "when we activate OIDC with EntraID, a user logs in for the first time and appears created three times / three times in the user list." No tracked issue number was provided — describing in full here.

## Type of Change

* [x] Bug fix (a change that does not break existing functionality and fixes an issue)
* [ ] Feature
* [ ] Documentation
* [ ] Refactor
* [ ] Performance improvement
* [x] Test (adding regression + e2e coverage)
* [ ] Build or infrastructure

## Dependencies Added

None.

## Affected Components

Backend only (FastAPI + Alembic). No frontend changes.

- `backend/services/user_service.py`
- `alembic/versions/useremail001_dedupe_users_add_unique_email.py` (new)

## Implementation Details

**Migration (`useremail001`, revises `20260717_conversation_starters`):**
- For every email shared by more than one `User` row, picks a canonical row by activity score (`count(owned App) + count(APIKey) + count(AppCollaborator) + count(usage_records) + count(MarketplaceUsage)`), tie-broken by lowest `user_id` (oldest).
- Reassigns FK'd data from the "loser" rows to the canonical row: `App.owner_id`, `APIKey.user_id`, `AppCollaborator.user_id`/`invited_by`, `Conversation.user_id`, `crawl_job.triggered_by_user_id`. For unique-per-user data (`subscriptions`, `user_credentials`) it reassigns only if the canonical row doesn't already have one. For period-keyed usage data (`usage_records`, `MarketplaceUsage`) it sums overlapping periods rather than blindly repointing. For `AgentMarketplaceRating`, the most recently updated rating wins on a same-profile collision.
- Deletes the loser `User` rows, then adds `uq_user_email` on `"User".email`.
- **This is a one-way data migration** — the row merge itself is not reversible (counters were summed, duplicate rows deleted). `downgrade()` only drops the constraint; it does not attempt to reconstitute merged data. Recommend a DB backup/snapshot before running against production, even though the migration was verified against a realistic worst-case fixture (see Testing below).

**Application fix (`UserService.get_or_create_user`, `backend/services/user_service.py`):**
- Wraps the INSERT in `try/except IntegrityError`: on conflict, rolls back and re-fetches the row the winning concurrent request created, so every caller converges on one row instead of erroring or duplicating.
- No change to `UserRepository.create` — the exception surfaces naturally from its own `commit()`.

No new environment variables or config.

## How to Test

1. Start the test DB: `docker compose -f docker/docker-compose.yaml --profile test up -d db_test`
2. Run the regression test for the race itself (reproduce-first — fails on the pre-fix code with a real `IntegrityError`, passes with the fix):
   ```bash
   SQLALCHEMY_DATABASE_URI="postgresql://test_user:test_pass@localhost:5433/test_db" \
     pytest tests/integration/test_oidc_duplicate_user_race.py -v
   ```
3. Run the end-to-end migration test — provisions a real ephemeral Postgres DB, runs the actual `alembic upgrade` CLI to the pre-fix revision, seeds 2 duplicate users each owning 2 apps with an agent (4 apps + 4 agents total), runs `alembic upgrade head`, and asserts the merge landed correctly (1 surviving user, all 4 apps reassigned, all 4 agents untouched, constraint present and enforced):
   ```bash
   SQLALCHEMY_DATABASE_URI="postgresql://test_user:test_pass@localhost:5433/test_db" \
     pytest tests/integration/test_useremail001_migration_e2e.py -v
   ```
4. Full suite for regressions: `pytest tests/unit tests/integration -q`. Note: this repo currently has ~77 pre-existing failures on `develop` unrelated to this change (confirmed via stash-based A/B comparison on a freshly-reset test DB — version-mismatch issues like `TestClient.delete() got an unexpected keyword argument 'json'`).
5. Migration rollback check: `alembic downgrade -1` should cleanly drop `uq_user_email` with no errors (the data merge itself is not undone — see note above).

## Checklist

* [x] Commit messages follow Conventional Commits (`type(scope): description`).
* [x] I have read the contributing guidelines and my change adheres to the coding standards of this project.
* [x] I have added tests that prove my fix works (race regression test + full migration e2e test).
* [x] I have run all existing tests and they all pass locally (excluding the ~77 pre-existing, unrelated failures noted above).
* [ ] I have updated any relevant documentation, configuration files, or environment examples as needed. *(none needed — no config/behavior surface change beyond the fix itself)*
* [x] I have considered backwards compatibility — existing single-user rows are untouched by the migration; only actual duplicates are merged.
* [ ] For UI changes, I have included relevant screenshots or screencasts. *(no UI changes)*

## Additional Notes

- **Run the migration before/alongside deploying the app change** — the application-level fix only holds once `uq_user_email` exists in the target database.
- Edge case accepted as-is (documented in the migration's docstring and logged via `RAISE NOTICE` at migration time): if *both* duplicate rows already had their own `subscriptions` or `user_credentials` row (1:1, unique per user) before the merge, the loser's row is dropped via cascade rather than merged — this should be rare, since neither is auto-created at OIDC signup, only on later billing/credential-linking actions.
- Frontend hardening (e.g. guarding `OIDCProvider`'s callback effect against React StrictMode double-invocation) was investigated but intentionally left out of scope — the backend race is the actual, production-relevant root cause regardless of how many parallel/duplicate requests the client fires.
