### PR TITLE
fix(backend): remove unused app_id from ConversationResponse

### DIFF
--- a/backend/routers/internal/marketplace.py
+++ b/backend/routers/internal/marketplace.py
@@ -295,7 +295,6 @@ async def get_marketplace_conversation(
         )
         return ConversationWithHistoryResponse(
             **conversation.to_dict(),
-            app_id=conversation.agent.app_id,
             messages=history or [],
         )
     except Exception as e:

--- a/backend/schemas/conversation_schemas.py
+++ b/backend/schemas/conversation_schemas.py
@@ -24,7 +24,6 @@ class ConversationResponse(ConversationBase):
     """Schema for conversation response"""
     conversation_id: int
     agent_id: int
-    app_id: int
     user_id: Optional[int] = None
     session_id: str
     created_at: datetime

--- a/tests/integration/test_conversations_router.py
+++ b/tests/integration/test_conversations_router.py
@@ -1,0 +1,240 @@
+"""
+Integration tests for the conversations endpoints.
+
+Endpoints under test (backend/routers/internal/conversations.py):
+  - POST   /internal/conversations                            (create conversation)
+  - GET    /internal/conversations?agent_id=...                (list conversations)
+  - GET    /internal/conversations/{conversation_id}           (get conversation)
+  - GET    /internal/conversations/{conversation_id}/history   (get conversation + message history)
+  - PATCH  /internal/conversations/{conversation_id}           (update conversation)
+
+Regression coverage:
+  `ConversationResponse` (backend/schemas/conversation_schemas.py) used to declare
+  a required `app_id: int` field that nothing ever populated -- no column on the
+  `Conversation` ORM model, no service logic setting it. Every endpoint here that
+  serializes a raw `Conversation` ORM object through `ConversationResponse` (or
+  `ConversationWithHistoryResponse`, which inherits from it) raised a Pydantic
+  `ResponseValidationError` ("Field required [type=missing] ... app_id"), i.e. a
+  500 on every call. This suite exercises the full router with zero mocking of
+  the response schema to catch any regression of that bug.
+"""
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Create conversation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateConversation:
+    """POST /internal/conversations"""
+
+    def test_create_conversation_returns_200_with_expected_fields(
+        self, client, fake_agent, auth_headers, db
+    ):
+        db.flush()
+        response = client.post(
+            f"/internal/conversations?agent_id={fake_agent.agent_id}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert isinstance(body["conversation_id"], int)
+        assert body["agent_id"] == fake_agent.agent_id
+        assert body["session_id"].startswith(f"conv_{fake_agent.agent_id}_")
+        assert body["message_count"] == 0
+        assert body["last_message"] is None
+        assert "created_at" in body
+        assert "updated_at" in body
+        # The bug reported app_id as a required-but-unpopulated field on this
+        # schema; it must not be present anymore (it was removed entirely).
+        assert "app_id" not in body
+
+    def test_create_conversation_with_title(self, client, fake_agent, auth_headers, db):
+        db.flush()
+        response = client.post(
+            "/internal/conversations",
+            headers=auth_headers,
+            params={"agent_id": fake_agent.agent_id, "title": "My Chat"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["title"] == "My Chat"
+
+    def test_create_conversation_without_title_gets_auto_title(
+        self, client, fake_agent, auth_headers, db
+    ):
+        db.flush()
+        response = client.post(
+            f"/internal/conversations?agent_id={fake_agent.agent_id}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["title"]  # auto-generated, non-empty
+
+
+# ---------------------------------------------------------------------------
+# List conversations
+# ---------------------------------------------------------------------------
+
+
+class TestListConversations:
+    """GET /internal/conversations?agent_id=..."""
+
+    def test_list_conversations_after_create(self, client, fake_agent, auth_headers, db):
+        """
+        Regression test for the app_id ResponseValidationError bug.
+
+        Prior to the fix, `ConversationResponse` required an `app_id: int`
+        field that nothing populated, so this endpoint raised a 500
+        ResponseValidationError (`Field required [type=missing] ... app_id`)
+        for any Conversation ORM object serialized through it -- meaning
+        listing conversations was completely broken.
+        """
+        db.flush()
+        create_resp = client.post(
+            f"/internal/conversations?agent_id={fake_agent.agent_id}",
+            headers=auth_headers,
+        )
+        assert create_resp.status_code == 200
+        created_id = create_resp.json()["conversation_id"]
+
+        list_resp = client.get(
+            "/internal/conversations",
+            headers=auth_headers,
+            params={"agent_id": fake_agent.agent_id},
+        )
+
+        assert list_resp.status_code == 200
+        body = list_resp.json()
+        assert body["total"] == 1
+        assert len(body["conversations"]) == 1
+        assert body["conversations"][0]["conversation_id"] == created_id
+        assert "app_id" not in body["conversations"][0]
+
+    def test_list_conversations_empty_for_agent_with_none(
+        self, client, fake_agent, auth_headers, db
+    ):
+        db.flush()
+        response = client.get(
+            "/internal/conversations",
+            headers=auth_headers,
+            params={"agent_id": fake_agent.agent_id},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 0
+        assert body["conversations"] == []
+
+
+# ---------------------------------------------------------------------------
+# Get conversation
+# ---------------------------------------------------------------------------
+
+
+class TestGetConversation:
+    """GET /internal/conversations/{conversation_id}"""
+
+    def test_get_conversation_by_id(self, client, fake_agent, auth_headers, db):
+        db.flush()
+        created = client.post(
+            f"/internal/conversations?agent_id={fake_agent.agent_id}",
+            headers=auth_headers,
+        ).json()
+
+        response = client.get(
+            f"/internal/conversations/{created['conversation_id']}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["conversation_id"] == created["conversation_id"]
+        assert body["agent_id"] == fake_agent.agent_id
+
+    def test_get_conversation_not_found_returns_404(self, client, auth_headers, db):
+        response = client.get(
+            "/internal/conversations/999999",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Get conversation history
+# ---------------------------------------------------------------------------
+
+
+class TestGetConversationHistory:
+    """GET /internal/conversations/{conversation_id}/history"""
+
+    def test_history_is_empty_for_fresh_conversation(
+        self, client, fake_agent, auth_headers, db
+    ):
+        """A freshly created conversation has no LangGraph checkpointer
+        messages yet, so `messages` must come back as an empty list."""
+        db.flush()
+        created = client.post(
+            f"/internal/conversations?agent_id={fake_agent.agent_id}",
+            headers=auth_headers,
+        ).json()
+
+        response = client.get(
+            f"/internal/conversations/{created['conversation_id']}/history",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["conversation_id"] == created["conversation_id"]
+        assert body["messages"] == []
+        assert "app_id" not in body
+
+    def test_history_not_found_returns_404(self, client, auth_headers, db):
+        response = client.get(
+            "/internal/conversations/999999/history",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Update conversation
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateConversation:
+    """PATCH /internal/conversations/{conversation_id}"""
+
+    def test_update_title(self, client, fake_agent, auth_headers, db):
+        db.flush()
+        created = client.post(
+            f"/internal/conversations?agent_id={fake_agent.agent_id}",
+            headers=auth_headers,
+        ).json()
+
+        response = client.patch(
+            f"/internal/conversations/{created['conversation_id']}",
+            headers=auth_headers,
+            json={"title": "New Title"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["title"] == "New Title"
+        assert body["conversation_id"] == created["conversation_id"]
+
+    def test_update_not_found_returns_404(self, client, auth_headers, db):
+        response = client.patch(
+            "/internal/conversations/999999",
+            headers=auth_headers,
+            json={"title": "New Title"},
+        )
+
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary

- `ConversationResponse.app_id: int` (`backend/schemas/conversation_schemas.py`) was added by an unrelated commit ("Primer fix", 835fa03) with no backing `Conversation` model column, no service logic, and no frontend consumer. Since `ConversationWithHistoryResponse` inherits from it, and every endpoint in `backend/routers/internal/conversations.py` (create, list, get, get-with-history, update) serializes a raw `Conversation` ORM object through one of these schemas via `from_attributes=True`, **all 5 endpoints raised a `ResponseValidationError`** (`Field required ... app_id`) — reported while manually testing the playground conversation list.
- A follow-up commit ("Arreglo errores 2", 7f04a22) patched around this for the marketplace routes only (a separate `MarketplaceConversationResponse` without the field, plus manually passing `app_id=conversation.agent.app_id` in one spot) but never touched the playground router.
- Confirmed via repo-wide grep that nothing — backend or frontend — reads `app_id` off a conversation object, so this PR removes the field entirely rather than wiring it up everywhere (which would also require handling that `Agent.app_id` is nullable).

## Changes

- Remove `app_id: int` from `ConversationResponse`.
- Remove the now-pointless `app_id=conversation.agent.app_id` workaround in `marketplace.py`'s `get_marketplace_conversation`.
- Add `tests/integration/test_conversations_router.py` (11 tests) — previously zero coverage existed for this router. Reproduce-first verified: fails with the exact reported error when `app_id` is re-added, passes with the fix.

## Test plan

- [x] New tests pass: `pytest tests/integration/test_conversations_router.py -v`
- [x] Reproduce-first: temporarily restored the broken schema, confirmed the identical `ResponseValidationError` on `app_id`, then reverted
- [x] Full suite shows no new regressions: `pytest tests/unit tests/integration -q` (pre-existing unrelated failure count unchanged)
- [x] Manually verified in a running instance against real data (agent with existing conversations) that the playground conversation list now loads