### PR TITLE
Fix/navigation

### DIFF
--- a/frontend/src/components/header/PageTitle.tsx
+++ b/frontend/src/components/header/PageTitle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams, Link } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
 import type { NavigationConfig, NavigationItem } from '../../core/types';
 
@@ -9,6 +9,7 @@ interface PageTitleProps {
 
 interface TitlePart {
   label: string;
+  path?: string;
 }
 
 const TOP_LEVEL_PATHS = new Set(['/home', '/marketplace', '/apps', '/about', '/profile']);
@@ -77,22 +78,33 @@ export const PageTitle: React.FC<PageTitleProps> = ({ navigationConfig }) => {
 
   // Settings sub-routes
   if (pathname !== settingsBase && pathname.startsWith(settingsBase + '/')) {
-    parts.push({ label: 'App Settings' });
+    parts.push({ 
+      label: 'App Settings',
+      path: settingsBase,
+    });
     const label = pathLookup.get(pathname);
-    parts.push({ label: label || 'Edit' });
+    parts.push({
+      label: label || 'Edit',
+    });
     return renderTitle(parts);
   }
 
   // Settings page itself
   if (pathname === settingsBase) {
-    parts.push({ label: 'App Settings' });
+    parts.push({
+      label: 'App Settings',
+      path: settingsBase,
+    });
     return renderTitle(parts);
   }
 
   // Direct match (e.g. /apps/:appId/agents)
   const directLabel = pathLookup.get(pathname);
   if (directLabel) {
-    parts.push({ label: directLabel });
+    parts.push({
+      label: directLabel,
+      path: pathname,
+    });
     return renderTitle(parts);
   }
 
@@ -102,7 +114,10 @@ export const PageTitle: React.FC<PageTitleProps> = ({ navigationConfig }) => {
     const candidatePath = '/' + segments.slice(0, i).join('/');
     const candidateLabel = pathLookup.get(candidatePath);
     if (candidateLabel) {
-      parts.push({ label: candidateLabel });
+      parts.push({
+        label: candidateLabel,
+        path: candidatePath,
+      });
       const lastSegment = segments[segments.length - 1];
       parts.push({ label: SUFFIX_LABELS[lastSegment] || 'Edit' });
       break;
@@ -123,15 +138,24 @@ function renderTitle(parts: TitlePart[]): React.ReactElement | null {
           {index > 0 && (
             <ChevronRight size={14} className="text-gray-400 flex-shrink-0" />
           )}
-          <span
-            className={
-              index === parts.length - 1 && parts.length > 1
-                ? 'text-sm text-gray-500'
-                : 'text-sm font-medium text-gray-700'
-            }
-          >
-            {part.label}
-          </span>
+          {part.path ? (
+            <Link
+              to={part.path}
+              className="text-sm font-medium text-gray-700 hover:text-blue-600 hover:underline"
+            >
+              {part.label}
+            </Link>
+          ) : (
+            <span
+              className={
+                index === parts.length - 1 && parts.length > 1
+                  ? 'text-sm text-gray-500'
+                  : 'text-sm font-medium text-gray-700'
+              }
+            >
+              {part.label}
+            </span>
+          )}
         </React.Fragment>
       ))}
     </div>

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -93,6 +93,14 @@ interface AgentFormData {
   rag_fixed_filters: RagFixedFilter[];
 }
 
+interface AgentFormDraft {
+  formData: AgentFormData;
+  activeTab: string;
+  showOutputParser: boolean;
+}
+
+const AGENT_FORM_DRAFT_STORAGE_PREFIX = 'agent-form-draft';
+
 // Output Parser Field Component
 const OutputParserField = ({
   showOutputParser,
@@ -228,6 +236,7 @@ function AgentFormPage() {
   const [showOutputParser, setShowOutputParser] = useState(false);
   const [siloMetadataFields, setSiloMetadataFields] = useState<SearchFilterMetadataField[]>([]);
   const [loadingSiloMetadata, setLoadingSiloMetadata] = useState(false);
+  const draftHydratedRef = useRef(false);
 
   // Marketplace state
   const [showMarketplace, setShowMarketplace] = useState(false);
@@ -242,6 +251,27 @@ function AgentFormPage() {
     cover_image_url: null,
     conversation_starters: [],
   });
+
+  const isNewAgent = Number.parseInt(agentId || '0') === 0;
+  const draftStorageKey = appId
+    ? `${AGENT_FORM_DRAFT_STORAGE_PREFIX}:${appId}`
+    : null;
+
+    const normalizeDraftFilters = useCallback((filters: RagFixedFilter[] = []) => {
+      return filters.map((filter) => ({
+        ...filter,
+        _key: filter._key ?? Math.random().toString(36).slice(2),
+      }));
+    }, []);
+
+    const clearDraft = useCallback(() => {
+      if (!draftStorageKey) return;
+      try {
+        sessionStorage.removeItem(draftStorageKey);
+      } catch (err) {
+        console.warn('Failed to clear agent form draft from session storage:', err);
+      }
+    }, [draftStorageKey]);
 
   // Load agent data when component mounts
   useEffect(() => {
@@ -287,7 +317,7 @@ function AgentFormPage() {
       setAgent(response);
 
       // Initialize form data
-      setFormData({
+      const initialFormData: AgentFormData = {
         name: response.name || '',
         description: response.description || '',
         system_prompt: response.system_prompt || '',
@@ -317,14 +347,43 @@ function AgentFormPage() {
         rag_search_type: response.rag_search_type ?? 'similarity',
         rag_score_threshold: response.rag_score_threshold ?? null,
         rag_max_retrieval_calls: response.rag_max_retrieval_calls ?? 4,
-        rag_fixed_filters: (response.rag_fixed_filters ?? []).map((f) => ({
-          ...f,
-          _key: Math.random().toString(36).slice(2),
-        }))
-      });
+        rag_fixed_filters: normalizeDraftFilters(response.rag_fixed_filters ?? [])
+      };
+
+      let nextFormData = initialFormData;
+      let nextShowOutputParser = !!response.output_parser_id;
+      let nextActiveTab = 'basic';
+
+      if (Number.parseInt(agentId) === 0 && draftStorageKey) {
+        try {
+          const rawDraft = sessionStorage.getItem(draftStorageKey);
+          if (rawDraft) {
+            const parsedDraft = JSON.parse(rawDraft) as Partial<AgentFormDraft>;
+            if (parsedDraft.formData) {
+              nextFormData = {
+                ...initialFormData,
+                ...parsedDraft.formData,
+                rag_fixed_filters: normalizeDraftFilters(parsedDraft.formData.rag_fixed_filters ?? []),
+              };
+            }
+            if (typeof parsedDraft.showOutputParser === 'boolean') {
+              nextShowOutputParser = parsedDraft.showOutputParser;
+            }
+            if (typeof parsedDraft.activeTab === 'string') {
+              nextActiveTab = parsedDraft.activeTab;
+            }
+          }
+        } catch (draftErr) {
+          console.warn('Failed to restore agent form draft from session storage:', draftErr);
+        }
+      }
+
+      setFormData(nextFormData);
 
       // Set output parser toggle based on whether agent has an output parser
-      setShowOutputParser(!!response.output_parser_id);
+      setShowOutputParser(nextShowOutputParser);
+      setActiveTab(nextActiveTab);
+      draftHydratedRef.current = true;
 
       // Load MCP usage and marketplace profile for existing agents
       if (Number.parseInt(agentId) !== 0) {
@@ -362,9 +421,26 @@ function AgentFormPage() {
       setError(err instanceof Error ? err.message : 'Failed to load agent data');
       console.error('Error loading agent data:', err);
     } finally {
+      if (Number.parseInt(agentId) !== 0) {
+        draftHydratedRef.current = true;
+      }
       setLoading(false);
     }
   }
+
+  useEffect(() => {
+    if (!isNewAgent || !draftStorageKey || !draftHydratedRef.current) return;
+    const draft: AgentFormDraft = {
+      formData,
+      activeTab,
+      showOutputParser,
+    };
+    try {
+      sessionStorage.setItem(draftStorageKey, JSON.stringify(draft));
+    } catch (err) {
+      console.warn('Failed to persist agent form draft to session storage:', err);
+    }
+  }, [isNewAgent, draftStorageKey, formData, activeTab, showOutputParser]);
 
   const handleInputChange = (field: keyof AgentFormData, value: any) => {
     setFormData(prev => ({
@@ -549,11 +625,12 @@ function AgentFormPage() {
     setSaving(false);
 
     if (result !== undefined) {
+      if (isNew) {
+        clearDraft();
+      }
       navigate(`/apps/${appId}/agents`);
     }
   };
-
-  const isNewAgent = Number.parseInt(agentId || '0') === 0;
 
   if (loading) {
     return (
@@ -591,7 +668,12 @@ function AgentFormPage() {
             </p>
           </div>
           <button
-            onClick={() => navigate(`/apps/${appId}/agents`)}
+            onClick={() => {
+              if (isNewAgent) {
+                clearDraft();
+              }
+              navigate(`/apps/${appId}/agents`);
+            }}
             className="flex items-center px-6 py-3 bg-white hover:bg-gray-50 rounded-xl text-gray-700 shadow-sm border border-gray-200 transition-all duration-200"
           >
             <ArrowLeft className="w-4 h-4 mr-2" />
@@ -1667,7 +1749,12 @@ function AgentFormPage() {
           <div className="flex justify-end space-x-4 mt-8 pt-6 border-t border-gray-200">
             <button
               type="button"
-              onClick={() => navigate(`/apps/${appId}/agents`)}
+              onClick={() => {
+                if (isNewAgent) {
+                  clearDraft();
+                }
+                navigate(`/apps/${appId}/agents`);
+              }}
               className="px-8 py-3 bg-gray-100 hover:bg-gray-200 text-gray-800 rounded-xl font-medium transition-all duration-200"
               disabled={saving}
             >

--- a/frontend/src/pages/admin/SystemAIServicesPage.tsx
+++ b/frontend/src/pages/admin/SystemAIServicesPage.tsx
@@ -169,7 +169,15 @@ const SystemAIServicesPage: React.FC = () => {
             ) : (
               services.map((svc) => (
                 <tr key={svc.service_id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{svc.name}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    <button
+                      type="button"
+                      className="text-sm font-medium text-gray-900 hover:text-blue-600 transition-colors text-left"
+                      onClick={() => void handleOpenEdit(svc)}
+                    >
+                      {svc.name}
+                    </button>
+                  </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
                     {svc.provider}
                   </td>

--- a/frontend/src/pages/admin/SystemEmbeddingServicesPage.tsx
+++ b/frontend/src/pages/admin/SystemEmbeddingServicesPage.tsx
@@ -229,7 +229,15 @@ const SystemEmbeddingServicesPage: React.FC = () => {
             ) : (
               services.map((svc) => (
                 <tr key={svc.service_id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{svc.name}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    <button
+                      type="button"
+                      className="text-sm font-medium text-gray-900 hover:text-blue-600 transition-colors text-left"
+                      onClick={() => void handleOpenEdit(svc)}
+                    >
+                      {svc.name}
+                    </button>
+                  </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
                     {svc.provider}
                   </td>

--- a/frontend/src/pages/settings/AIServicesPage.tsx
+++ b/frontend/src/pages/settings/AIServicesPage.tsx
@@ -22,6 +22,7 @@ interface AIService {
   model_name: string;
   created_at: string;
   needs_api_key?: boolean;
+  is_system?: boolean;
 }
 
 function AIServicesPage() {
@@ -208,13 +209,22 @@ function AIServicesPage() {
           {
             header: 'Name',
             render: (service: AIService) => (
-              canEdit ? (
-                <button type="button" className="text-sm font-medium text-gray-900 hover:text-blue-600 transition-colors text-left" onClick={() => handleEdit(service.service_id)}>
-                  {service.name}
-                </button>
-              ) : (
-                <span className="text-sm font-medium text-gray-900">{service.name}</span>
-              )
+              <span className="flex items-center gap-1.5">
+                {canEdit && !service.is_system ? (
+                  <button 
+                    type="button"
+                    className="text-sm font-medium text-gray-900 hover:text-blue-600 transition-colors text-left"
+                    onClick={() => handleEdit(service.service_id)}
+                  >
+                    {service.name}
+                  </button>
+                ) : (
+                  <span className="text-sm font-medium text-gray-900">{service.name}</span>
+                )}
+                {service.is_system && (
+                  <span className="ml-1 text-xs font-medium text-blue-700 bg-blue-100 px-1.5 py-0.5 rounded">System</span>
+                )}
+              </span>
             )
           },
           { header: 'Model', accessor: 'model_name' },
@@ -236,7 +246,9 @@ function AIServicesPage() {
           )},
           { header: 'Created', render: (service: any) => (service.created_at ? new Date(service.created_at).toLocaleDateString() : 'N/A') },
           { header: 'Actions', className: 'relative', render: (service: AIService) => (
-            canEdit ? (
+            service.is_system ? (
+              <span className="text-gray-400 text-sm">System</span>
+            ) : canEdit ? (
               <ActionDropdown actions={[
                 {
                   label: testingServiceId === service.service_id ? 'Testing...' : 'Test Connection',


### PR DESCRIPTION
## Description

This pull request introduces several usability improvements across the frontend focused on navigation, form persistence, and service management.

### Main changes

- Added clickable breadcrumb navigation in `PageTitle` so users can easily navigate back to parent sections directly from the page header.
- Implemented draft persistence for new agent creation forms using `sessionStorage`. Users can now leave the page and return without losing their progress while creating a new agent.
- Added automatic draft cleanup when a new agent is successfully created or when the creation flow is explicitly cancelled.
- Improved AI Services and Embedding Services administration pages by allowing service records to be opened for editing directly by clicking on the service name.
- Added support for displaying system-managed AI services in the application settings UI, including:
  - Visual identification through a "System" badge.
  - Prevention of editing actions for system-level services.
  - Read-only presentation of system services while preserving edit capabilities for user-managed services.

These changes improve overall user experience, reduce the risk of accidental data loss during agent creation, and provide clearer distinction between system-managed and user-managed AI service configurations.

## Type of Change

- [x] Bug fix (a change that does not break existing functionality and fixes an issue)
- [ ] Feature (a change that does not break existing functionality and adds new functionality)
- [ ] Documentation (updates or adds documentation only)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Performance improvement
- [ ] Test (adding or updating tests)
- [ ] Build or infrastructure (changes to tooling, deployment scripts, CI/CD, etc.)

## Affected Components

**Frontend (React)**

Affected modules:

- `frontend/src/components/header/PageTitle.tsx`
- `frontend/src/pages/AgentFormPage.tsx`
- `frontend/src/pages/admin/SystemAIServicesPage.tsx`
- `frontend/src/pages/admin/SystemEmbeddingServicesPage.tsx`
- `frontend/src/pages/settings/AIServicesPage.tsx`

## Implementation Details

### Breadcrumb navigation

`PageTitle` was enhanced to support route-aware breadcrumb links by adding an optional `path` property to breadcrumb items. Parent navigation entries are now rendered using `react-router-dom`'s `Link` component, allowing users to navigate directly from the header.

### Agent form draft persistence

A draft mechanism was added for new agent creation flows:

- Drafts are stored in `sessionStorage` using an application-scoped key (`agent-form-draft:<appId>`).
- Persisted information includes:
  - Form data
  - Active tab
  - Output parser visibility state
- Drafts are automatically restored when reopening the new-agent page.
- `rag_fixed_filters` are normalized during draft restoration to ensure valid internal keys.
- Draft saving only applies to new agents (`agentId = 0`).

### Draft cleanup

Draft data is automatically removed when:

- A new agent is successfully created.
- The user cancels the creation process and navigates back to the agents list.

This prevents stale draft data from being unintentionally reused.

### Service management improvements

For both AI Services and Embedding Services administration pages:

- Service names are now rendered as clickable actions.
- Clicking the service name opens the existing edit flow directly, reducing the number of clicks required to manage a service.

### System service handling

The AI Services settings page now supports backend-provided `is_system` metadata:

- System services display a dedicated "System" badge.
- System services cannot be edited.
- Action menus are disabled for system-managed entries.
- User-managed services continue to behave as before.

No API contract changes or environment variable changes were introduced.

## How to Test

### Breadcrumb navigation

1. Navigate to an application settings page.
2. Verify that breadcrumb items are displayed as links.
3. Click a parent breadcrumb.
4. Confirm that navigation redirects to the expected page.

### Agent draft persistence

1. Open the "Create Agent" page.
2. Fill multiple fields across different tabs.
3. Navigate away from the page or refresh the browser tab.
4. Return to the create-agent page.
5. Verify that:
   - Form values are restored.
   - The previously selected tab is restored.
   - Output Parser visibility state is restored.

### Draft cleanup

1. Create a draft on a new agent form.
2. Click **Cancel**.
3. Reopen the create-agent page.
4. Verify the form is reset.

Repeat the test by creating an agent successfully and verifying that no draft is restored afterwards.

### Service edit shortcuts

1. Navigate to:
   - System AI Services
   - System Embedding Services
2. Click a service name.
3. Verify that the corresponding edit dialog/page opens.

### System service behavior

1. Open AI Services settings.
2. Verify that system services display a **System** badge.
3. Confirm that system services:
   - Cannot be edited by clicking the name.
   - Do not expose editable actions.
4. Verify that non-system services remain editable.

## Checklist

- [x] Commit messages follow Conventional Commits (`type(scope): description`).
- [x] I have read the contributing guidelines and my change adheres to the coding standards of this project (see `docs/README.md#contributing`).
- [ ] I have added tests that prove my fix or feature works, or confirm that tests are not needed for this change.
- [ ] I have run all existing tests and they all pass locally.
- [ ] I have updated any relevant documentation, configuration files, or environment examples as needed.
- [x] I have considered backwards compatibility and ensured that my change does not break existing functionality.
- [ ] For UI changes, I have included relevant screenshots or screencasts.

## Additional Notes

- No breaking changes.
- No database migrations required.
- No backend changes required.
- Draft persistence uses browser `sessionStorage`, meaning data is retained only for the active browser session and is automatically cleared when the session ends.
- System service restrictions are enforced at the UI layer to clearly distinguish platform-managed resources from user-managed configurations.