### PR TITLE
Add new data type Enum creation possibility

### DIFF
--- a/alembic/versions/enums001_add_output_parser_enums.py
+++ b/alembic/versions/enums001_add_output_parser_enums.py
@@ -1,0 +1,24 @@
+"""add output parser enum support
+
+Revision ID: enums001
+Revises: ec5b82391242
+Create Date: 2026-08-05 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'enums001'
+down_revision = 'ec5b82391242'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'OutputParser',
+        sa.Column('is_enum', sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade():
+    op.drop_column('OutputParser', 'is_enum')

--- a/backend/models/output_parser.py
+++ b/backend/models/output_parser.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, JSON, ForeignKey, DateTime
+from sqlalchemy import Column, Integer, String, JSON, ForeignKey, DateTime, Boolean
 from sqlalchemy.orm import relationship
 from db.database import Base
 from datetime import datetime
@@ -10,6 +10,7 @@ class OutputParser(Base):
     description = Column(String(1000))
     create_date = Column(DateTime, default=datetime.now)
     fields = Column(JSON)
+    is_enum = Column(Boolean, nullable=False, default=False, server_default='false')
     app_id = Column(Integer,
                     ForeignKey('App.app_id'),
                     nullable=True)

--- a/backend/repositories/agent_repository.py
+++ b/backend/repositories/agent_repository.py
@@ -232,9 +232,9 @@ class AgentRepository:
     
     @staticmethod
     def get_output_parsers_by_app_id(db: Session, app_id: int) -> List[OutputParser]:
-        """Get all output parsers for a specific app"""
+        """Get data structures available for agent output configuration."""
         parser_repo = OutputParserRepository()
-        return parser_repo.get_by_app_id(db, app_id)
+        return parser_repo.get_available_parsers_for_app(db, app_id)
     
     @staticmethod
     def get_mcp_configs_by_app_id(db: Session, app_id: int) -> List[MCPConfig]:

--- a/backend/repositories/output_parser_repository.py
+++ b/backend/repositories/output_parser_repository.py
@@ -23,12 +23,22 @@ class OutputParserRepository:
     
     def get_available_parsers_for_app(self, db: Session, app_id: int, exclude_parser_id: Optional[int] = None) -> List[OutputParser]:
         """Get available parsers for references (excluding specified parser to prevent self-reference)"""
-        query = db.query(OutputParser).filter(OutputParser.app_id == app_id)
+        query = db.query(OutputParser).filter(
+            OutputParser.app_id == app_id,
+            OutputParser.is_enum.is_(False),
+        )
         
         if exclude_parser_id is not None:
             query = query.filter(OutputParser.parser_id != exclude_parser_id)
             
         return query.all()
+
+    def get_available_enums_for_app(self, db: Session, app_id: int) -> List[OutputParser]:
+        """Get enum definitions available for field references."""
+        return db.query(OutputParser).filter(
+            OutputParser.app_id == app_id,
+            OutputParser.is_enum.is_(True),
+        ).all()
     
     def create(self, db: Session, parser: OutputParser) -> OutputParser:
         """Create a new output parser"""

--- a/backend/routers/internal/output_parsers.py
+++ b/backend/routers/internal/output_parsers.py
@@ -60,6 +60,17 @@ async def list_output_parsers(
         )
 
 
+@output_parsers_router.get("/enums/", summary="List enums", tags=["Output Parsers"], response_model=List[OutputParserListItemSchema])
+async def list_enums(
+    app_id: int,
+    current_user: Annotated[dict, Depends(get_current_user_oauth)],
+    db: Annotated[Session, Depends(get_db)],
+    role: Annotated[AppRole, Depends(require_min_role("viewer"))],
+):
+    service = OutputParserService()
+    return service.list_enums(db, app_id)
+
+
 # ==================== STATIC ROUTES (without {{parser_id}} parameter) ====================
 
 
@@ -152,6 +163,21 @@ async def get_output_parser(
         )
 
 
+@output_parsers_router.get("/enums/{parser_id}", summary="Get enum details", tags=["Output Parsers"], response_model=OutputParserDetailSchema)
+async def get_enum(
+    app_id: int,
+    parser_id: int,
+    current_user: Annotated[dict, Depends(get_current_user_oauth)],
+    db: Annotated[Session, Depends(get_db)],
+    role: Annotated[AppRole, Depends(require_min_role("viewer"))],
+):
+    service = OutputParserService()
+    result = service.get_output_parser_detail(db, app_id, parser_id, is_enum=True)
+    if result is None or not result.is_enum:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Enum not found")
+    return result
+
+
 @output_parsers_router.post("/{parser_id}",
                             summary="Create or update output parser",
                             tags=["Output Parsers"],
@@ -168,6 +194,8 @@ async def create_or_update_output_parser(
     Create a new output parser or update an existing one.
     """
     try:
+        if parser_data.is_enum:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Use the enum endpoint for enum definitions")
         service = OutputParserService()
         parser = service.create_or_update_output_parser(db, app_id, parser_id, parser_data)
         
@@ -188,6 +216,27 @@ async def create_or_update_output_parser(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error creating/updating output parser: {str(e)}"
         )
+
+
+@output_parsers_router.post("/enums/{parser_id}", response_model=OutputParserDetailSchema)
+async def create_or_update_enum(
+    app_id: int,
+    parser_id: int,
+    parser_data: CreateUpdateOutputParserSchema,
+    current_user: Annotated[dict, Depends(get_current_user_oauth)],
+    db: Annotated[Session, Depends(get_db)],
+    role: Annotated[AppRole, Depends(require_min_role("administrator"))],
+):
+    parser_data.is_enum = True
+    service = OutputParserService()
+    if parser_id != 0:
+        existing = service.repository.get_by_id_and_app_id(db, parser_id, app_id)
+        if existing is None or not existing.is_enum:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Enum not found")
+    parser = service.create_or_update_output_parser(db, app_id, parser_id, parser_data)
+    if parser is None or not parser.is_enum:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Enum not found")
+    return service.get_output_parser_detail(db, app_id, parser.parser_id, is_enum=True)
 
 
 @output_parsers_router.delete("/{parser_id}",

--- a/backend/schemas/export_schemas.py
+++ b/backend/schemas/export_schemas.py
@@ -66,6 +66,8 @@ class ExportOutputParserFieldSchema(BaseModel):
     parser_name: Optional[str] = None  # For type='parser' (name-based reference)
     list_item_type: Optional[str] = None  # For type='list'
     list_item_parser_name: Optional[str] = None  # For list of parsers (name-based reference)
+    enum_name: Optional[str] = None
+    list_item_enum_name: Optional[str] = None
 
 
 class ExportOutputParserSchema(BaseModel):
@@ -74,6 +76,7 @@ class ExportOutputParserSchema(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
     description: Optional[str] = None
     fields: List[ExportOutputParserFieldSchema] = []
+    is_enum: bool = False
 
 
 # ==================== MCP CONFIG ====================

--- a/backend/schemas/output_parser_schemas.py
+++ b/backend/schemas/output_parser_schemas.py
@@ -10,6 +10,7 @@ class OutputParserListItemSchema(BaseModel):
     description: Optional[str] = None
     field_count: int  # Number of fields in the parser
     created_at: Optional[datetime] = None
+    is_enum: bool = False
     
     model_config = ConfigDict(from_attributes=True)
 
@@ -17,12 +18,14 @@ class OutputParserListItemSchema(BaseModel):
 class OutputParserFieldSchema(BaseModel):
     """Schema for individual parser fields"""
     name: str
-    type: str  # 'str', 'int', 'float', 'bool', 'date', 'list', 'dict', 'parser'
+    type: str  # 'str', 'int', 'float', 'bool', 'date', 'list', 'dict', 'parser', 'enum'
     description: str
     optional: bool = False  # If True, the field is optional (may be absent in LLM output)
     parser_id: Optional[int] = None  # For type='parser'
     list_item_type: Optional[str] = None  # For type='list'
     list_item_parser_id: Optional[int] = None  # For list of parsers
+    enum_id: Optional[int] = None  # For type='enum'
+    list_item_enum_id: Optional[int] = None  # For list of enums
 
 
 class OutputParserDetailSchema(BaseModel):
@@ -33,6 +36,8 @@ class OutputParserDetailSchema(BaseModel):
     fields: List[OutputParserFieldSchema]
     created_at: Optional[datetime] = None
     available_parsers: List[Dict[str, Any]]  # Other parsers for references
+    available_enums: List[Dict[str, Any]] = []
+    is_enum: bool = False
     
     model_config = ConfigDict(from_attributes=True)
 
@@ -42,3 +47,4 @@ class CreateUpdateOutputParserSchema(BaseModel):
     name: str
     description: Optional[str] = ""
     fields: List[OutputParserFieldSchema]
+    is_enum: bool = False

--- a/backend/services/output_parser_export_service.py
+++ b/backend/services/output_parser_export_service.py
@@ -83,6 +83,10 @@ class OutputParserExportService(BaseExportService):
                         parser_name=parser_name,
                         list_item_type=field_data.get("list_item_type"),
                         list_item_parser_name=list_item_parser_name,
+                        enum_name=(self.output_parser_repo.get_by_id(self.session, field_data["enum_id"]).name
+                                   if field_data.get("enum_id") else None),
+                        list_item_enum_name=(self.output_parser_repo.get_by_id(self.session, field_data["list_item_enum_id"]).name
+                                             if field_data.get("list_item_enum_id") else None),
                     )
                 )
 
@@ -91,6 +95,7 @@ class OutputParserExportService(BaseExportService):
             name=parser.name,
             description=parser.description,
             fields=export_fields,
+            is_enum=parser.is_enum,
         )
 
         # Create export file

--- a/backend/services/output_parser_import_service.py
+++ b/backend/services/output_parser_import_service.py
@@ -106,6 +106,14 @@ class OutputParserImportService:
                 )
                 if ref_parser:
                     field_dict["list_item_parser_id"] = ref_parser.parser_id
+            if field.enum_name:
+                ref_enum = self.get_by_name_and_app(field.enum_name, app_id)
+                if ref_enum and ref_enum.is_enum:
+                    field_dict["enum_id"] = ref_enum.parser_id
+            if field.list_item_enum_name:
+                ref_enum = self.get_by_name_and_app(field.list_item_enum_name, app_id)
+                if ref_enum and ref_enum.is_enum:
+                    field_dict["list_item_enum_id"] = ref_enum.parser_id
             fields_json.append(field_dict)
         return fields_json
 
@@ -164,6 +172,7 @@ class OutputParserImportService:
                 )
 
                 existing_parser.fields = fields_json
+                existing_parser.is_enum = export_data.output_parser.is_enum
 
                 self.session.add(existing_parser)
                 self.session.flush()
@@ -193,6 +202,7 @@ class OutputParserImportService:
             name=final_name,
             description=export_data.output_parser.description,
             fields=fields_json,
+            is_enum=export_data.output_parser.is_enum,
             create_date=datetime.now(),
         )
 

--- a/backend/services/output_parser_service.py
+++ b/backend/services/output_parser_service.py
@@ -13,14 +13,14 @@ from datetime import datetime
 
 class OutputParserService:
     def __init__(self):
-        self.field_types = ['str', 'int', 'float', 'bool', 'date', 'list']
+        self.field_types = ['str', 'int', 'float', 'bool', 'date', 'list', 'enum']
         self.repository = OutputParserRepository()
     
     def list_output_parsers(self, db: Session, app_id: int) -> List[OutputParserListItemSchema]:
         """
         List all output parsers (data structures) for a specific app.
         """
-        parsers = self.repository.get_by_app_id(db, app_id)
+        parsers = [p for p in self.repository.get_by_app_id(db, app_id) if not p.is_enum]
         
         result = []
         for parser in parsers:
@@ -30,22 +30,39 @@ class OutputParserService:
                 name=parser.name,
                 description=parser.description,
                 field_count=field_count,
-                created_at=parser.create_date
+                created_at=parser.create_date,
+                is_enum=False,
             ))
         
         return result
+
+    def list_enums(self, db: Session, app_id: int) -> List[OutputParserListItemSchema]:
+        enums = [p for p in self.repository.get_by_app_id(db, app_id) if p.is_enum]
+        return [OutputParserListItemSchema(
+            parser_id=enum.parser_id,
+            name=enum.name,
+            description=enum.description,
+            field_count=len(enum.fields) if enum.fields else 0,
+            created_at=enum.create_date,
+            is_enum=True,
+        ) for enum in enums]
     
-    def get_output_parser_detail(self, db: Session, app_id: int, parser_id: int) -> OutputParserDetailSchema:
+    def get_output_parser_detail(self, db: Session, app_id: int, parser_id: int, is_enum: bool = False) -> OutputParserDetailSchema:
         """
         Get detailed information about a specific output parser including its fields.
         """
         # Get available parsers for references (excluding current parser to prevent self-reference)
         exclude_parser_id = parser_id if parser_id != 0 else None
         available_parsers_list = self.repository.get_available_parsers_for_app(db, app_id, exclude_parser_id)
+        available_enums_list = self.repository.get_available_enums_for_app(db, app_id)
         
         available_parsers = [
             {"value": p.parser_id, "name": p.name}
             for p in available_parsers_list
+        ]
+        available_enums = [
+            {"value": enum.parser_id, "name": enum.name}
+            for enum in available_enums_list
         ]
         
         if parser_id == 0:
@@ -56,7 +73,9 @@ class OutputParserService:
                 description="",
                 fields=[],
                 created_at=None,
-                available_parsers=available_parsers
+                available_parsers=available_parsers,
+                available_enums=available_enums,
+                is_enum=is_enum,
             )
         
         # Existing output parser
@@ -76,7 +95,9 @@ class OutputParserService:
                     optional=field_data.get('optional', False),
                     parser_id=field_data.get('parser_id'),
                     list_item_type=field_data.get('list_item_type'),
-                    list_item_parser_id=field_data.get('list_item_parser_id')
+                    list_item_parser_id=field_data.get('list_item_parser_id'),
+                    enum_id=field_data.get('enum_id'),
+                    list_item_enum_id=field_data.get('list_item_enum_id'),
                 ))
         
         return OutputParserDetailSchema(
@@ -85,7 +106,9 @@ class OutputParserService:
             description=parser.description,
             fields=fields,
             created_at=parser.create_date,
-            available_parsers=available_parsers
+            available_parsers=available_parsers,
+            available_enums=available_enums,
+            is_enum=parser.is_enum,
         )
     
     def create_or_update_output_parser(self, db: Session, app_id: int, parser_id: int, 
@@ -108,6 +131,7 @@ class OutputParserService:
         # Update parser data
         parser.name = parser_data.name
         parser.description = parser_data.description
+        parser.is_enum = parser_data.is_enum
         
         # Convert fields to JSON format
         fields_json = []
@@ -124,11 +148,15 @@ class OutputParserService:
             
             if field_data.type == 'parser' and field_data.parser_id:
                 field_dict['parser_id'] = field_data.parser_id
+            elif field_data.type == 'enum' and field_data.enum_id:
+                field_dict['enum_id'] = field_data.enum_id
             elif field_data.type == 'list':
                 if field_data.list_item_type:
                     field_dict['list_item_type'] = field_data.list_item_type
                 if field_data.list_item_type == 'parser' and field_data.list_item_parser_id:
                     field_dict['list_item_parser_id'] = field_data.list_item_parser_id
+                if field_data.list_item_type == 'enum' and field_data.list_item_enum_id:
+                    field_dict['list_item_enum_id'] = field_data.list_item_enum_id
             
             fields_json.append(field_dict)
         

--- a/backend/tools/outputParserTools.py
+++ b/backend/tools/outputParserTools.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Type, Dict, Any, List, Optional, get_origin, get_args
+from typing import Type, Dict, Any, List, Optional, Literal, get_origin, get_args
 from sqlalchemy.orm import Session
 from utils.schema_utils import sanitize_identifier
 from db.database import SessionLocal
@@ -90,7 +90,24 @@ def create_dynamic_pydantic_model(model_name: str,
         **{field_key: field_val[1] for field_key, field_val in model_fields.items()}
     })
 
-def get_type_from_string(type_str: str, list_item_type: str = None, list_item_parser_id: int = None, parser_id: int = None):
+def get_enum_values(enum_id: int) -> list[str]:
+    session = SessionLocal()
+    try:
+        enum = session.query(OutputParser).filter(
+            OutputParser.parser_id == enum_id,
+            OutputParser.is_enum.is_(True),
+        ).first()
+        if not enum:
+            raise ValueError(f"No se encontró el enum con ID {enum_id}")
+        values = [field.get('name', '') for field in (enum.fields or []) if field.get('name')]
+        if not values:
+            raise ValueError(f"El enum {enum_id} no tiene valores definidos")
+        return values
+    finally:
+        session.close()
+
+
+def get_type_from_string(type_str: str, list_item_type: str = None, list_item_parser_id: int = None, parser_id: int = None, enum_id: int = None, list_item_enum_id: int = None):
     """
     Convierte una cadena de tipo en su equivalente Python/Pydantic.
     
@@ -113,12 +130,16 @@ def get_type_from_string(type_str: str, list_item_type: str = None, list_item_pa
         if parser_id is None:
             raise ValueError("Se requiere parser_id para campos de tipo parser")
         return get_parser_model_by_id(parser_id)
+    elif type_str == 'enum':
+        return Literal.__getitem__(tuple(get_enum_values(enum_id)))
     elif type_str == 'list':
         if list_item_type == 'parser':
             if list_item_parser_id is None:
                 raise ValueError("Se requiere list_item_parser_id para listas de tipo parser")
             parser_model = get_parser_model_by_id(list_item_parser_id)
             return List[parser_model]
+        if list_item_type == 'enum':
+            return List[Literal.__getitem__(tuple(get_enum_values(list_item_enum_id)))]
         return List[basic_types.get(list_item_type, str)]
     
     return basic_types.get(type_str, str)
@@ -149,7 +170,9 @@ def create_model_from_json_schema(schema_data: List[Dict[str, Any]], model_name:
                     field['type'],
                     field.get('list_item_type'),
                     field.get('list_item_parser_id'),
-                    int(field.get('parser_id')) if field.get('parser_id') else None
+                    int(field.get('parser_id')) if field.get('parser_id') else None,
+                    int(field.get('enum_id')) if field.get('enum_id') else None,
+                    int(field.get('list_item_enum_id')) if field.get('list_item_enum_id') else None,
                 )
             field_types.append(tipo)
             field_descriptions.append(field['description'])

--- a/frontend/src/components/forms/DataStructureForm.tsx
+++ b/frontend/src/components/forms/DataStructureForm.tsx
@@ -11,6 +11,8 @@ interface FieldDefinition {
   parser_id?: number;
   list_item_type?: string;
   list_item_parser_id?: number;
+  enum_id?: number;
+  list_item_enum_id?: number;
   _key?: string;
 }
 
@@ -27,6 +29,7 @@ interface DataStructure {
   fields: FieldDefinition[];
   created_at: string;
   available_parsers: Array<{value: number, name: string}>;
+  available_enums: Array<{value: number, name: string}>;
 }
 
 interface DataStructureFormProps {
@@ -97,9 +100,16 @@ function DataStructureForm({ dataStructure, onSubmit, onCancel }: Readonly<DataS
       if (field.type === 'parser' && !field.parser_id) {
         return `Field '${field.name}' with parser type must have a parser selected`;
       }
+      if (field.type === 'enum' && !field.enum_id) {
+        return `Field '${field.name}' with enum type must have an enum selected`;
+      }
       
       if (field.type === 'list' && field.list_item_type === 'parser' && !field.list_item_parser_id) {
         return `Field '${field.name}' with list of parsers must have a parser selected`;
+      }
+
+      if (field.type === 'list' && field.list_item_type === 'enum' && !field.list_item_enum_id) {
+        return `Field '${field.name}' with list of enums must have an enum selected`;
       }
     }
 
@@ -135,6 +145,7 @@ function DataStructureForm({ dataStructure, onSubmit, onCancel }: Readonly<DataS
   };
 
   const availableParsers = dataStructure?.available_parsers || [];
+  const availableEnums = dataStructure?.available_enums || [];
 
   return (
     <form onSubmit={handleSubmit} className="space-y-8">
@@ -189,6 +200,7 @@ function DataStructureForm({ dataStructure, onSubmit, onCancel }: Readonly<DataS
           fields={formData.fields}
           onChange={handleFieldsChange}
           availableParsers={availableParsers}
+          availableEnums={availableEnums}
           maxFields={20}
         />
       </div>

--- a/frontend/src/components/forms/EnumForm.tsx
+++ b/frontend/src/components/forms/EnumForm.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react';
+import FormActions from './FormActions';
+
+interface EnumOption {
+  name: string;
+  description: string;
+  _key?: string;
+}
+
+export interface EnumFormData {
+  name: string;
+  description: string;
+  fields: Array<{ name: string; type: 'str'; description: string }>;
+  is_enum: true;
+}
+
+interface EnumDefinition {
+  parser_id: number;
+  name: string;
+  description: string;
+  fields: EnumOption[];
+}
+
+interface EnumFormProps {
+  enumDefinition?: EnumDefinition | null;
+  onSubmit: (data: EnumFormData) => Promise<void>;
+  onCancel: () => void;
+}
+
+function EnumForm({ enumDefinition, onSubmit, onCancel }: Readonly<EnumFormProps>) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [fields, setFields] = useState<EnumOption[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setName(enumDefinition?.name || '');
+    setDescription(enumDefinition?.description || '');
+    setFields((enumDefinition?.fields || []).map((field) => ({ ...field, _key: crypto.randomUUID() })));
+  }, [enumDefinition]);
+
+  const updateField = (index: number, update: Partial<EnumOption>) => {
+    setFields((current) => current.map((field, fieldIndex) => fieldIndex === index ? { ...field, ...update } : field));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const namePattern = /^\w+$/;
+    if (!name.trim() || !namePattern.test(name)) {
+      setError('Enum name is required and may only contain letters, numbers, and underscores');
+      return;
+    }
+    const options = fields.filter((field) => field.name.trim());
+    if (new Set(options.map((field) => field.name)).size !== options.length) {
+      setError('Enum values must be unique');
+      return;
+    }
+    try {
+      setIsSubmitting(true);
+      setError(null);
+      await onSubmit({
+        name,
+        description,
+        fields: options.map(({ name: optionName, description: optionDescription }) => ({ name: optionName, type: 'str', description: optionDescription })),
+        is_enum: true,
+      });
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : 'Failed to save enum');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {error && <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-600">{error}</div>}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div>
+          <label htmlFor="enum-name" className="block text-sm font-medium text-gray-700 mb-2">Enum Name *</label>
+          <input id="enum-name" value={name} onChange={(event) => setName(event.target.value)} className="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="e.g., Status" required />
+        </div>
+        <div>
+          <label htmlFor="enum-description" className="block text-sm font-medium text-gray-700 mb-2">Description</label>
+          <textarea id="enum-description" value={description} onChange={(event) => setDescription(event.target.value)} rows={3} className="w-full px-4 py-3 border border-gray-300 rounded-lg resize-none" placeholder="Describe the allowed values..." />
+        </div>
+      </div>
+      <div className="space-y-3">
+        <div className="flex justify-between items-center">
+          <h3 className="text-lg font-medium text-gray-900">Values ({fields.length}/20)</h3>
+          <button type="button" onClick={() => fields.length < 20 && setFields([...fields, { name: '', description: '', _key: crypto.randomUUID() }])} disabled={fields.length >= 20} className="px-3 py-1 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white text-sm rounded">Add Value</button>
+        </div>
+        <div className="rounded-lg overflow-hidden">
+          {fields.length === 0 
+            ? 
+            <div className="text-center py-8 border-2 border-dashed border-gray-300 rounded-lg">
+                <p className="text-gray-500 mb-4">No enum values defined yet</p>
+                <button
+                    type="button"
+                    onClick={() => setFields([...fields, { name: '', description: '', _key: crypto.randomUUID() }])}
+                    className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
+                >
+                    Add First Value
+                </button>
+            </div>
+            : (
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50"><tr><th className="px-4 py-3 text-left text-xs text-gray-500 uppercase">Value</th><th className="px-4 py-3 text-left text-xs text-gray-500 uppercase">Description</th><th className="w-16" /></tr></thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {fields.map((field, index) => <tr key={field._key}>
+                  <td className="px-4 py-3"><input value={field.name} onChange={(event) => updateField(index, { name: event.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-md" placeholder="value_name" /></td>
+                  <td className="px-4 py-3"><input value={field.description} onChange={(event) => updateField(index, { description: event.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-md" placeholder="Optional description" /></td>
+                  <td className="px-4 py-3">
+                    <button
+                        type="button"
+                        onClick={() => setFields(fields.filter((_, fieldIndex) => fieldIndex !== index))}
+                        className="text-red-600 hover:text-red-900 transition-colors p-2"
+                        title="Remove field"
+                    >
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+                        </svg>
+                    </button>
+                  </td>
+                </tr>)}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+      <FormActions onCancel={onCancel} isSubmitting={isSubmitting} isEditing={Boolean(enumDefinition && enumDefinition.parser_id !== 0)} submitLabel={enumDefinition?.parser_id ? 'Update Enum' : 'Create Enum'} submitButtonColor="purple" />
+    </form>
+  );
+}
+
+export default EnumForm;

--- a/frontend/src/components/forms/FieldManager.tsx
+++ b/frontend/src/components/forms/FieldManager.tsx
@@ -6,6 +6,8 @@ interface FieldDefinition {
   parser_id?: number;
   list_item_type?: string;
   list_item_parser_id?: number;
+  enum_id?: number;
+  list_item_enum_id?: number;
   _key?: string;
 }
 
@@ -13,10 +15,11 @@ interface FieldManagerProps {
   fields: FieldDefinition[];
   onChange: (fields: FieldDefinition[]) => void;
   availableParsers: Array<{value: number, name: string}>;
+  availableEnums?: Array<{value: number, name: string}>;
   maxFields?: number;
 }
 
-function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Readonly<FieldManagerProps>) {
+function FieldManager({ fields, onChange, availableParsers, availableEnums = [], maxFields = 20 }: Readonly<FieldManagerProps>) {
   const fieldTypes = [
     { value: 'str', name: 'String' },
     { value: 'int', name: 'Integer' },
@@ -26,6 +29,7 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
     { value: 'dict', name: 'Dictionary (JSON Object)' },
     { value: 'list', name: 'List' },
     { value: 'parser', name: 'Parser Reference' }
+    ,{ value: 'enum', name: 'Enum' }
   ];
 
   const addField = () => {
@@ -56,9 +60,13 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
           if (updates.type !== 'parser') {
             updatedField.parser_id = undefined;
           }
+          if (updates.type !== 'enum') {
+            updatedField.enum_id = undefined;
+          }
           if (updates.type !== 'list') {
             updatedField.list_item_type = undefined;
             updatedField.list_item_parser_id = undefined;
+            updatedField.list_item_enum_id = undefined;
           }
         }
         
@@ -82,7 +90,8 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
     { value: 'bool', name: 'Boolean' },
     { value: 'date', name: 'Date' },
     { value: 'dict', name: 'Dictionary (JSON Object)' },
-    { value: 'parser', name: 'Parser Reference' }
+    { value: 'parser', name: 'Parser Reference' },
+    { value: 'enum', name: 'Enum' }
   ];
 
   return (
@@ -181,6 +190,16 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
                           </select>
                         </div>
                       )}
+
+                      {field.type === 'enum' && (
+                        <div>
+                          <label htmlFor={`enum_ref_${index}`} className="block text-xs font-medium text-gray-700 mb-1">Reference Enum:</label>
+                          <select id={`enum_ref_${index}`} value={field.enum_id || ''} onChange={(e) => updateField(index, { enum_id: Number.parseInt(e.target.value) || undefined })} className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm">
+                            <option value="">Select enum...</option>
+                            {availableEnums.map((enumDefinition) => <option key={enumDefinition.value} value={enumDefinition.value}>{enumDefinition.name}</option>)}
+                          </select>
+                        </div>
+                      )}
                       
                       {/* List Type Selectors */}
                       {field.type === 'list' && (
@@ -218,6 +237,15 @@ function FieldManager({ fields, onChange, availableParsers, maxFields = 20 }: Re
                                     {parser.name}
                                   </option>
                                 ))}
+                              </select>
+                            </div>
+                          )}
+                          {field.list_item_type === 'enum' && (
+                            <div>
+                              <label htmlFor={`list_item_enum_${index}`} className="block text-xs font-medium text-gray-700 mb-1">List Item Enum:</label>
+                              <select id={`list_item_enum_${index}`} value={field.list_item_enum_id || ''} onChange={(e) => updateField(index, { list_item_enum_id: Number.parseInt(e.target.value) || undefined })} className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm">
+                                <option value="">Select enum...</option>
+                                {availableEnums.map((enumDefinition) => <option key={enumDefinition.value} value={enumDefinition.value}>{enumDefinition.name}</option>)}
                               </select>
                             </div>
                           )}

--- a/frontend/src/contexts/SettingsCacheContext.tsx
+++ b/frontend/src/contexts/SettingsCacheContext.tsx
@@ -45,6 +45,7 @@ interface DataStructure {
   description: string;
   field_count: number;
   created_at: string;
+  is_enum?: boolean;
 }
 
 interface Collaborator {
@@ -68,6 +69,7 @@ interface SettingsCacheState {
   mcpConfigs: { [appId: string]: MCPConfig[] };
   skills: { [appId: string]: Skill[] };
   dataStructures: { [appId: string]: DataStructure[] };
+  enums: { [appId: string]: DataStructure[] };
   collaborators: { [appId: string]: Collaborator[] };
 }
 
@@ -107,6 +109,11 @@ interface SettingsCacheContextType {
   getDataStructures: (appId: string) => DataStructure[] | null;
   setDataStructures: (appId: string, structures: DataStructure[]) => void;
   invalidateDataStructures: (appId: string) => void;
+
+  // Enums
+  getEnums: (appId: string) => DataStructure[] | null;
+  setEnums: (appId: string, enums: DataStructure[]) => void;
+  invalidateEnums: (appId: string) => void;
   
   // Collaborators
   getCollaborators: (appId: string) => Collaborator[] | null;
@@ -140,6 +147,7 @@ export const SettingsCacheProvider: React.FC<SettingsCacheProviderProps> = ({ ch
     mcpConfigs: {},
     skills: {},
     dataStructures: {},
+    enums: {},
     collaborators: {},
   });
 
@@ -249,6 +257,21 @@ export const SettingsCacheProvider: React.FC<SettingsCacheProviderProps> = ({ ch
     });
   }, []);
 
+  const setEnums = useCallback((appId: string, enums: DataStructure[]) => {
+    setCache(prev => ({
+      ...prev,
+      enums: { ...prev.enums, [appId]: enums }
+    }));
+  }, []);
+
+  const invalidateEnums = useCallback((appId: string) => {
+    setCache(prev => {
+      const newEnums = { ...prev.enums };
+      delete newEnums[appId];
+      return { ...prev, enums: newEnums };
+    });
+  }, []);
+
   const setCollaborators = useCallback((appId: string, collaborators: Collaborator[]) => {
     setCache(prev => ({
       ...prev,
@@ -273,6 +296,7 @@ export const SettingsCacheProvider: React.FC<SettingsCacheProviderProps> = ({ ch
       const newMCPConfigs = { ...prev.mcpConfigs };
       const newSkills = { ...prev.skills };
       const newDataStructures = { ...prev.dataStructures };
+      const newEnums = { ...prev.enums };
       const newCollaborators = { ...prev.collaborators };
 
       delete newAIServices[appId];
@@ -282,6 +306,7 @@ export const SettingsCacheProvider: React.FC<SettingsCacheProviderProps> = ({ ch
       delete newMCPConfigs[appId];
       delete newSkills[appId];
       delete newDataStructures[appId];
+      delete newEnums[appId];
       delete newCollaborators[appId];
 
       return {
@@ -292,6 +317,7 @@ export const SettingsCacheProvider: React.FC<SettingsCacheProviderProps> = ({ ch
         mcpConfigs: newMCPConfigs,
         skills: newSkills,
         dataStructures: newDataStructures,
+        enums: newEnums,
         collaborators: newCollaborators,
       };
     });
@@ -307,6 +333,7 @@ export const SettingsCacheProvider: React.FC<SettingsCacheProviderProps> = ({ ch
     getMCPConfigs: (appId: string) => cache.mcpConfigs[appId] || null,
     getSkills: (appId: string) => cache.skills[appId] || null,
     getDataStructures: (appId: string) => cache.dataStructures[appId] || null,
+    getEnums: (appId: string) => cache.enums[appId] || null,
     getCollaborators: (appId: string) => cache.collaborators[appId] || null,
     // Stable setter/invalidator references from useCallback
     setAIServices,
@@ -323,6 +350,8 @@ export const SettingsCacheProvider: React.FC<SettingsCacheProviderProps> = ({ ch
     invalidateSkills,
     setDataStructures,
     invalidateDataStructures,
+    setEnums,
+    invalidateEnums,
     setCollaborators,
     invalidateCollaborators,
     clearAppCache,
@@ -335,6 +364,7 @@ export const SettingsCacheProvider: React.FC<SettingsCacheProviderProps> = ({ ch
     setMCPConfigs, invalidateMCPConfigs,
     setSkills, invalidateSkills,
     setDataStructures, invalidateDataStructures,
+    setEnums, invalidateEnums,
     setCollaborators, invalidateCollaborators,
     clearAppCache,
   ]);

--- a/frontend/src/pages/settings/DataStructuresPage.tsx
+++ b/frontend/src/pages/settings/DataStructuresPage.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { toast } from 'sonner';
-import { BarChart2, Upload, ArrowDownToLine, Pencil, Trash2, Lightbulb, FileText } from 'lucide-react';
+import { BarChart2, ListChecks, Upload, ArrowDownToLine, Pencil, Trash2, Lightbulb, FileText } from 'lucide-react';
 import Modal from '../../components/ui/Modal';
 import DataStructureForm from '../../components/forms/DataStructureForm';
+import EnumForm, { type EnumFormData } from '../../components/forms/EnumForm';
 import { apiService } from '../../services/api';
 import ActionDropdown from '../../components/ui/ActionDropdown';
 import { useSettingsCache } from '../../contexts/SettingsCacheContext';
@@ -23,6 +24,7 @@ interface DataStructure {
   description: string;
   field_count: number;
   created_at: string;
+  is_enum?: boolean;
 }
 
 function DataStructuresPage() {
@@ -33,10 +35,13 @@ function DataStructuresPage() {
   const confirm = useConfirm();
   const mutate = useApiMutation();
   const [dataStructures, setDataStructures] = useState<DataStructure[]>([]);
+  const [enums, setEnums] = useState<DataStructure[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingStructure, setEditingStructure] = useState<any>(null);
+  const [editingEnum, setEditingEnum] = useState<any>(null);
+  const [isEnumModalOpen, setIsEnumModalOpen] = useState(false);
   const [showImportModal, setShowImportModal] = useState(false);
   const [exportingParserId, setExportingParserId] = useState<number | null>(null);
 
@@ -50,8 +55,10 @@ function DataStructuresPage() {
     
     // Check if we have cached data first
     const cachedData = settingsCache.getDataStructures(appId);
-    if (cachedData) {
+    const cachedEnums = settingsCache.getEnums(appId);
+    if (cachedData && cachedEnums) {
       setDataStructures(cachedData);
+      setEnums(cachedEnums);
       setLoading(false);
       return;
     }
@@ -61,9 +68,12 @@ function DataStructuresPage() {
       setLoading(true);
       setError(null);
       const response = await apiService.getOutputParsers(Number.parseInt(appId));
+      const enumResponse = await apiService.getEnums(Number.parseInt(appId));
       setDataStructures(response);
+      setEnums(enumResponse);
       // Cache the response
       settingsCache.setDataStructures(appId, response);
+      settingsCache.setEnums(appId, enumResponse);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load data structures');
       console.error('Error loading data structures:', err);
@@ -79,9 +89,12 @@ function DataStructuresPage() {
       setLoading(true);
       setError(null);
       const response = await apiService.getOutputParsers(Number.parseInt(appId));
+      const enumResponse = await apiService.getEnums(Number.parseInt(appId));
       setDataStructures(response);
+      setEnums(enumResponse);
       // Cache the response
       settingsCache.setDataStructures(appId, response);
+      settingsCache.setEnums(appId, enumResponse);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load data structures');
       console.error('Error loading data structures:', err);
@@ -143,6 +156,47 @@ function DataStructuresPage() {
     }
   }
 
+  async function handleCreateEnum() {
+    if (!appId) return;
+    try {
+      const blankEnum = await apiService.getEnum(Number.parseInt(appId), 0);
+      setEditingEnum({ ...blankEnum, is_enum: true });
+      setIsEnumModalOpen(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load enum options');
+    }
+  }
+
+  async function handleEditEnum(enumId: number) {
+    if (!appId) return;
+    try {
+      setEditingEnum(await apiService.getEnum(Number.parseInt(appId), enumId));
+      setIsEnumModalOpen(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load enum details');
+    }
+  }
+
+  async function handleDeleteEnum(enumDefinition: DataStructure) {
+    if (!appId) return;
+    const ok = await confirm({
+      title: MESSAGES.CONFIRM_DELETE_TITLE('enum'),
+      message: `Are you sure you want to delete "${enumDefinition.name}"? This action cannot be undone.`,
+      variant: 'danger',
+      confirmLabel: 'Delete',
+    });
+    if (!ok) return;
+    const result = await mutate(() => apiService.deleteEnum(Number.parseInt(appId), enumDefinition.parser_id), {
+      loading: MESSAGES.DELETING('enum'),
+      success: MESSAGES.DELETED('enum'),
+      error: (err) => errorMessage(err, MESSAGES.DELETE_FAILED('enum')),
+    });
+    if (result === undefined) return;
+    const newEnums = enums.filter((item) => item.parser_id !== enumDefinition.parser_id);
+    setEnums(newEnums);
+    settingsCache.setEnums(appId, newEnums);
+  }
+
   async function handleSaveStructure(data: any) {
     if (!appId) return;
 
@@ -171,9 +225,33 @@ function DataStructuresPage() {
     setEditingStructure(null);
   }
 
+  async function handleSaveEnum(data: EnumFormData) {
+    if (!appId) return;
+    const isUpdate = Boolean(editingEnum && editingEnum.parser_id !== 0);
+    const result = await mutate(
+      () => isUpdate
+        ? apiService.updateEnum(Number.parseInt(appId), editingEnum.parser_id, data)
+        : apiService.createEnum(Number.parseInt(appId), data),
+      {
+        loading: isUpdate ? MESSAGES.UPDATING('enum') : MESSAGES.CREATING('enum'),
+        success: isUpdate ? MESSAGES.UPDATED('enum') : MESSAGES.CREATED('enum'),
+        error: (err) => errorMessage(err, MESSAGES.SAVE_FAILED('enum')),
+      },
+    );
+    if (result === undefined) return;
+    await forceReloadDataStructures();
+    setIsEnumModalOpen(false);
+    setEditingEnum(null);
+  }
+
   function handleCloseModal() {
     setIsModalOpen(false);
     setEditingStructure(null);
+  }
+
+  function handleCloseEnumModal() {
+    setIsEnumModalOpen(false);
+    setEditingEnum(null);
   }
 
   async function handleExport(parserId: number) {
@@ -283,6 +361,12 @@ function DataStructuresPage() {
                 <span className="mr-2">+</span>
                 {' '}Create Data Structure
               </button>
+              <button
+                onClick={() => void handleCreateEnum()}
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center"
+              >
+                <ListChecks className="w-4 h-4 mr-2" />Create Enum
+              </button>
             </div>
           )}
         </div>
@@ -389,6 +473,35 @@ function DataStructuresPage() {
           </div>
         )}
 
+        <div className="mt-10 mb-6">
+          <h2 className="text-xl font-semibold text-gray-900">Enums</h2>
+          <p className="text-gray-600">Define reusable allowed values for data structure fields</p>
+        </div>
+        <Table
+          data={enums}
+          keyExtractor={(enumDefinition) => enumDefinition.parser_id.toString()}
+          columns={[
+            {
+              header: 'Name',
+              render: (enumDefinition) => (
+                <div className="flex items-center">
+                  <ListChecks className="w-5 h-5 text-blue-400 mr-3 shrink-0" />
+                  {canEdit ? <button type="button" className="text-sm font-medium text-gray-900 hover:text-blue-600" onClick={() => void handleEditEnum(enumDefinition.parser_id)}>{enumDefinition.name}</button> : <span>{enumDefinition.name}</span>}
+                </div>
+              ),
+            },
+            { header: 'Description', render: (enumDefinition) => <div className="text-sm text-gray-900 max-w-xs truncate">{enumDefinition.description || 'No description'}</div> },
+            { header: 'Values', render: (enumDefinition) => <span className="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-blue-100 text-blue-800">{enumDefinition.field_count} value{enumDefinition.field_count === 1 ? '' : 's'}</span> },
+            { header: 'Actions', render: (enumDefinition) => canEdit ? <ActionDropdown actions={[{ label: 'Edit', onClick: () => { void handleEditEnum(enumDefinition.parser_id); }, icon: <Pencil className="w-4 h-4" />, variant: 'primary' }, { label: 'Delete', onClick: () => { void handleDeleteEnum(enumDefinition); }, icon: <Trash2 className="w-4 h-4" />, variant: 'danger' }]} size="sm" /> : <span className="text-gray-400 text-sm">View only</span> },
+          ]}
+          emptyIcon={<ListChecks className="w-10 h-10 text-gray-300" />}
+          emptyMessage="No Enums"
+          emptySubMessage="Create an enum to constrain a data structure field to known values."
+          loading={loading}
+        />
+
+        {!loading && enums.length === 0 && canEdit && <div className="text-center py-6"><button onClick={() => void handleCreateEnum()} className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-lg">Create First Enum</button></div>}
+
         {/* Info Boxes */}
         <div className="mt-6 space-y-4">
           {/* Main Info */}
@@ -448,6 +561,10 @@ function DataStructuresPage() {
             onSubmit={handleSaveStructure}
             onCancel={handleCloseModal}
           />
+        </Modal>
+
+        <Modal isOpen={isEnumModalOpen} onClose={handleCloseEnumModal} title={editingEnum?.parser_id ? 'Edit Enum' : 'Create New Enum'} size="xlarge">
+          <EnumForm enumDefinition={editingEnum} onSubmit={handleSaveEnum} onCancel={handleCloseEnumModal} />
         </Modal>
 
         {/* Import Modal */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -314,6 +314,9 @@ export interface DataStructureField {
   parser_id?: number;
   list_item_type?: string;
   list_item_parser_id?: number;
+  enum_id?: number;
+  list_item_enum_id?: number;
+  optional?: boolean;
 }
 
 export interface DataStructure {
@@ -324,6 +327,8 @@ export interface DataStructure {
   fields?: DataStructureField[];
   created_at: string;
   available_parsers?: Array<{ value: number; name: string }>;
+  available_enums?: Array<{ value: number; name: string }>;
+  is_enum?: boolean;
 }
 
 export interface Collaborator {
@@ -1279,12 +1284,27 @@ class ApiService {
     return this.request(`/internal/apps/${appId}/output-parsers/`);
   }
 
+  async getEnums(appId: number): Promise<(DataStructure & { field_count: number; is_enum: true })[]> {
+    return this.request(`/internal/apps/${appId}/output-parsers/enums/`);
+  }
+
   async getOutputParser(appId: number, parserId: number): Promise<DataStructure> {
     return this.request(`/internal/apps/${appId}/output-parsers/${parserId}`);
   }
 
+  async getEnum(appId: number, enumId: number): Promise<DataStructure> {
+    return this.request(`/internal/apps/${appId}/output-parsers/enums/${enumId}`);
+  }
+
   async createOutputParser(appId: number, data: any): Promise<DataStructure> {
     return this.request(`/internal/apps/${appId}/output-parsers/0`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async createEnum(appId: number, data: any): Promise<DataStructure> {
+    return this.request(`/internal/apps/${appId}/output-parsers/enums/0`, {
       method: 'POST',
       body: JSON.stringify(data),
     });
@@ -1297,8 +1317,21 @@ class ApiService {
     });
   }
 
+  async updateEnum(appId: number, enumId: number, data: any): Promise<DataStructure> {
+    return this.request(`/internal/apps/${appId}/output-parsers/enums/${enumId}`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
   async deleteOutputParser(appId: number, parserId: number): Promise<void> {
     return this.request(`/internal/apps/${appId}/output-parsers/${parserId}`, {
+      method: 'DELETE',
+    });
+  }
+
+  async deleteEnum(appId: number, enumId: number): Promise<void> {
+    return this.request(`/internal/apps/${appId}/output-parsers/${enumId}`, {
       method: 'DELETE',
     });
   }


### PR DESCRIPTION
## Description

Adds reusable Enum definitions to Data Structures.

Enums have a name, description, and up to 20 unique allowed values. They can be referenced by data-structure fields to constrain generated output to the enum values, including lists of enum values.

The implementation includes:

* Enum creation, editing, deletion, and listing in the Data Structures page.
* Persistence through the existing `OutputParser` model using `is_enum`.
* Backend CRUD endpoints with tenant isolation.
* Runtime validation using `Literal `types.
* Export/import support.
* Exclusion of enums from the Agent Form Page and data-structure selector.
* Enum caching so definitions remain visible after client-side navigation.

## Type of Change

Please check the option that best describes the purpose of this pull request:

* [ ] Bug fix (a change that does not break existing functionality and fixes an issue)
* [x] Feature (a change that does not break existing functionality and adds new functionality)
* [ ] Documentation (updates or adds documentation only)
* [ ] Refactor (code change that neither fixes a bug nor adds a feature)
* [ ] Performance improvement
* [ ] Test (adding or updating tests)
* [ ] Build or infrastructure (changes to tooling, deployment scripts, CI/CD, etc.)

## Affected Components

Both backend and frontend:

* Backend: FastAPI routes, SQLAlchemy model, schemas, repository, services, runtime output validation, import/export services, and Alembic migration.
* Frontend: Data Structures page, enum form, field manager, API service, and settings cache context.

## Implementation Details

Enums reuse the existing `OutputParser` infrastructure and are identified with the `is_enum` flag. Existing data structures remain unchanged and continue to use the same APIs.

Enum references are stored in data-structure field definitions. During runtime model generation, enum fields are converted to `Literal[...]` constraints, while list-of-enum fields become `List[Literal[...]]`.

The backend exposes dedicated enum endpoints and prevents enum resources from being returned as selectable data structures for agents.

A new Alembic migration adds the non-nullable `is_enum` column with a default value of `false`.

No new environment variables or external dependencies are required.

## How to Test

1. Open an app's Data Structures page.
2. Create an enum with a name, description, and allowed values.
3. Create or edit a data structure and verify that:
   * Enum fields can select an existing enum.
   * List-of-enum fields can select an existing enum.
   * Enum definitions do not appear as data structures in the Agent Form Page.
4. Edit and delete enum definitions.
5. Navigate away from the Data Structures page and return. Verify that enums remain visible without a full page reload.
6. Verify export/import behavior for data structures referencing enums.

## Checklist

* [x] Commit messages follow Conventional Commits (`type(scope): description`).
* [x] I have read the contributing guidelines and my change adheres to the coding standards of this project (see `docs/README.md#contributing`).
* [ ] I have added tests that prove my fix or feature works, or confirm that tests are not needed for this change.
* [ ] I have run all existing tests and they all pass locally.
* [ ] I have updated any relevant documentation, configuration files, or environment examples as needed.
* [x] I have considered backwards compatibility and ensured that my change does not break existing functionality.
* [ ] For UI changes, I have included relevant screenshots or screencasts.

## Additional Notes

The implementation intentionally reuses `OutputParser` rather than introducing a separate enum table, minimizing schema duplication while preserving a clear distinction between data structures and enums.

Existing data structures default to `is_enum=false`, so the migration is backwards compatible.