### PR TITLE
Feature/execution profiles

### DIFF
--- a/alembic/versions/execprof001_add_execution_profiles.py
+++ b/alembic/versions/execprof001_add_execution_profiles.py
@@ -1,0 +1,42 @@
+"""Add execution_profile columns to AIService and Agent tables.
+
+This migration introduces the execution profiles system that lets users
+control model reasoning depth (FAST, BALANCED, DEEP, MAX) independently
+of the LLM provider.
+
+- AIService.execution_profile : SmallInteger, NOT NULL, default 1 (BALANCED)
+- Agent.execution_profile     : SmallInteger, nullable (None = inherit)
+
+Revision ID: execprof001
+Revises: userdel001
+Create Date: 2026-07-07
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'execprof001'
+down_revision = 'userdel001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # AIService
+    op.add_column(
+        'AIService',
+        op.Column('execution_profile', op.SmallInteger(), nullable=False, server_default='1'),
+    )
+
+    # Agent
+    op.add_column(
+        'Agent',
+        op.Column('execution_profile', op.SmallInteger(), nullable=True),
+    )
+
+    # OCRAgent inherits from Agent so the column is automatically available.
+
+
+def downgrade() -> None:
+    op.drop_column('OCRAgent', 'execution_profile')
+    op.drop_column('Agent', 'execution_profile')
+    op.drop_column('AIService', 'execution_profile')

--- a/alembic/versions/execprof001_add_execution_profiles.py
+++ b/alembic/versions/execprof001_add_execution_profiles.py
@@ -8,7 +8,7 @@ of the LLM provider.
 - Agent.execution_profile     : SmallInteger, nullable (None = inherit)
 
 Revision ID: execprof001
-Revises: merge001_usedel_platform_role
+Revises: merge001_userdel_platform_role
 Create Date: 2026-07-07
 """
 from alembic import op
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'execprof001'
-down_revision = 'merge001_usedel_platform_role'
+down_revision = 'merge001_userdel_platform_role'
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/execprof001_add_execution_profiles.py
+++ b/alembic/versions/execprof001_add_execution_profiles.py
@@ -8,7 +8,7 @@ of the LLM provider.
 - Agent.execution_profile     : SmallInteger, nullable (None = inherit)
 
 Revision ID: execprof001
-Revises: merge001_userdel_platform_role
+Revises: ec5b82391242
 Create Date: 2026-07-07
 """
 from alembic import op
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'execprof001'
-down_revision = 'merge001_userdel_platform_role'
+down_revision = 'ec5b82391242'
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/execprof001_add_execution_profiles.py
+++ b/alembic/versions/execprof001_add_execution_profiles.py
@@ -8,14 +8,15 @@ of the LLM provider.
 - Agent.execution_profile     : SmallInteger, nullable (None = inherit)
 
 Revision ID: execprof001
-Revises: userdel001
+Revises: merge001_usedel_platform_role
 Create Date: 2026-07-07
 """
 from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'execprof001'
-down_revision = 'userdel001'
+down_revision = 'merge001_usedel_platform_role'
 branch_labels = None
 depends_on = None
 
@@ -24,19 +25,18 @@ def upgrade() -> None:
     # AIService
     op.add_column(
         'AIService',
-        op.Column('execution_profile', op.SmallInteger(), nullable=False, server_default='1'),
+        sa.Column('execution_profile', sa.SmallInteger(), nullable=False, server_default='1'),
     )
 
     # Agent
     op.add_column(
         'Agent',
-        op.Column('execution_profile', op.SmallInteger(), nullable=True),
+        sa.Column('execution_profile', sa.SmallInteger(), nullable=True),
     )
 
     # OCRAgent inherits from Agent so the column is automatically available.
 
 
 def downgrade() -> None:
-    op.drop_column('OCRAgent', 'execution_profile')
     op.drop_column('Agent', 'execution_profile')
     op.drop_column('AIService', 'execution_profile')

--- a/alembic/versions/merge001_userdel_platform_role_heads.py
+++ b/alembic/versions/merge001_userdel_platform_role_heads.py
@@ -14,7 +14,7 @@ Create Date: 2026-06-05
 
 # revision identifiers, used by Alembic.
 revision = 'merge001_userdel_platform_role'
-down_revision = ('userdel001',)
+down_revision = ('userdel001','platform_role002')
 branch_labels = None
 depends_on = None
 

--- a/backend/models/agent.py
+++ b/backend/models/agent.py
@@ -1,6 +1,6 @@
 import enum
 
-from sqlalchemy import Column, Integer, String, Text, Boolean, ForeignKey, Table, DateTime, Float, Enum, JSON
+from sqlalchemy import Column, Integer, String, Text, Boolean, ForeignKey, Table, DateTime, Float, Enum, JSON, SmallInteger
 from sqlalchemy.orm import relationship
 from db.database import Base
 from datetime import datetime
@@ -98,6 +98,9 @@ class Agent(Base):
                         nullable=True)
     temperature = Column(Float, default=DEFAULT_AGENT_TEMPERATURE, nullable=False)
     is_frozen = Column(Boolean, default=False, nullable=False)
+
+    # Execution profile override (null = inherit from AIService; 0-3 = FAST/BALANCED/DEEP/MAX).
+    execution_profile = Column(SmallInteger, nullable=True)
 
     marketplace_visibility = Column(
         Enum(MarketplaceVisibility),

--- a/backend/models/ai_service.py
+++ b/backend/models/ai_service.py
@@ -1,5 +1,5 @@
 import enum
-from sqlalchemy import Column, String, Integer, Boolean, ForeignKey
+from sqlalchemy import Column, String, Integer, Boolean, ForeignKey, SmallInteger
 from sqlalchemy.orm import relationship
 from models.base_service import BaseService
 
@@ -14,10 +14,12 @@ class ProviderEnum(enum.Enum):
     OpenRouter = "OpenRouter"
     Bedrock = "Bedrock"
 
+
 class AIService(BaseService):
     __tablename__ = 'AIService'
     
     provider = Column(String(45), nullable=False)
     supports_video = Column(Boolean, nullable=False, default=False, server_default='false')
     app_id = Column(Integer, ForeignKey('App.app_id'), nullable=True)  # NULL = system/platform service
+    execution_profile = Column(SmallInteger, nullable=False, default=1, server_default='1')
     app = relationship('App', back_populates='ai_services') 

--- a/backend/routers/internal/agents.py
+++ b/backend/routers/internal/agents.py
@@ -734,6 +734,8 @@ async def chat_with_agent_stream(
     file_references: Annotated[Optional[str], Form()] = None,
     search_params: Annotated[Optional[str], Form()] = None,
     conversation_id: Annotated[Optional[int], Form()] = None,
+    override_execution_profile: Annotated[Optional[int], Form()] = None,
+    override_temperature: Annotated[Optional[float], Form()] = None,
 ):
     """
     Internal API: Chat with agent using Server-Sent Events streaming (OAuth authentication)
@@ -779,6 +781,8 @@ async def chat_with_agent_stream(
             user_context=user_context,
             conversation_id=conversation_id,
             db=db,
+            override_execution_profile=override_execution_profile,
+            override_temperature=override_temperature,
         )
 
         # Wrap so ephemeral uploads are cleaned when the consumer is done

--- a/backend/routers/internal/agents.py
+++ b/backend/routers/internal/agents.py
@@ -642,6 +642,8 @@ async def chat_with_agent(
     file_references: Annotated[Optional[str], Form()] = None,
     search_params: Annotated[Optional[str], Form()] = None,
     conversation_id: Annotated[Optional[int], Form()] = None,
+    override_execution_profile: Annotated[Optional[int], Form()] = None,
+    override_temperature: Annotated[Optional[float], Form()] = None,
 ):
     """
     Internal API: Chat with agent for playground (OAuth authentication)
@@ -653,6 +655,8 @@ async def chat_with_agent(
         file_references: Optional JSON array of file_ids to include. If not provided, all files are included.
         search_params: Optional search parameters
         conversation_id: Optional conversation ID to continue existing conversation
+        override_execution_profile: Execution profile override (0=FAST, 1=BALANCED, 2=DEEP, 3=MAX). None = inherit from agent/service.
+        override_temperature: Temperature override (0.0-2.0). None = inherit from model config.
     """
     fms = FileManagementService()
     all_file_references: list = []
@@ -698,6 +702,8 @@ async def chat_with_agent(
             user_context=user_context,
             conversation_id=conversation_id,
             db=db,
+            override_execution_profile=override_execution_profile,
+            override_temperature=override_temperature,
         )
 
         # Increment marketplace usage counter (if marketplace agent and not exempt)

--- a/backend/routers/internal/agents.py
+++ b/backend/routers/internal/agents.py
@@ -387,6 +387,7 @@ async def create_or_update_agent(
         'silo_id': agent_data.silo_id,
         'output_parser_id': agent_data.output_parser_id,
         'temperature': agent_data.temperature,
+        'execution_profile': agent_data.execution_profile,
         # OCR-specific fields
         'vision_service_id': agent_data.vision_service_id,
         'vision_system_prompt': agent_data.vision_system_prompt,

--- a/backend/routers/internal/ai_services.py
+++ b/backend/routers/internal/ai_services.py
@@ -437,7 +437,7 @@ async def get_execution_profiles(
 ):
     """
     Get execution profiles configuration.
-    
+
     Returns the four execution profiles (FAST, BALANCED, DEEP, MAX) and
     indicates which providers support reasoning with their mapping.
     """

--- a/backend/routers/internal/ai_services.py
+++ b/backend/routers/internal/ai_services.py
@@ -19,7 +19,12 @@ from services.provider_models_service import (
 )
 
 # Import schemas and auth
-from schemas.ai_service_schemas import AIServiceListItemSchema, AIServiceDetailSchema, CreateUpdateAIServiceSchema
+from schemas.ai_service_schemas import (
+    AIServiceListItemSchema,
+    AIServiceDetailSchema,
+    CreateUpdateAIServiceSchema,
+    ExecutionProfilesResponseSchema,
+)
 from schemas.import_schemas import ConflictMode, ImportResponseSchema
 from schemas.export_schemas import AIServiceExportFileSchema
 from schemas.provider_models_schemas import (
@@ -415,3 +420,31 @@ async def export_ai_service(
     except Exception as e:
         logger.error(f"Export error: {str(e)}", exc_info=True)
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Export failed")
+
+
+# ==================== EXECUTION PROFILES ENDPOINTS ====================
+
+
+@ai_services_router.get(
+    "/execution-profiles",
+    summary="Get execution profiles configuration",
+    tags=["AI Services"],
+    response_model=ExecutionProfilesResponseSchema,
+)
+async def get_execution_profiles(
+    auth_context: Annotated[AuthContext, Depends(get_current_user_oauth)],
+    role: Annotated[AppRole, Depends(require_min_role("viewer"))],
+):
+    """
+    Get execution profiles configuration.
+    
+    Returns the four execution profiles (FAST, BALANCED, DEEP, MAX) and
+    indicates which providers support reasoning with their mapping.
+    """
+    try:
+        return AIServiceService.get_execution_profiles()
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error retrieving execution profiles: {str(e)}"
+        )

--- a/backend/routers/internal/marketplace.py
+++ b/backend/routers/internal/marketplace.py
@@ -576,6 +576,18 @@ def _safe_increment_marketplace_usage(user_id: int, db: Session) -> None:
         logger.error(f"Failed to increment marketplace usage for user {user_id}: {inc_err}")
 
 
+def _parse_execution_profile(value: Optional[str]) -> Optional[int]:
+    """Parse an optional execution profile string to int, returning None for 'inherit' or empty."""
+    if not value or value.strip() == '':
+        return None
+    if value.strip().lower() == 'inherit':
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
 def _prepare_marketplace_chat(
     conversation_id: int,
     user_id: int,
@@ -611,6 +623,7 @@ async def marketplace_chat(
     current_user: Annotated[AuthContext, Depends(get_current_user_oauth)],
     files: Annotated[List[UploadFile], File()] = None,
     file_references: Annotated[Optional[str], Form()] = None,
+    override_execution_profile: Annotated[Optional[str], Form()] = None,
 ):
     """Send a message in a marketplace conversation."""
     user_id = int(current_user.identity.id)
@@ -648,6 +661,7 @@ async def marketplace_chat(
             user_context=user_context,
             conversation_id=conversation_id,
             db=db,
+            override_execution_profile=_parse_execution_profile(override_execution_profile),
         )
 
         _safe_increment_marketplace_usage(user_id, db)
@@ -683,6 +697,7 @@ async def marketplace_chat_stream(
     current_user: Annotated[AuthContext, Depends(get_current_user_oauth)],
     files: Annotated[List[UploadFile], File()] = None,
     file_references: Annotated[Optional[str], Form()] = None,
+    override_execution_profile: Annotated[Optional[str], Form()] = None,
 ):
     """Stream a marketplace chat turn as Server-Sent Events.
 
@@ -723,6 +738,7 @@ async def marketplace_chat_stream(
             user_context=user_context,
             conversation_id=conversation_id,
             db=db,
+            override_execution_profile=_parse_execution_profile(override_execution_profile),
         )
 
         async def generator() -> AsyncGenerator[str, None]:

--- a/backend/routers/internal/marketplace.py
+++ b/backend/routers/internal/marketplace.py
@@ -583,9 +583,18 @@ def _parse_execution_profile(value: Optional[str]) -> Optional[int]:
     if value.strip().lower() == 'inherit':
         return None
     try:
-        return int(value)
-    except ValueError:
-        return None
+        profile = int(value)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="override_execution_profile must be an integer from 0 to 3 or 'inherit'.",
+        ) from exc
+    if profile not in range(4):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="override_execution_profile must be an integer from 0 to 3 or 'inherit'.",
+        )
+    return profile
 
 
 def _prepare_marketplace_chat(

--- a/backend/schemas/agent_schemas.py
+++ b/backend/schemas/agent_schemas.py
@@ -137,6 +137,7 @@ class AgentDetailSchema(BaseModel):
     silo_id: Optional[int] = None
     output_parser_id: Optional[int] = None
     temperature: float = DEFAULT_AGENT_TEMPERATURE
+    execution_profile: Optional[int] = None
     tool_ids: List[int] = []
     mcp_config_ids: List[int] = []
     skill_ids: List[int] = []
@@ -190,6 +191,7 @@ class CreateUpdateAgentSchema(RagConfigFieldsMixin):
     silo_id: Optional[int] = None
     output_parser_id: Optional[int] = None
     temperature: Optional[float] = DEFAULT_AGENT_TEMPERATURE
+    execution_profile: Optional[int] = None
     tool_ids: Optional[List[int]] = []
     mcp_config_ids: Optional[List[int]] = []
     skill_ids: Optional[List[int]] = []
@@ -244,6 +246,7 @@ class PublicAgentDetailSchema(BaseModel):
     silo_id: Optional[int] = None
     output_parser_id: Optional[int] = None
     temperature: Optional[float] = DEFAULT_AGENT_TEMPERATURE
+    execution_profile: Optional[int] = None
     # OCR-specific fields
     vision_service_id: Optional[int] = None
     vision_system_prompt: Optional[str] = None
@@ -272,6 +275,7 @@ class CreateAgentRequestSchema(RagConfigFieldsMixin):
     silo_id: Optional[int] = None
     output_parser_id: Optional[int] = None
     temperature: Optional[float] = DEFAULT_AGENT_TEMPERATURE
+    execution_profile: Optional[int] = None
     tool_ids: Optional[List[int]] = []
     mcp_config_ids: Optional[List[int]] = []
     skill_ids: Optional[List[int]] = []
@@ -292,6 +296,7 @@ class CreateOCRAgentRequestSchema(BaseModel):
     text_system_prompt: Optional[str] = ""
     output_parser_id: Optional[int] = None
     temperature: Optional[float] = DEFAULT_AGENT_TEMPERATURE
+    execution_profile: Optional[int] = None
     tool_ids: Optional[List[int]] = []
     mcp_config_ids: Optional[List[int]] = []
     skill_ids: Optional[List[int]] = []
@@ -312,6 +317,7 @@ class UpdateAgentRequestSchema(RagConfigFieldsMixin):
     silo_id: Optional[int] = None
     output_parser_id: Optional[int] = None
     temperature: Optional[float] = None
+    execution_profile: Optional[int] = None
     tool_ids: Optional[List[int]] = None
     mcp_config_ids: Optional[List[int]] = None
     skill_ids: Optional[List[int]] = None

--- a/backend/schemas/ai_service_schemas.py
+++ b/backend/schemas/ai_service_schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing import Optional, List, Dict, Any
 from datetime import datetime
 
@@ -7,7 +7,7 @@ class ExecutionProfileSchema(BaseModel):
     """Schema for execution profile choices available to the user."""
     profile_name: str
     level: int
-    
+
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -18,7 +18,7 @@ class AIServiceListItemSchema(BaseModel):
     provider: Optional[str] = None
     model_name: str
     supports_video: bool = False
-    execution_profile: int = 1
+    execution_profile: int = Field(1, ge=0, le=3)
     created_at: Optional[datetime]
     needs_api_key: bool = False
     is_system: bool = False
@@ -35,7 +35,7 @@ class AIServiceDetailSchema(BaseModel):
     api_key: str
     base_url: str
     supports_video: bool = False
-    execution_profile: int = 1
+    execution_profile: int = Field(1, ge=0, le=3)
     created_at: Optional[datetime] = None
     available_providers: List[Dict[str, Any]] = []
     execution_profiles: List[ExecutionProfileSchema] = []
@@ -59,7 +59,7 @@ class CreateUpdateAIServiceSchema(BaseModel):
     # via ``api_key``; the access key id and region travel here.
     aws_access_key_id: Optional[str] = None
     aws_region: Optional[str] = None
-    execution_profile: Optional[int] = 1
+    execution_profile: Optional[int] = Field(1, ge=0, le=3)
 
     @field_validator("api_key", "base_url", "aws_access_key_id", "aws_region", mode="before")
     @classmethod

--- a/backend/schemas/ai_service_schemas.py
+++ b/backend/schemas/ai_service_schemas.py
@@ -3,7 +3,13 @@ from typing import Optional, List, Dict, Any
 from datetime import datetime
 
 
-# ==================== AI SERVICE SCHEMAS ====================
+class ExecutionProfileSchema(BaseModel):
+    """Schema for execution profile choices available to the user."""
+    profile_name: str
+    level: int
+    
+    model_config = ConfigDict(from_attributes=True)
+
 
 class AIServiceListItemSchema(BaseModel):
     """Schema for AI service list items"""
@@ -12,6 +18,7 @@ class AIServiceListItemSchema(BaseModel):
     provider: Optional[str] = None
     model_name: str
     supports_video: bool = False
+    execution_profile: int = 1
     created_at: Optional[datetime]
     needs_api_key: bool = False
     is_system: bool = False
@@ -28,8 +35,10 @@ class AIServiceDetailSchema(BaseModel):
     api_key: str
     base_url: str
     supports_video: bool = False
+    execution_profile: int = 1
     created_at: Optional[datetime] = None
     available_providers: List[Dict[str, Any]] = []
+    execution_profiles: List[ExecutionProfileSchema] = []
     needs_api_key: bool = False
     # AWS Bedrock identifiers (non-secret). Empty for other providers.
     aws_access_key_id: Optional[str] = None
@@ -50,6 +59,7 @@ class CreateUpdateAIServiceSchema(BaseModel):
     # via ``api_key``; the access key id and region travel here.
     aws_access_key_id: Optional[str] = None
     aws_region: Optional[str] = None
+    execution_profile: Optional[int] = 1
 
     @field_validator("api_key", "base_url", "aws_access_key_id", "aws_region", mode="before")
     @classmethod
@@ -59,3 +69,10 @@ class CreateUpdateAIServiceSchema(BaseModel):
         # whitespace cause httpx to fail building the Authorization header
         # and the OpenAI SDK reports it as a misleading "Connection error".
         return v.strip() if isinstance(v, str) else v
+
+
+class ExecutionProfilesResponseSchema(BaseModel):
+    """Schema for the execution profile configuration endpoint."""
+    profiles: List[ExecutionProfileSchema]
+    default_profile: ExecutionProfileSchema
+    available_providers: List[str]

--- a/backend/schemas/export_schemas.py
+++ b/backend/schemas/export_schemas.py
@@ -171,6 +171,7 @@ class ExportAgentSchema(BaseModel):
     memory_max_tokens: Optional[int] = None
     memory_summarize_threshold: Optional[int] = 10
     temperature: Optional[float] = 0.7
+    execution_profile: Optional[int] = None
     # OCR-specific fields
     vision_service_name: Optional[str] = None  # Reference by name (OCR agents only)
     vision_system_prompt: Optional[str] = None  # OCR agents only

--- a/backend/services/agent_execution_context.py
+++ b/backend/services/agent_execution_context.py
@@ -44,3 +44,7 @@ class AgentExecutionContext:
     processed_files: List[Dict[str, Any]] = field(default_factory=list)
     search_params: Optional[Dict[str, Any]] = None
     user_context: Optional[Dict[str, Any]] = None
+
+    # Per-request runtime overrides (take priority over agent/service defaults)
+    override_execution_profile: Optional[int] = None
+    override_temperature: Optional[float] = None

--- a/backend/services/agent_execution_service.py
+++ b/backend/services/agent_execution_service.py
@@ -360,6 +360,8 @@ class AgentExecutionService:
         user_context: Dict = None,
         conversation_id: int = None,
         db: Session = None,
+        override_execution_profile: Optional[int] = None,
+        override_temperature: Optional[float] = None,
     ) -> Dict[str, Any]:
         """Execute agent chat with persistent file references.
 

--- a/backend/services/agent_execution_service.py
+++ b/backend/services/agent_execution_service.py
@@ -377,6 +377,8 @@ class AgentExecutionService:
                 user_context=user_context,
                 conversation_id=conversation_id,
                 db=db,
+                override_execution_profile=override_execution_profile,
+                override_temperature=override_temperature,
             )
             sandbox_turn_active = self._begin_sandbox_turn(ctx, db=db)
 
@@ -419,6 +421,8 @@ class AgentExecutionService:
         user_context: Dict = None,
         conversation_id: int = None,
         db: Session = None,
+        override_execution_profile: int = None,
+        override_temperature: float = None,
     ) -> AgentExecutionContext:
         """Run all setup steps for one agent chat turn.
 
@@ -646,6 +650,8 @@ class AgentExecutionService:
             processed_files=processed_files,
             search_params=search_params,
             user_context=user_context,
+            override_execution_profile=override_execution_profile,
+            override_temperature=override_temperature,
         )
 
     def _sandbox_turn_expected_seconds(self) -> int:

--- a/backend/services/agent_export_service.py
+++ b/backend/services/agent_export_service.py
@@ -144,6 +144,7 @@ class AgentExportService(BaseExportService):
             memory_max_tokens=agent.memory_max_tokens,
             memory_summarize_threshold=agent.memory_summarize_threshold,
             temperature=agent.temperature,
+            execution_profile=agent.execution_profile,
             # OCR-specific fields
             vision_service_name=vision_service_name,
             vision_system_prompt=vision_system_prompt,

--- a/backend/services/agent_import_service.py
+++ b/backend/services/agent_import_service.py
@@ -755,6 +755,7 @@ class AgentImportService:
                     export_data.agent.memory_summarize_threshold
                 )
                 existing_agent.temperature = export_data.agent.temperature
+                existing_agent.execution_profile = export_data.agent.execution_profile
                 
                 # Update OCR-specific fields if present
                 if hasattr(existing_agent, 'vision_system_prompt'):
@@ -841,6 +842,7 @@ class AgentImportService:
                     export_data.agent.memory_summarize_threshold
                 ),
                 temperature=export_data.agent.temperature,
+                execution_profile=export_data.agent.execution_profile,
                 vision_service_id=vision_service_id,
                 vision_system_prompt=export_data.agent.vision_system_prompt,
                 text_system_prompt=export_data.agent.text_system_prompt,
@@ -865,6 +867,7 @@ class AgentImportService:
                     export_data.agent.memory_summarize_threshold
                 ),
                 temperature=export_data.agent.temperature,
+                execution_profile=export_data.agent.execution_profile,
                 create_date=datetime.now(),
                 request_count=0,
                 is_tool=False,

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -110,6 +110,7 @@ class AgentService:
             silo_id=getattr(agent, 'silo_id', None),
             output_parser_id=getattr(agent, 'output_parser_id', None),
             temperature=agent.temperature if agent.temperature is not None else DEFAULT_AGENT_TEMPERATURE,
+            execution_profile=getattr(agent, 'execution_profile', None),
             tool_ids=associations['tool_ids'],
             mcp_config_ids=associations['mcp_ids'],
             skill_ids=associations['skill_ids'],
@@ -154,7 +155,7 @@ class AgentService:
             return type('Agent', (), {
                 'agent_id': 0, 'name': '', 'system_prompt': '', 'prompt_template': '', 
                 'type': 'agent', 'is_tool': False, 'create_date': None, 'request_count': 0,
-                'temperature': DEFAULT_AGENT_TEMPERATURE
+                'temperature': DEFAULT_AGENT_TEMPERATURE, 'execution_profile': None
             })()
         else:
             # Existing agent - determine if it's OCR agent or regular agent

--- a/backend/services/agent_streaming_service.py
+++ b/backend/services/agent_streaming_service.py
@@ -130,75 +130,6 @@ class AgentStreamingService:
                 },
             )
 
-            # ----------------------------------------------------------------
-            # 3. Build agent chain
-            # ----------------------------------------------------------------
-            agent_chain, mcp_client = await create_agent(
-                ctx.fresh_agent,
-                ctx.search_params,
-                ctx.session_id_for_cache,
-                ctx.user_context,
-                ctx.working_dir,
-                override_execution_profile=ctx.override_execution_profile,
-                override_temperature=ctx.override_temperature,
-            )
-
-            config = prepare_agent_config(ctx.fresh_agent)
-
-            if ctx.fresh_agent.has_memory and ctx.session_id_for_cache:
-                config["configurable"]["thread_id"] = (
-                    f"thread_{ctx.fresh_agent.agent_id}_{ctx.session_id_for_cache}"
-                )
-                logger.info(
-                    "Using session-aware thread_id: %s",
-                    config["configurable"]["thread_id"],
-                )
-            else:
-                config["configurable"]["thread_id"] = (
-                    f"thread_{ctx.fresh_agent.agent_id}"
-                )
-
-            config["configurable"]["question"] = ctx.enhanced_message
-
-            # ----------------------------------------------------------------
-            # 4. Build the HumanMessage payload (handles multimodal images)
-            # ----------------------------------------------------------------
-            message_payload = build_human_message(
-                ctx.fresh_agent, ctx.enhanced_message, ctx.image_files, ctx.user_context
-            )
-
-            # ----------------------------------------------------------------
-            # 5. Attach LangSmith tracer + metadata when configured
-            # ----------------------------------------------------------------
-            ls_settings = resolve_langsmith_settings(ctx.fresh_agent.app)
-            if ls_settings:
-                tracer, overrides = build_tracing_config(
-                    ls_settings,
-                    agent=ctx.fresh_agent,
-                    user_context=ctx.user_context,
-                    conversation_id=ctx.effective_conv_id,
-                    session_id=ctx.session_id_for_cache,
-                )
-                apply_tracing_to_config(config, tracer, overrides)
-                logger.info(
-                    "LangSmith tracing ENABLED — project='%s' source='%s'",
-                    ls_settings.project_name,
-                    ls_settings.source,
-                )
-
-            # ----------------------------------------------------------------
-            # 6. Streaming loop — the only part that stays in this service
-            # ----------------------------------------------------------------
-            # Return the sync connection to the pool for the duration of the
-            # stream: astream uses the async checkpointer, not this session, so
-            # holding it across LLM I/O would exhaust the pool. ctx objects expire
-            # but stay attached, so _finalize_turn reloads them on demand.
-            if effective_db is not None:
-                effective_db.commit()
-
-            accumulated_content = ""
-            structured_response = None
-
             for attempt in range(2):
                 mcp_client = None
                 # ------------------------------------------------------------
@@ -213,6 +144,8 @@ class AgentStreamingService:
                     sandbox_handle=ctx.sandbox_handle,
                     sandbox_provider=ctx.sandbox_provider,
                     sandbox_session_key=ctx.sandbox_session_key,
+                    override_execution_profile=ctx.override_execution_profile,
+                    override_temperature=ctx.override_temperature,
                 )
                 agent_chain, mcp_client = create_agent_result[:2]
 

--- a/backend/services/agent_streaming_service.py
+++ b/backend/services/agent_streaming_service.py
@@ -53,6 +53,8 @@ class AgentStreamingService:
         user_context: dict | None = None,
         conversation_id: int | None = None,
         db: Session | None = None,
+        override_execution_profile: int | None = None,
+        override_temperature: float | None = None,
     ) -> AsyncGenerator[str, None]:
         """Stream an agent chat turn as SSE events.
 
@@ -107,6 +109,8 @@ class AgentStreamingService:
                 user_context=user_context,
                 conversation_id=conversation_id,
                 db=effective_db,
+                override_execution_profile=override_execution_profile,
+                override_temperature=override_temperature,
             )
             sandbox_turn_active = self.execution_service._begin_sandbox_turn(
                 ctx,
@@ -125,6 +129,72 @@ class AgentStreamingService:
                     "has_memory": ctx.agent.has_memory,
                 },
             )
+
+            # ----------------------------------------------------------------
+            # 3. Build agent chain
+            # ----------------------------------------------------------------
+            agent_chain, mcp_client = await create_agent(
+                ctx.fresh_agent,
+                ctx.search_params,
+                ctx.session_id_for_cache,
+                ctx.user_context,
+                ctx.working_dir,
+                override_execution_profile=ctx.override_execution_profile,
+                override_temperature=ctx.override_temperature,
+            )
+
+            config = prepare_agent_config(ctx.fresh_agent)
+
+            if ctx.fresh_agent.has_memory and ctx.session_id_for_cache:
+                config["configurable"]["thread_id"] = (
+                    f"thread_{ctx.fresh_agent.agent_id}_{ctx.session_id_for_cache}"
+                )
+                logger.info(
+                    "Using session-aware thread_id: %s",
+                    config["configurable"]["thread_id"],
+                )
+            else:
+                config["configurable"]["thread_id"] = (
+                    f"thread_{ctx.fresh_agent.agent_id}"
+                )
+
+            config["configurable"]["question"] = ctx.enhanced_message
+
+            # ----------------------------------------------------------------
+            # 4. Build the HumanMessage payload (handles multimodal images)
+            # ----------------------------------------------------------------
+            message_payload = build_human_message(
+                ctx.fresh_agent, ctx.enhanced_message, ctx.image_files, ctx.user_context
+            )
+
+            # ----------------------------------------------------------------
+            # 5. Attach LangSmith tracer + metadata when configured
+            # ----------------------------------------------------------------
+            ls_settings = resolve_langsmith_settings(ctx.fresh_agent.app)
+            if ls_settings:
+                tracer, overrides = build_tracing_config(
+                    ls_settings,
+                    agent=ctx.fresh_agent,
+                    user_context=ctx.user_context,
+                    conversation_id=ctx.effective_conv_id,
+                    session_id=ctx.session_id_for_cache,
+                )
+                apply_tracing_to_config(config, tracer, overrides)
+                logger.info(
+                    "LangSmith tracing ENABLED — project='%s' source='%s'",
+                    ls_settings.project_name,
+                    ls_settings.source,
+                )
+
+            # ----------------------------------------------------------------
+            # 6. Streaming loop — the only part that stays in this service
+            # ----------------------------------------------------------------
+            # Return the sync connection to the pool for the duration of the
+            # stream: astream uses the async checkpointer, not this session, so
+            # holding it across LLM I/O would exhaust the pool. ctx objects expire
+            # but stay attached, so _finalize_turn reloads them on demand.
+            if effective_db is not None:
+                effective_db.commit()
 
             accumulated_content = ""
             structured_response = None

--- a/backend/services/ai_service_service.py
+++ b/backend/services/ai_service_service.py
@@ -5,6 +5,7 @@ from schemas.ai_service_schemas import (
     AIServiceListItemSchema,
     AIServiceDetailSchema,
     CreateUpdateAIServiceSchema,
+    ExecutionProfileSchema,
 )
 from core.export_constants import PLACEHOLDER_API_KEY
 from utils.secret_utils import mask_api_key, is_masked_key
@@ -12,12 +13,32 @@ from tools.aws_bedrock_utils import build_extra_config, parse_extra_config
 from datetime import datetime
 from typing import List
 from tools.aiServiceTools import create_llm_from_service
+from tools.execution_profiles import ExecutionProfile
 from utils.logger import get_logger
 import asyncio
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from langchain_core.runnables import RunnableConfig
 
 logger = get_logger(__name__)
+
+
+def _execution_profiles_for_provider(provider: str) -> List[ExecutionProfileSchema]:
+    """Return the four execution profile options for a provider."""
+    profiles = []
+    for ep in ExecutionProfile:
+        profiles.append(ExecutionProfileSchema(
+            profile_name=ep.name,
+            level=ep.value,
+        ))
+    return profiles
+
+
+def _get_default_execution_profile(provider: str) -> ExecutionProfile:
+    """Get the default execution profile for a provider."""
+    from tools.execution_profiles import get_provider_capability
+    cap = get_provider_capability(provider)
+    return cap.default_profile if cap else ExecutionProfile.BALANCED
+
 
 class AIServiceService:
 
@@ -34,6 +55,7 @@ class AIServiceService:
             provider=service.provider.value if hasattr(service.provider, 'value') else service.provider,
             model_name=service.description or "",  # description stores model name
             supports_video=service.supports_video or False,
+            execution_profile=int(getattr(service, 'execution_profile', 1) or 1),
             created_at=service.create_date,
             needs_api_key=needs_api_key,
             is_system=is_system,
@@ -65,9 +87,14 @@ class AIServiceService:
                 api_key="",
                 base_url="",
                 supports_video=False,
+                execution_profile=1,
                 created_at=None,
                 # Form data
-                available_providers=providers
+                available_providers=providers,
+                execution_profiles=[
+                    ExecutionProfileSchema(profile_name=ep.name, level=ep.value)
+                    for ep in ExecutionProfile
+                ],
             )
         
         # Existing AI service
@@ -92,8 +119,13 @@ class AIServiceService:
             api_key=mask_api_key(service.api_key),
             base_url=service.endpoint or "",  # Use endpoint as base_url
             supports_video=service.supports_video or False,
+            execution_profile=int(getattr(service, 'execution_profile', 1) or 1),
             created_at=service.create_date,
             available_providers=providers,
+            execution_profiles=[
+                ExecutionProfileSchema(profile_name=ep.name, level=ep.value)
+                for ep in ExecutionProfile
+            ],
             needs_api_key=needs_api_key,
             aws_access_key_id=extra_cfg.get("aws_access_key_id"),
             aws_region=extra_cfg.get("aws_region"),
@@ -135,6 +167,19 @@ class AIServiceService:
             service_data.aws_access_key_id,
             service_data.aws_region,
         )
+        # Handle execution profile
+        if service_data.execution_profile is not None:
+            try:
+                service.execution_profile = int(service_data.execution_profile)
+            except (ValueError, TypeError):
+                service.execution_profile = 1
+        elif service_id == 0 and service.provider:
+            # Set default for new services based on provider
+            provider_name = service.provider
+            if hasattr(provider_name, 'value'):
+                provider_name = provider_name.value
+            default_profile = _get_default_execution_profile(provider_name)
+            service.execution_profile = default_profile.value
         
         # Create or update the service
         if service_id == 0:
@@ -171,6 +216,7 @@ class AIServiceService:
             endpoint=service.endpoint,
             supports_video=service.supports_video or False,
             extra_config=service.extra_config,
+            execution_profile=getattr(service, 'execution_profile', 1),
             create_date=datetime.now()
         )
         
@@ -204,6 +250,7 @@ class AIServiceService:
                     self.api_version = data.get('api_version')
                     self.extra_config = data.get('extra_config')
             
+
             service = MockAIService(config)
             
             # Guard: placeholder, missing, or masked API key
@@ -329,6 +376,7 @@ class AIServiceService:
         }
         
         return AIServiceService.test_connection_with_config(config)
+    
     @staticmethod
     def delete_by_app_id(app_id: int):
         """Delete all AI services for a specific app"""
@@ -338,3 +386,40 @@ class AIServiceService:
             AIServiceRepository.delete_by_app_id(session, app_id)
         finally:
             session.close() 
+
+    @staticmethod
+    def get_execution_profiles(provider: str = None) -> "schemas.ai_service_schemas.ExecutionProfilesResponseSchema":
+        """Get execution profiles configuration.
+        
+        Returns the four standard profiles and indicates which providers support
+        reasoning with which parameters.
+        """
+        from tools.execution_profiles import get_provider_capability
+        from schemas.ai_service_schemas import ExecutionProfilesResponseSchema
+
+        available_providers = []
+        for p in ProviderEnum:
+            provider_name = p.value if hasattr(p, 'value') else p
+            cap = get_provider_capability(provider_name)
+            if provider is None or provider_name == provider:
+                available_providers.append({
+                    "provider": provider_name,
+                    "supports_reasoning": cap.supported,
+                    "reasoning_kwarg": cap.reasoning_kwarg,
+                    "default_profile": cap.default_profile.name if cap.supported else None,
+                })
+
+        profiles = [
+            ExecutionProfileSchema(profile_name=ep.name, level=ep.value)
+            for ep in ExecutionProfile
+        ]
+        default = ExecutionProfileSchema(
+            profile_name=ExecutionProfile.BALANCED.name,
+            level=ExecutionProfile.BALANCED.value,
+        )
+
+        return ExecutionProfilesResponseSchema(
+            profiles=profiles,
+            default_profile=default,
+            available_providers=available_providers,
+        )

--- a/backend/services/ai_service_service.py
+++ b/backend/services/ai_service_service.py
@@ -55,7 +55,10 @@ class AIServiceService:
             provider=service.provider.value if hasattr(service.provider, 'value') else service.provider,
             model_name=service.description or "",  # description stores model name
             supports_video=service.supports_video or False,
-            execution_profile=int(getattr(service, 'execution_profile', 1) or 1),
+            execution_profile=int(
+                1 if getattr(service, 'execution_profile', None) is None
+                else service.execution_profile
+            ),
             created_at=service.create_date,
             needs_api_key=needs_api_key,
             is_system=is_system,
@@ -119,7 +122,10 @@ class AIServiceService:
             api_key=mask_api_key(service.api_key),
             base_url=service.endpoint or "",  # Use endpoint as base_url
             supports_video=service.supports_video or False,
-            execution_profile=int(getattr(service, 'execution_profile', 1) or 1),
+            execution_profile=int(
+                1 if getattr(service, 'execution_profile', None) is None
+                else service.execution_profile
+            ),
             created_at=service.create_date,
             available_providers=providers,
             execution_profiles=[
@@ -374,9 +380,9 @@ class AIServiceService:
             "api_key": service.api_key,
             "endpoint": service.endpoint
         }
-        
+
         return AIServiceService.test_connection_with_config(config)
-    
+
     @staticmethod
     def delete_by_app_id(app_id: int):
         """Delete all AI services for a specific app"""
@@ -385,12 +391,12 @@ class AIServiceService:
         try:
             AIServiceRepository.delete_by_app_id(session, app_id)
         finally:
-            session.close() 
+            session.close()
 
     @staticmethod
     def get_execution_profiles(provider: str = None) -> "schemas.ai_service_schemas.ExecutionProfilesResponseSchema":
         """Get execution profiles configuration.
-        
+
         Returns the four standard profiles and indicates which providers support
         reasoning with which parameters.
         """

--- a/backend/tools/agentTools.py
+++ b/backend/tools/agentTools.py
@@ -236,7 +236,7 @@ async def create_agent(
         override_execution_profile: optional per-request execution profile override
         override_temperature: optional per-request temperature override
     """
-    llm = get_llm(agent, override_temperature=override_temperature)
+    llm = get_llm(agent, override_temperature=override_temperature, override_execution_profile=override_execution_profile)
     if llm is None:
         raise ValueError("No LLM found for agent")
 

--- a/backend/tools/agentTools.py
+++ b/backend/tools/agentTools.py
@@ -218,6 +218,8 @@ async def create_agent(
     sandbox_provider: Optional[Any] = None,
     sandbox_session_key: Optional[str] = None,
     sandbox_session_service: Optional[Any] = None,
+    override_execution_profile: Optional[int] = None,
+    override_temperature: Optional[float] = None
 ):
     """Create a new agent instance with cached checkpointer if memory is enabled.
 
@@ -231,8 +233,10 @@ async def create_agent(
         sandbox_provider: Optional provider matching sandbox_handle
         sandbox_session_key: Optional key for sandbox active-use leasing
         sandbox_session_service: Optional service used for sandbox active-use leasing
+        override_execution_profile: optional per-request execution profile override
+        override_temperature: optional per-request temperature override
     """
-    llm = get_llm(agent)
+    llm = get_llm(agent, override_temperature=override_temperature)
     if llm is None:
         raise ValueError("No LLM found for agent")
 

--- a/backend/tools/aiServiceTools.py
+++ b/backend/tools/aiServiceTools.py
@@ -162,7 +162,7 @@ def create_llm_from_service(
     return builder()
 
 
-def get_llm(agent, is_vision=False, override_temperature: Optional[float] = None):
+def get_llm(agent, is_vision=False, override_temperature: Optional[float] = None, override_execution_profile: Optional[int] = None):
     """
     Función base para obtener cualquier modelo LLM
     Args:
@@ -185,6 +185,7 @@ def get_llm(agent, is_vision=False, override_temperature: Optional[float] = None
     return create_llm_from_service(
         ai_service, temperature, is_vision, agent=agent,
         override_temperature=override_temperature,
+        override_execution_profile=override_execution_profile,
     )
 
 class MistralWrapper:

--- a/backend/tools/aiServiceTools.py
+++ b/backend/tools/aiServiceTools.py
@@ -51,14 +51,21 @@ def get_output_parser(agent):
 # Legacy functions removed - now using create_agent from agentTools.py
 # This provides full tool support, MCP integration, and LangSmith tracing
 
-def _resolve_execution_profile(ai_service, agent, is_vision=False) -> "ExecutionProfile":
+def _resolve_execution_profile(ai_service, agent, is_vision=False, override_profile=None) -> "ExecutionProfile":
     """Resolve the execution profile for an LLM build.
 
     Resolution order:
-      1. Agent-level override (if set)
-      2. AI service default
-      3. Provider default
+      1. Per-request override (if provided)
+      2. Agent-level override (if set)
+      3. AI service default
+      4. Provider default
     """
+    if override_profile is not None:
+        try:
+            return ExecutionProfile(int(override_profile))
+        except ValueError:
+            pass
+
     agent_profile = getattr(agent, 'execution_profile', None) if agent is not None else None
     if agent_profile is not None:
         try:
@@ -81,6 +88,8 @@ def create_llm_from_service(
     temperature=0,
     is_vision=False,
     agent: Optional[Any] = None,
+    override_execution_profile: Optional[int] = None,
+    override_temperature: Optional[float] = None,
 ) -> Any:
     """
     Create an LLM instance from an AIService model, threaded with
@@ -91,6 +100,8 @@ def create_llm_from_service(
         temperature: float.
         is_vision: boolean (used for Mistral vision path).
         agent: optional Agent that may override the service profile.
+        override_execution_profile: optional per-request execution profile override.
+        override_temperature: optional per-request temperature override.
     """
     provider_builders = {
         ProviderEnum.OpenAI.value: lambda: _build_openai_llm(ai_service, temperature),
@@ -103,7 +114,12 @@ def create_llm_from_service(
         ProviderEnum.OpenRouter.value: lambda: _build_openrouter_llm(ai_service, temperature),
         ProviderEnum.Bedrock.value: lambda: _build_bedrock_llm(ai_service, temperature),
     }
-    execution_profile = _resolve_execution_profile(ai_service, agent, is_vision)
+    # Determine which temperature to use: per-request override > agent value
+    effective_temperature = temperature
+    if override_temperature is not None:
+        effective_temperature = override_temperature
+
+    execution_profile = _resolve_execution_profile(ai_service, agent, is_vision, override_profile=override_execution_profile)
 
     # Handle case where provider might be an Enum object instead of string
     provider = ai_service.provider
@@ -120,7 +136,12 @@ def create_llm_from_service(
     )
 
     # Determine temperature — may be disabled by the runtime config
-    temp = temperature if not runtime_config.disable_temperature else None
+    temp = effective_temperature if not runtime_config.disable_temperature else None
+
+    # If the model requires a specific temperature value (e.g. 1.0) regardless
+    # of what the agent or user configured, override here.
+    if runtime_config.force_temperature is not None:
+        temp = runtime_config.force_temperature
 
     # Dispatch to provider-specific builder with runtime kwargs
     provider_builders = {
@@ -141,12 +162,13 @@ def create_llm_from_service(
     return builder()
 
 
-def get_llm(agent, is_vision=False):
+def get_llm(agent, is_vision=False, override_temperature: Optional[float] = None):
     """
     Función base para obtener cualquier modelo LLM
     Args:
         agent: Agent object with model configuration
         is_vision: Boolean que indica si es un modelo de visión
+        override_temperature: optional per-request temperature override
     """
     if is_vision:
         ai_service = agent.vision_service_rel
@@ -158,9 +180,12 @@ def get_llm(agent, is_vision=False):
     
     # Get temperature from agent, default to DEFAULT_AGENT_TEMPERATURE if not set
     from models.agent import DEFAULT_AGENT_TEMPERATURE
-    temperature = getattr(agent, 'temperature', DEFAULT_AGENT_TEMPERATURE)
+    temperature = override_temperature if override_temperature is not None else getattr(agent, 'temperature', DEFAULT_AGENT_TEMPERATURE)
 
-    return create_llm_from_service(ai_service, temperature, is_vision, agent=agent)
+    return create_llm_from_service(
+        ai_service, temperature, is_vision, agent=agent,
+        override_temperature=override_temperature,
+    )
 
 class MistralWrapper:
     def __init__(self, client, model_name):

--- a/backend/tools/aiServiceTools.py
+++ b/backend/tools/aiServiceTools.py
@@ -218,6 +218,8 @@ def _build_openai_llm(ai_service, temperature, runtime_config):
     # Add runtime reasoning kwargs
     kwargs.update(build_runtime_kwargs(runtime_config))
 
+    logger.info("OpenAI LLM kwargs: %s", kwargs)
+
     return ChatOpenAI(**kwargs)
 
 
@@ -427,6 +429,8 @@ def _build_google_llm(ai_service, temperature, runtime_config):
             google_kwargs["client_options"] = client_options
 
     google_kwargs.update(build_runtime_kwargs(runtime_config))
+
+    logger.info("Google LLM kwargs: %s", google_kwargs)
 
     return ChatGoogleGenerativeAI(**google_kwargs)
 

--- a/backend/tools/aiServiceTools.py
+++ b/backend/tools/aiServiceTools.py
@@ -14,9 +14,14 @@ from urllib.parse import urlparse
 
 from models.ai_service import ProviderEnum
 from tools.outputParserTools import get_parser_model_by_id
-from typing import List
+from typing import List, Any, Optional
 from langchain_core.documents import Document
 from tools.embeddingTools import get_embeddings_model
+from tools.execution_profiles import (
+    ExecutionProfile,
+    RuntimeConfigBuilder,
+    build_runtime_kwargs,
+)
 from utils.logger import get_logger
 
 load_dotenv()
@@ -46,13 +51,46 @@ def get_output_parser(agent):
 # Legacy functions removed - now using create_agent from agentTools.py
 # This provides full tool support, MCP integration, and LangSmith tracing
 
-def create_llm_from_service(ai_service, temperature=0, is_vision=False):
+def _resolve_execution_profile(ai_service, agent, is_vision=False) -> "ExecutionProfile":
+    """Resolve the execution profile for an LLM build.
+
+    Resolution order:
+      1. Agent-level override (if set)
+      2. AI service default
+      3. Provider default
     """
-    Create an LLM instance from an AIService model
+    agent_profile = getattr(agent, 'execution_profile', None) if agent is not None else None
+    if agent_profile is not None:
+        try:
+            return ExecutionProfile(agent_profile)
+        except ValueError:
+            pass
+
+    service_profile = getattr(ai_service, 'execution_profile', 1)
+    if service_profile is not None:
+        try:
+            return ExecutionProfile(int(service_profile))
+        except ValueError:
+            pass
+
+    return ExecutionProfile.BALANCED
+
+
+def create_llm_from_service(
+    ai_service,
+    temperature=0,
+    is_vision=False,
+    agent: Optional[Any] = None,
+) -> Any:
+    """
+    Create an LLM instance from an AIService model, threaded with
+    execution-profile parameters.
+
     Args:
-        ai_service: AIService model instance
-        temperature: float
-        is_vision: boolean
+        ai_service: AIService model instance.
+        temperature: float.
+        is_vision: boolean (used for Mistral vision path).
+        agent: optional Agent that may override the service profile.
     """
     provider_builders = {
         ProviderEnum.OpenAI.value: lambda: _build_openai_llm(ai_service, temperature),
@@ -65,17 +103,43 @@ def create_llm_from_service(ai_service, temperature=0, is_vision=False):
         ProviderEnum.OpenRouter.value: lambda: _build_openrouter_llm(ai_service, temperature),
         ProviderEnum.Bedrock.value: lambda: _build_bedrock_llm(ai_service, temperature),
     }
+    execution_profile = _resolve_execution_profile(ai_service, agent, is_vision)
 
     # Handle case where provider might be an Enum object instead of string
     provider = ai_service.provider
     if hasattr(provider, 'value'):
         provider = provider.value
 
+    model_id = ai_service.description or ""
+
+    # Build runtime config from provider + model + profile
+    runtime_config = RuntimeConfigBuilder.build(
+        provider=provider,
+        model_id=model_id,
+        execution_profile=execution_profile,
+    )
+
+    # Determine temperature — may be disabled by the runtime config
+    temp = temperature if not runtime_config.disable_temperature else None
+
+    # Dispatch to provider-specific builder with runtime kwargs
+    provider_builders = {
+        ProviderEnum.OpenAI.value: lambda: _build_openai_llm(ai_service, temp, runtime_config),
+        ProviderEnum.Anthropic.value: lambda: _build_anthropic_llm(ai_service, temp, runtime_config),
+        ProviderEnum.MistralAI.value: lambda: _build_mistral_llm(ai_service, temp, is_vision, runtime_config),
+        ProviderEnum.Custom.value: lambda: _build_custom_llm(ai_service, temp, runtime_config),
+        ProviderEnum.Azure.value: lambda: _build_azure_llm(ai_service, temp, runtime_config),
+        ProviderEnum.Google.value: lambda: _build_google_llm(ai_service, temp, runtime_config),
+        ProviderEnum.GoogleCloud.value: lambda: _build_google_cloud_llm(ai_service, temp, runtime_config),
+        ProviderEnum.OpenRouter.value: lambda: _build_openrouter_llm(ai_service, temp, runtime_config),
+    }
+
     builder = provider_builders.get(provider)
     if builder is None:
         raise ValueError(f"Proveedor de modelo no soportado: {provider}")
 
     return builder()
+
 
 def get_llm(agent, is_vision=False):
     """
@@ -96,7 +160,7 @@ def get_llm(agent, is_vision=False):
     from models.agent import DEFAULT_AGENT_TEMPERATURE
     temperature = getattr(agent, 'temperature', DEFAULT_AGENT_TEMPERATURE)
 
-    return create_llm_from_service(ai_service, temperature, is_vision)
+    return create_llm_from_service(ai_service, temperature, is_vision, agent=agent)
 
 class MistralWrapper:
     def __init__(self, client, model_name):
@@ -105,28 +169,37 @@ class MistralWrapper:
 
 class VoidRetriever(BaseRetriever):
     
-    def _get_relevant_documents(self, query: str) -> List[Document]:
+    def _get_relevant_documents(self, query: str) -> "List[Document]":
         return []
 
-    async def _aget_relevant_documents(self, query: str) -> List[Document]:
+    async def _aget_relevant_documents(self, query: str) -> "List[Document]":
         return []
 
 
-def _build_openai_llm(ai_service, temperature):
+def _build_openai_llm(ai_service, temperature, runtime_config):
     base_url = ai_service.endpoint if ai_service.endpoint else None
-    return ChatOpenAI(
-        model=ai_service.description,
-        temperature=temperature,
-        api_key=ai_service.api_key,
-        base_url=base_url,
-    )
+
+    kwargs = {
+        "model": ai_service.description,
+        "api_key": ai_service.api_key,
+        "base_url": base_url,
+    }
+
+    # Temperature (may be skipped by runtime config)
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+
+    # Add runtime reasoning kwargs
+    kwargs.update(build_runtime_kwargs(runtime_config))
+
+    return ChatOpenAI(**kwargs)
 
 
 # OpenRouter session-level defaults — configurable later via env vars.
 _OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
 
 
-def _build_openrouter_llm(ai_service, temperature):
+def _build_openrouter_llm(ai_service, temperature, runtime_config):
     """Build a ChatOpenAI instance pointed at OpenRouter's API.
 
     OpenRouter speaks the OpenAI chat completions protocol, so we reuse
@@ -143,35 +216,54 @@ def _build_openrouter_llm(ai_service, temperature):
         "X-Title": "MattinAI",
     }
 
-    return ChatOpenAI(
-        model=ai_service.description,
-        temperature=temperature,
-        api_key=ai_service.api_key,
-        base_url=base_url,
-        default_headers=default_headers,
-    )
+    kwargs = {
+        "model": ai_service.description,
+        "api_key": ai_service.api_key,
+        "base_url": base_url,
+        "default_headers": default_headers,
+    }
+
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+
+    kwargs.update(build_runtime_kwargs(runtime_config))
+
+    return ChatOpenAI(**kwargs)
 
 
-def _build_anthropic_llm(ai_service, temperature):
-    return ChatAnthropic(
-        model=ai_service.description,
-        temperature=temperature,
-        api_key=ai_service.api_key,
-    )
+def _build_anthropic_llm(ai_service, temperature, runtime_config):
+    kwargs = {
+        "model": ai_service.description,
+        "api_key": ai_service.api_key,
+    }
+
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+
+    kwargs.update(build_runtime_kwargs(runtime_config))
+
+    return ChatAnthropic(**kwargs)
 
 
-def _build_mistral_llm(ai_service, temperature, is_vision):
+def _build_mistral_llm(ai_service, temperature, is_vision, runtime_config):
     if is_vision:
         mistral_client = Mistral(api_key=ai_service.api_key)
         return MistralWrapper(client=mistral_client, model_name=ai_service.description)
-    return ChatMistralAI(
-        model=ai_service.description,
-        temperature=temperature,
-        api_key=ai_service.api_key,
-    )
+
+    kwargs = {
+        "model": ai_service.description,
+        "api_key": ai_service.api_key,
+    }
+
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+
+    kwargs.update(build_runtime_kwargs(runtime_config))
+
+    return ChatMistralAI(**kwargs)
 
 
-def build_ollama_auth_headers(api_key: str | None, endpoint: str | None) -> dict[str, str]:
+def build_ollama_auth_headers(api_key: Optional[str], endpoint: Optional[str]) -> dict:
     """Build auth headers for an Ollama-protocol endpoint.
 
     Self-hosted Ollama instances are commonly placed behind a reverse
@@ -187,7 +279,7 @@ def build_ollama_auth_headers(api_key: str | None, endpoint: str | None) -> dict
     adapter in :mod:`tools.ai.provider_model_clients` so the two paths
     cannot drift out of sync.
     """
-    headers: dict[str, str] = {}
+    headers = {}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
     if endpoint:
@@ -199,30 +291,42 @@ def build_ollama_auth_headers(api_key: str | None, endpoint: str | None) -> dict
     return headers
 
 
-def _build_custom_llm(ai_service, temperature):
+def _build_custom_llm(ai_service, temperature, runtime_config):
     client_kwargs = {"verify": False}
     headers = build_ollama_auth_headers(ai_service.api_key, ai_service.endpoint)
     if headers:
         client_kwargs["headers"] = headers
 
-    service = ChatOllama(
-        model=ai_service.description,
-        temperature=temperature,
-        base_url=ai_service.endpoint,
-        client_kwargs=client_kwargs,
-    )
-    logger.info(f"Service: {service}")
-    return service
+    kwargs = {
+        "model": ai_service.description,
+        "client_kwargs": client_kwargs,
+    }
+
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+
+    if ai_service.endpoint:
+        kwargs["base_url"] = ai_service.endpoint
+
+    kwargs.update(build_runtime_kwargs(runtime_config))
+
+    return ChatOllama(**kwargs)
 
 
-def _build_azure_llm(ai_service, temperature):
-    return AzureAIChatCompletionsModel(
-        model=ai_service.description,
-        temperature=temperature,
-        credential=ai_service.api_key,
-        endpoint=ai_service.endpoint,
-        api_version=ai_service.api_version,
-    )
+def _build_azure_llm(ai_service, temperature, runtime_config):
+    kwargs = {
+        "model": ai_service.description,
+        "credential": ai_service.api_key,
+        "endpoint": ai_service.endpoint,
+        "api_version": ai_service.api_version,
+    }
+
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+
+    kwargs.update(build_runtime_kwargs(runtime_config))
+
+    return AzureAIChatCompletionsModel(**kwargs)
 
 
 def _build_bedrock_llm(ai_service, temperature):
@@ -279,12 +383,14 @@ def _resolve_google_client_options(endpoint_raw, service_name):
     return {"api_endpoint": f"https://{host}"}
 
 
-def _build_google_llm(ai_service, temperature):
+def _build_google_llm(ai_service, temperature, runtime_config):
     google_kwargs = {
         "model": ai_service.description,
-        "temperature": temperature,
         "api_key": ai_service.api_key,
     }
+
+    if temperature is not None:
+        google_kwargs["temperature"] = temperature
 
     endpoint_raw = (ai_service.endpoint or "").strip()
     if endpoint_raw:
@@ -294,10 +400,14 @@ def _build_google_llm(ai_service, temperature):
         if client_options:
             google_kwargs["client_options"] = client_options
 
+    google_kwargs.update(build_runtime_kwargs(runtime_config))
+
     return ChatGoogleGenerativeAI(**google_kwargs)
 
-def _build_google_cloud_llm(ai_service, temperature):
-    import json, os
+
+def _build_google_cloud_llm(ai_service, temperature, runtime_config):
+    import json
+    import os
     from google.oauth2 import service_account
 
     project_id = (ai_service.endpoint or "").strip()
@@ -317,11 +427,17 @@ def _build_google_cloud_llm(ai_service, temperature):
         scopes=["https://www.googleapis.com/auth/cloud-platform"],
     )
 
-    return ChatGoogleGenerativeAI(
-        model=ai_service.description,
-        temperature=temperature,
-        credentials=credentials,
-        project=project_id,
-        location=location,
-        vertexai=True,
-    )
+    kwargs = {
+        "model": ai_service.description,
+        "credentials": credentials,
+        "project": project_id,
+        "location": location,
+        "vertexai": True,
+    }
+
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+
+    kwargs.update(build_runtime_kwargs(runtime_config))
+
+    return ChatGoogleGenerativeAI(**kwargs)

--- a/backend/tools/aiServiceTools.py
+++ b/backend/tools/aiServiceTools.py
@@ -103,17 +103,6 @@ def create_llm_from_service(
         override_execution_profile: optional per-request execution profile override.
         override_temperature: optional per-request temperature override.
     """
-    provider_builders = {
-        ProviderEnum.OpenAI.value: lambda: _build_openai_llm(ai_service, temperature),
-        ProviderEnum.Anthropic.value: lambda: _build_anthropic_llm(ai_service, temperature),
-        ProviderEnum.MistralAI.value: lambda: _build_mistral_llm(ai_service, temperature, is_vision),
-        ProviderEnum.Custom.value: lambda: _build_custom_llm(ai_service, temperature),
-        ProviderEnum.Azure.value: lambda: _build_azure_llm(ai_service, temperature),
-        ProviderEnum.Google.value: lambda: _build_google_llm(ai_service, temperature),
-        ProviderEnum.GoogleCloud.value: lambda: _build_google_cloud_llm(ai_service, temperature),
-        ProviderEnum.OpenRouter.value: lambda: _build_openrouter_llm(ai_service, temperature),
-        ProviderEnum.Bedrock.value: lambda: _build_bedrock_llm(ai_service, temperature),
-    }
     # Determine which temperature to use: per-request override > agent value
     effective_temperature = temperature
     if override_temperature is not None:
@@ -153,6 +142,7 @@ def create_llm_from_service(
         ProviderEnum.Google.value: lambda: _build_google_llm(ai_service, temp, runtime_config),
         ProviderEnum.GoogleCloud.value: lambda: _build_google_cloud_llm(ai_service, temp, runtime_config),
         ProviderEnum.OpenRouter.value: lambda: _build_openrouter_llm(ai_service, temp, runtime_config),
+        ProviderEnum.Bedrock.value: lambda: _build_bedrock_llm(ai_service, temp, runtime_config),
     }
 
     builder = provider_builders.get(provider)
@@ -217,8 +207,6 @@ def _build_openai_llm(ai_service, temperature, runtime_config):
 
     # Add runtime reasoning kwargs
     kwargs.update(build_runtime_kwargs(runtime_config))
-
-    logger.info("OpenAI LLM kwargs: %s", kwargs)
 
     return ChatOpenAI(**kwargs)
 
@@ -357,7 +345,7 @@ def _build_azure_llm(ai_service, temperature, runtime_config):
     return AzureAIChatCompletionsModel(**kwargs)
 
 
-def _build_bedrock_llm(ai_service, temperature):
+def _build_bedrock_llm(ai_service, temperature, runtime_config):
     from langchain_aws import ChatBedrockConverse
 
     from tools.aws_bedrock_utils import resolve_bedrock_credentials
@@ -372,6 +360,8 @@ def _build_bedrock_llm(ai_service, temperature):
     endpoint_raw = (ai_service.endpoint or "").strip()
     if endpoint_raw:
         bedrock_kwargs["endpoint_url"] = endpoint_raw
+
+    bedrock_kwargs.update(build_runtime_kwargs(runtime_config))
 
     return ChatBedrockConverse(**bedrock_kwargs)
 
@@ -429,8 +419,6 @@ def _build_google_llm(ai_service, temperature, runtime_config):
             google_kwargs["client_options"] = client_options
 
     google_kwargs.update(build_runtime_kwargs(runtime_config))
-
-    logger.info("Google LLM kwargs: %s", google_kwargs)
 
     return ChatGoogleGenerativeAI(**google_kwargs)
 

--- a/backend/tools/execution_profiles.py
+++ b/backend/tools/execution_profiles.py
@@ -663,7 +663,7 @@ def _register_builtin_model_overrides() -> None:
     register_model_override(
         ModelCapability(
             provider=PROVIDER_OPENAI,
-            regex_pattern=r"^gpt-5\.(?:1|2|3)(?:-[a-z]+)*$",
+            regex_pattern=r"^gpt-5\.(?:1|2|3)-chat-latest$",
             profile_values={
                 ExecutionProfile.FAST: "medium",
                 ExecutionProfile.BALANCED: "medium",
@@ -671,6 +671,14 @@ def _register_builtin_model_overrides() -> None:
                 ExecutionProfile.MAX: "medium",
             },
             force_temperature=1.0,
+        )
+    )
+
+    register_model_override(
+        ModelCapability(
+            provider=PROVIDER_OPENAI,
+            regex_pattern=r"^gpt-5-chat-latest$",
+            supports_reasoning=False,
         )
     )
 
@@ -685,7 +693,15 @@ def _register_builtin_model_overrides() -> None:
     register_model_override(
         ModelCapability(
             provider=PROVIDER_OPENAI,
-            regex_pattern=r"^gpt-5\.(?:[4-9]|[1-9][0-9]+)(?:-[a-z]+)*$",
+            regex_pattern=r"^gpt-5\.[4-9]",
+            supports_reasoning=False,
+        )
+    )
+
+    register_model_override(
+        ModelCapability(
+            provider=PROVIDER_OPENAI,
+            regex_pattern=r"(^|-)search(-|$)",
             supports_reasoning=False,
         )
     )
@@ -697,14 +713,21 @@ def _register_builtin_model_overrides() -> None:
     register_model_override(
         ModelCapability(
             provider=PROVIDER_OPENAI,
-            regex_pattern=r"^gpt-4\.1",
+            regex_pattern=r"^gpt-4",
+            supports_reasoning=False,
+        )
+    )
+
+    register_model_override(
+        ModelCapability(
+            provider=PROVIDER_GOOGLE,
+            regex_pattern=r"^gemini-2\.5",
             profile_values={
-                ExecutionProfile.FAST: "medium",
-                ExecutionProfile.BALANCED: "medium",
-                ExecutionProfile.DEEP: "medium",
-                ExecutionProfile.MAX: "medium",
-            },
-            force_temperature=1.0,
+                ExecutionProfile.FAST: 1024,
+                ExecutionProfile.BALANCED: 5000,
+                ExecutionProfile.DEEP: 24576,
+                ExecutionProfile.MAX: 24576,
+            }
         )
     )
 

--- a/backend/tools/execution_profiles.py
+++ b/backend/tools/execution_profiles.py
@@ -1,0 +1,580 @@
+"""
+Execution Profiles for Mattin AI.
+
+A provider-agnostic abstraction that controls model behaviour
+(primarily reasoning depth) through four profiles: FAST, BALANCED, DEEP, MAX.
+
+The rest of the application never sees provider-specific reasoning
+ parameters — the ``ExecutionProfileRegistry`` and ``RuntimeConfigBuilder``
+ handle the mapping automatically.
+"""
+
+from __future__ import annotations
+
+import re
+import enum
+import dataclasses
+from typing import Dict, List, Optional, Any
+
+from tools.ai.model_catalog import PROVIDER_OPENAI, PROVIDER_ANTHROPIC
+from tools.ai.model_catalog import (
+    PROVIDER_MISTRAL,
+    PROVIDER_GOOGLE,
+    PROVIDER_GOOGLE_CLOUD,
+    PROVIDER_AZURE,
+    PROVIDER_OPENROUTER,
+    PROVIDER_CUSTOM,
+)
+
+# ====================================================================
+# ExecutionProfile enum
+# ====================================================================
+
+
+class ExecutionProfile(enum.IntEnum):
+    """Profiles are integer levels that the **entire application** uses.
+
+    Internally each provider maps these levels to its own reasoning
+    parameters (reasoning effort, thinking tokens, etc.).  The rest of
+    Mattin AI should never see those provider-specific values — it
+    only works with ``ExecutionProfile``.
+    """
+
+    FAST = 0
+    BALANCED = 1
+    DEEP = 2
+    MAX = 3
+
+
+# ====================================================================
+# ProviderCapability
+# ====================================================================
+
+
+@dataclasses.dataclass(frozen=True)
+class ProviderCapability:
+    """Describes how a provider handles reasoning / thinking.
+
+    The registry contains one ``ProviderCapability`` instance per
+    provider.  Each provider definition states:
+
+    * Whether reasoning is supported at all.
+    * The runtime kwarg name that carries the value
+      (``reasoning_effort``, ``thinking_budget``, ``reasoning_level``,
+      or a free-form key for future mechanisms).
+    * How the four execution levels map to provider-specific values.
+    * A default execution profile for the provider.
+
+    When a new provider needs reasoning support, developers only
+    **add an entry to the registry** — no other code path changes.
+    """
+
+    supported: bool = False
+
+    # The exact model kwarg that LangChain / provider SDK expects
+    # (e.g. ``reasoning_effort``, ``thinking_budget``, ``reasoning_level``).
+    reasoning_kwarg: Optional[str] = None
+
+    # Mapping from ExecutionProfile -> the value the provider SDK understands.
+    profile_values: Dict[ExecutionProfile, Any] = dataclasses.field(default_factory=dict)
+
+    # When reasoning is enabled, which profile the provider should start
+    # with (usually FAST or BALANCED).
+    default_profile: ExecutionProfile = ExecutionProfile.BALANCED
+
+    # When True and a reasoning profile is active, the runtime builder
+    # will add the kwarg to the model kwargs sent to LangChain.
+    @property
+    def has_reasoning_config(self) -> bool:
+        return self.supported and self.reasoning_kwarg is not None
+
+
+# ====================================================================
+# ModelCapability
+# ====================================================================
+
+
+@dataclasses.dataclass(frozen=True)
+class ModelCapability:
+    """Per-model (or per-prefix) overrides for a provider's capabilities.
+
+    A ``ModelCapability`` inherits everything from its parent
+    ``ProviderCapability`` unless explicitly overridden.  Prefix
+    matching lets administrators define behaviour for an entire
+    model family with a single entry (e.g. ``gpt-4o`` covers
+    ``gpt-4o-2024-05-13``, ``gpt-4o-mini``, etc.).
+    """
+
+    # Regex prefix to match against the model id (e.g. ``o1``,
+    # ``claude-3-5``, ``gemini-2``).  If ``regex_pattern`` is empty
+    # the capability applies to a single specific model id
+    # (``model_id`` field).
+    regex_pattern: str = ""
+
+    # The provider this rule applies to (e.g. "OpenAI", "Anthropic").
+    # When ``regex_pattern`` is empty this field is ignored.
+    provider: str = ""
+
+    # When a regex_prefix is set this is ignored.
+    model_id: str = ""
+
+    # Capability overrides — only non-None values are applied.
+    supports_reasoning: Optional[bool] = None
+    # Override the provider's profiling values (e.g. make a model
+    # support DEEP but not MAX).  If ``None`` the provider defaults
+    # are inherited.
+    profile_values: Optional[Dict[ExecutionProfile, Any]] = None
+
+    # Disable temperature for this model (some reasoning models
+    # reject temperature when thinking is enabled).
+    disable_temperature: bool = False
+
+    # Other capability flags (mirrors ProviderCapabilities from
+    # schemas.provider_models_schemas for discovery consistency).
+    supports_vision: Optional[bool] = None
+    supports_json_mode: Optional[bool] = None
+
+    @classmethod
+    def for_model(cls, provider: str, model_id: str) -> ModelCapability:
+        """Find the most specific ModelCapability for *model_id*.
+
+        Walks the **global model overrides** registry (``_MODEL_OVERRIDES``)
+        and returns the first matching rule — exact match takes
+        precedence over the longest prefix match.
+        """
+        lid = model_id.lower() if model_id else ""
+
+        # 1. Exact match
+        for rule in _MODEL_OVERRIDES:
+            if rule.provider == provider and rule.model_id == model_id:
+                return rule
+
+        # 2. Longest prefix match
+        best_match: Optional[ModelCapability] = None
+        best_len = 0
+
+        for rule in _MODEL_OVERRIDES:
+            if rule.provider != provider:
+                continue
+            if not rule.regex_pattern:
+                continue
+            if re.search(rule.regex_pattern, lid):
+                pat_len = len(rule.regex_pattern)
+                if pat_len > best_len:
+                    best_len = pat_len
+                    best_match = rule
+
+        if best_match is not None:
+            return best_match
+
+        # 3. Fallback — sentinel that means "use provider defaults".
+        return ModelCapability()
+
+    def apply_provider_defaults(self, provider_cap: ProviderCapability) -> ProviderCapability:
+        """Return a new ``ProviderCapability`` with overrides applied."""
+        pc = dataclasses.replace(provider_cap)
+
+        if self.supports_reasoning is not None:
+            pc = dataclasses.replace(pc, supported=self.supports_reasoning)
+
+        if self.profile_values is not None:
+            pc = dataclasses.replace(pc, profile_values=dict(self.profile_values))
+
+        return pc
+
+    @property
+    def should_disable_temperature(self) -> bool:
+        if not self.supports_reasoning:
+            return False
+        return self.disable_temperature
+
+
+# ====================================================================
+# RuntimeConfig
+# ====================================================================
+
+
+@dataclasses.dataclass(frozen=True)
+class RuntimeConfig:
+    """Minimal, provider-agnostic config for the inference layer.
+
+    The agent LLM builder passes **only** this object to the runtime
+    kwarg generator — the caller never queries provider definitions
+    directly.
+    """
+
+    # Identity
+    provider: str
+    model_id: str
+
+    # Execution profile chosen by the user / inherited from the AIService.
+    execution_profile: ExecutionProfile
+
+    # Reasoning runtime parameter: the kwarg name and value that will
+    # be sent to the LLM client (e.g. ``("reasoning_effort", "high")``).
+    # ``None`` when reasoning is not supported for this model/profile.
+    reasoning_kwarg: Optional[str] = None
+    reasoning_value: Optional[Any] = None
+
+    # Capability flags — precomputed from provider + model override so
+    # the inference layer only looks at runtime config.
+    supports_reasoning: bool = False
+    supports_vision: bool = False
+    supports_json_mode: bool = False
+
+    # When the provider disables temperature alongside reasoning
+    # (some models reject ``temperature`` when thinking is on).
+    disable_temperature: bool = False
+
+    # Execution-profile metadata (default profile, available levels).
+    # Exposed so callers can validate overrides.
+    default_profile: ExecutionProfile = ExecutionProfile.BALANCED
+
+    # Execution profile limits — how much the model can do at each level.
+    # Provider-level defaults, possibly overridden at model level.
+    profile_values: Dict[ExecutionProfile, Any] = dataclasses.field(default_factory=dict)
+
+
+# ====================================================================
+# RuntimeConfigBuilder
+# ====================================================================
+
+
+class RuntimeConfigBuilder:
+    """Builds a :class:`RuntimeConfig` from provider, model, and profile.
+
+    Resolution order:
+
+    1. Look up the provider's ``ProviderCapability`` in the global registry.
+    2. Apply ``ModelCapability`` overrides from the global overrides.
+    3. Populate the ``RuntimeConfig`` with the resolved kwarg mapping.
+    """
+
+    @staticmethod
+    def build(
+        provider: str,
+        model_id: str,
+        execution_profile: ExecutionProfile,
+    ) -> RuntimeConfig:
+        # 1. Provider defaults
+        provider_cap = _REGISTRY.get(provider) or ProviderCapability()
+
+        # 2. Model overrides
+        model_cap = ModelCapability.for_model(provider, model_id)
+        resolved = model_cap.apply_provider_defaults(provider_cap)
+
+        # 3. Resolve specific value for the chosen profile
+        reasoning_kwarg: Optional[str] = None
+        reasoning_value: Optional[Any] = None
+
+        if resolved.has_reasoning_config:
+            profile_val = resolved.profile_values.get(execution_profile)
+            if profile_val is not None:
+                reasoning_kwarg = resolved.reasoning_kwarg
+                reasoning_value = profile_val
+
+        # 4. Compute derived capability flags
+        caps = model_cap.supports_reasoning or resolved.supported
+        disallow_temp = model_cap.should_disable_temperature and caps
+
+        return RuntimeConfig(
+            provider=provider,
+            model_id=model_id,
+            execution_profile=execution_profile,
+            reasoning_kwarg=reasoning_kwarg,
+            reasoning_value=reasoning_value,
+            supports_reasoning=caps,
+            supports_vision=model_cap.supports_vision or False,
+            supports_json_mode=model_cap.supports_json_mode or False,
+            disable_temperature=disallow_temp,
+            default_profile=resolved.default_profile,
+            profile_values=dict(resolved.profile_values),
+        )
+
+
+# ====================================================================
+# Runtime kwarg builder
+# ====================================================================
+
+
+def build_runtime_kwargs(
+    runtime_config: RuntimeConfig,
+    temperature: Optional[float] = None,
+    additional_kwargs: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Turn a :class:`RuntimeConfig` into model kwargs for the LLM client.
+
+    This is the **single generic function** the inference layer calls to
+    produce the kwargs dictionary for ``ChatOpenAI(...)``,
+    ``ChatAnthropic(...)``, etc.
+
+    Usage::
+
+        rc = RuntimeConfigBuilder.build(
+            provider="OpenAI",
+            model_id="gpt-4o",
+            execution_profile=ExecutionProfile.DEEP,
+        )
+        kwargs = build_runtime_kwargs(rc, temperature=0.7)
+        # kwargs = {"thinking_budget": 125_000, "temperature": 0.7}
+        llm = ChatAnthropic(**kwargs, api_key=...)
+
+    Adding a new provider with a new reasoning mechanism only requires
+    registering it in ``_REGISTRY`` — the kwarg builder stays unchanged.
+    """
+    kwargs: Dict[str, Any] = {}
+
+    # Temperature — may be skipped when the profile disables it.
+    if temperature is not None and not runtime_config.disable_temperature:
+        kwargs["temperature"] = temperature
+
+    # Reasoning parameter
+    if runtime_config.reasoning_kwarg is not None and runtime_config.reasoning_value is not None:
+        kwargs[runtime_config.reasoning_kwarg] = runtime_config.reasoning_value
+
+    # Additional override kwargs (retrievers, custom metadata…)
+    if additional_kwargs:
+        kwargs.update(additional_kwargs)
+
+    return kwargs
+
+
+# ====================================================================
+# Global registry — provider capabilities
+# ====================================================================
+
+_REGISTRY: Dict[str, ProviderCapability] = {}
+
+
+def register_provider_capability(capability: ProviderCapability, provider: str) -> None:
+    """Register (or update) a provider's reasoning configuration.
+
+    Call this at module-initialisation time to define how each
+    provider maps execution profiles to its own parameters.
+    """
+    _REGISTRY[provider] = capability
+
+
+def get_provider_capability(provider: str) -> ProviderCapability:
+    """Return the capability for *provider*, or a disabled sentinel."""
+    return _REGISTRY.get(provider) or ProviderCapability()
+
+
+# ====================================================================
+# Global model overrides registry
+# ====================================================================
+
+_MODEL_OVERRIDES: List[ModelCapability] = []
+
+
+def register_model_override(override: ModelCapability) -> None:
+    """Append a per-model override to the global registry."""
+    _MODEL_OVERRIDES.append(override)
+
+
+def clear_model_overrides() -> None:
+    """Clear all model overrides.  Useful for tests."""
+    _MODEL_OVERRIDES.clear()
+
+
+# ====================================================================
+# Built-in provider capabilities
+# ====================================================================
+
+
+def _register_builtin_capabilities() -> None:
+    """Wire up reasoning capabilities for every supported provider."""
+
+    # --------------------------------------------------------------
+    # OpenAI  — reasoning_effort parameter (o-series, gpt-4o+)
+    # "low" | "medium" | "high"  or None when disabled
+    # --------------------------------------------------------------
+    register_provider_capability(
+        ProviderCapability(
+            supported=True,
+            reasoning_kwarg="reasoning_effort",
+            profile_values={
+                ExecutionProfile.FAST: "low",
+                ExecutionProfile.BALANCED: "medium",
+                ExecutionProfile.DEEP: "high",
+                ExecutionProfile.MAX: "high",
+            },
+            default_profile=ExecutionProfile.BALANCED,
+        ),
+        PROVIDER_OPENAI,
+    )
+
+    # --------------------------------------------------------------
+    # Anthropic  — thinking_budget parameter (optional)
+    # integer token budget (0-125000)
+    # --------------------------------------------------------------
+    register_provider_capability(
+        ProviderCapability(
+            supported=True,
+            reasoning_kwarg="thinking_budget",
+            profile_values={
+                ExecutionProfile.FAST: 1024,
+                ExecutionProfile.BALANCED: 5000,
+                ExecutionProfile.DEEP: 50000,
+                ExecutionProfile.MAX: 125000,
+            },
+            default_profile=ExecutionProfile.BALANCED,
+        ),
+        PROVIDER_ANTHROPIC,
+    )
+
+    # --------------------------------------------------------------
+    # MistralAI  — no native reasoning parameter yet
+    # --------------------------------------------------------------
+    register_provider_capability(
+        ProviderCapability(
+            supported=False,
+            default_profile=ExecutionProfile.BALANCED,
+        ),
+        PROVIDER_MISTRAL,
+    )
+
+    # --------------------------------------------------------------
+    # Google Gemini  — thinking_config / thinking_budget token budget
+    # Gemini uses thinking_budget (int) via client_options.
+    # --------------------------------------------------------------
+    register_provider_capability(
+        ProviderCapability(
+            supported=True,
+            reasoning_kwarg="thinking_budget",
+            profile_values={
+                ExecutionProfile.FAST: 1024,
+                ExecutionProfile.BALANCED: 5000,
+                ExecutionProfile.DEEP: 50000,
+                ExecutionProfile.MAX: 125000,
+            },
+            default_profile=ExecutionProfile.BALANCED,
+        ),
+        PROVIDER_GOOGLE,
+    )
+
+    # --------------------------------------------------------------
+    # Google Cloud (Vertex AI) — same mechanism as Gemini
+    # --------------------------------------------------------------
+    register_provider_capability(
+        ProviderCapability(
+            supported=True,
+            reasoning_kwarg="thinking_budget",
+            profile_values={
+                ExecutionProfile.FAST: 1024,
+                ExecutionProfile.BALANCED: 5000,
+                ExecutionProfile.DEEP: 50000,
+                ExecutionProfile.MAX: 125000,
+            },
+            default_profile=ExecutionProfile.BALANCED,
+        ),
+        PROVIDER_GOOGLE_CLOUD,
+    )
+
+    # --------------------------------------------------------------
+    # Azure OpenAI  — supports reasoning_effort via Azure's API
+    # --------------------------------------------------------------
+    register_provider_capability(
+        ProviderCapability(
+            supported=True,
+            reasoning_kwarg="reasoning_effort",
+            profile_values={
+                ExecutionProfile.FAST: "low",
+                ExecutionProfile.BALANCED: "medium",
+                ExecutionProfile.DEEP: "high",
+                ExecutionProfile.MAX: "high",
+            },
+            default_profile=ExecutionProfile.BALANCED,
+        ),
+        PROVIDER_AZURE,
+    )
+
+    # --------------------------------------------------------------
+    # OpenRouter  — passes reasoning parameter through to underlying
+    # model (provider-agnostic — OpenRouter normalises reasoning_effort).
+    # --------------------------------------------------------------
+    register_provider_capability(
+        ProviderCapability(
+            supported=True,
+            reasoning_kwarg="reasoning_effort",
+            profile_values={
+                ExecutionProfile.FAST: "low",
+                ExecutionProfile.BALANCED: "medium",
+                ExecutionProfile.DEEP: "high",
+                ExecutionProfile.MAX: "high",
+            },
+            default_profile=ExecutionProfile.BALANCED,
+        ),
+        PROVIDER_OPENROUTER,
+    )
+
+    # --------------------------------------------------------------
+    # Custom / Ollama  — may support reasoning parameters but
+    # default to disabled until the user configures it.
+    # --------------------------------------------------------------
+    register_provider_capability(
+        ProviderCapability(
+            supported=False,
+            default_profile=ExecutionProfile.BALANCED,
+        ),
+        PROVIDER_CUSTOM,
+    )
+
+
+# ====================================================================
+# Built-in model overrides
+# ====================================================================
+
+
+def _register_builtin_model_overrides() -> None:
+    """Register per-model capability overrides."""
+
+    # OpenAI o-series: reasoning is mandatory and temperature is
+    # incompatible with thinking.
+    register_model_override(
+        ModelCapability(
+            provider=PROVIDER_OPENAI,
+            regex_pattern=r"^o\d",
+            supports_reasoning=True,
+            disable_temperature=True,
+            supports_vision=True,
+        )
+    )
+
+    # Claude models: reasoning is always enabled; disable temperature
+    # when thinking budget > 0 (Anthropic's behaviour for some models).
+    register_model_override(
+        ModelCapability(
+            provider=PROVIDER_ANTHROPIC,
+            regex_pattern=r"^claude-(?:opus|sonnet|haiku)-\d",
+            supports_vision=True,
+        )
+    )
+
+    # Gemini models: multimodal, reasoning supported.
+    register_model_override(
+        ModelCapability(
+            provider=PROVIDER_GOOGLE,
+            regex_pattern=r"^gemini-[2-9]",
+            supports_reasoning=True,
+            supports_vision=True,
+        )
+    )
+
+    register_model_override(
+        ModelCapability(
+            provider=PROVIDER_GOOGLE,
+            regex_pattern=r"^gemini-1\.5",
+            supports_reasoning=True,
+            supports_vision=True,
+        )
+    )
+
+
+# ====================================================================
+# Module initialisation
+# ====================================================================
+
+
+_register_builtin_capabilities()
+_register_builtin_model_overrides()

--- a/backend/tools/execution_profiles.py
+++ b/backend/tools/execution_profiles.py
@@ -713,8 +713,15 @@ def _register_builtin_model_overrides() -> None:
     register_model_override(
         ModelCapability(
             provider=PROVIDER_OPENAI,
-            regex_pattern=r"^gpt-4",
-            supports_reasoning=False,
+            regex_pattern=r"^gpt-4\.1",
+            supports_reasoning=True,
+            profile_values={
+                ExecutionProfile.FAST: "medium",
+                ExecutionProfile.BALANCED: "medium",
+                ExecutionProfile.DEEP: "medium",
+                ExecutionProfile.MAX: "medium",
+            },
+            force_temperature=1.0,
         )
     )
 

--- a/backend/tools/execution_profiles.py
+++ b/backend/tools/execution_profiles.py
@@ -658,7 +658,7 @@ def _register_builtin_model_overrides() -> None:
     register_model_override(
         ModelCapability(
             provider=PROVIDER_OPENAI,
-            regex_pattern=r"^gpt-5\.",
+            regex_pattern=r"^gpt-5\.[4-9]",
             supports_reasoning=False,
         )
     )
@@ -672,7 +672,7 @@ def _register_builtin_model_overrides() -> None:
     register_model_override(
         ModelCapability(
             provider=PROVIDER_OPENAI,
-            regex_pattern=r"^gpt-5\.[1-3](?!\d)",
+            regex_pattern = r"^gpt-5\.[1-3]-chat-latest$",
             force_temperature=1.0,
         )
     )

--- a/backend/tools/execution_profiles.py
+++ b/backend/tools/execution_profiles.py
@@ -506,6 +506,9 @@ def _register_builtin_capabilities() -> None:
     )
 
     # ------ Google Gemini — thinking_budget token budget
+    # Gemini API rejects thinking_budget outside [-1, 65535].
+    # Cap DEEP/MAX at 65535 to keep profile range safe across all
+    # Gemini models (flash-lite, pro, etc.).
     register_provider_capability(
         ProviderCapability(
             supported=True,
@@ -513,8 +516,8 @@ def _register_builtin_capabilities() -> None:
             profile_values={
                 ExecutionProfile.FAST: 1024,
                 ExecutionProfile.BALANCED: 5000,
-                ExecutionProfile.DEEP: 50000,
-                ExecutionProfile.MAX: 125000,
+                ExecutionProfile.DEEP: 65535,
+                ExecutionProfile.MAX: 65535,
             },
             default_profile=ExecutionProfile.BALANCED,
         ),
@@ -522,6 +525,7 @@ def _register_builtin_capabilities() -> None:
     )
 
     # ------ Google Cloud (Vertex AI) — same mechanism as Gemini
+    # Vertex AI also uses Gemini API, capped at 65535.
     register_provider_capability(
         ProviderCapability(
             supported=True,
@@ -529,8 +533,8 @@ def _register_builtin_capabilities() -> None:
             profile_values={
                 ExecutionProfile.FAST: 1024,
                 ExecutionProfile.BALANCED: 5000,
-                ExecutionProfile.DEEP: 50000,
-                ExecutionProfile.MAX: 125000,
+                ExecutionProfile.DEEP: 65535,
+                ExecutionProfile.MAX: 65535,
             },
             default_profile=ExecutionProfile.BALANCED,
         ),
@@ -630,11 +634,13 @@ def _register_builtin_model_overrides() -> None:
         )
     )
 
-    # Gemini models: multimodal, reasoning supported.
+    # Gemini 2.x+ models: multimodal, reasoning supported.
+    # Excludes flash-flashlite and all flash variants that don't support
+    # Gemini thinking (the API rejects thinking_config for those models).
     register_model_override(
         ModelCapability(
             provider=PROVIDER_GOOGLE,
-            regex_pattern=r"^gemini-[2-9]",
+            regex_pattern=r"^gemini-(?!\d.*flash)",
             supports_reasoning=True,
             supports_vision=True,
         )
@@ -649,30 +655,55 @@ def _register_builtin_model_overrides() -> None:
         )
     )
 
-    # OpenAI gpt-5.4, gpt-5.5, and similar models reject reasoning_effort
-    # when function tools are used (they expect /v1/responses instead of
-    # /v1/chat/completions).  The safest approach: disable reasoning entirely
-    # for these models in the chat completions path.  The regex uses `.` to
-    # match any minor version (gpt-5.X), not just single digits, so it scales
-    # to gpt-5.10, gpt-5.99, etc.
+    # OpenAI gpt-5.{1,2,3}-chat-latest — only accept reasoning_effort=medium
+    # (all other levels throw 400).  They also reject temperature != 1.0.
+    # Force both so these models work at every execution profile.
+    # Must be placed BEFORE the gpt-5.4+ rule so it takes precedence
+    # (longest/winner regex matching).
     register_model_override(
         ModelCapability(
             provider=PROVIDER_OPENAI,
-            regex_pattern=r"^gpt-5\.[4-9]",
+            regex_pattern=r"^gpt-5\.(?:1|2|3)(?:-[a-z]+)*$",
+            profile_values={
+                ExecutionProfile.FAST: "medium",
+                ExecutionProfile.BALANCED: "medium",
+                ExecutionProfile.DEEP: "medium",
+                ExecutionProfile.MAX: "medium",
+            },
+            force_temperature=1.0,
+        )
+    )
+
+    # OpenAI gpt-5.{4,5,6,...}-chat-latest and similar post-5.3 models
+    # reject reasoning_effort when function tools are used (they expect
+    # /v1/responses instead of /v1/chat/completions).  The safest approach:
+    # disable reasoning entirely for these models in the chat completions
+    # path.  The regex uses `[0-9]+` to match any minor version number
+    # (gpt-5.X), including multi-digit ones like gpt-5.10, gpt-5.99, etc.
+    # [4-9] matches single digits 4-9; [1-9][0-9]+ matches only 2+ digit
+    # versions (10, 11, …) so gpt-5.1/5.2/5.3 never match this branch.
+    register_model_override(
+        ModelCapability(
+            provider=PROVIDER_OPENAI,
+            regex_pattern=r"^gpt-5\.(?:[4-9]|[1-9][0-9]+)(?:-[a-z]+)*$",
             supports_reasoning=False,
         )
     )
 
-    # gpt-5.1, gpt-5.2, gpt-5.3 — these models reject any temperature value
-    # other than the default (1.0).  The error message reads:
-    #   "Unsupported value: 'temperature' does not support 0.7 with this
-    #    model.  Only the default (1) value is supported."
-    # Force temperature to 1.0 so build_runtime_kwargs always includes the
-    # correct value regardless of what the agent or user configured.
+    # gpt-4.1-series (`gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`) — these
+    # models reject temperature != 1.0 and only accept reasoning_effort=medium
+    # regardless of execution profile.  This covers every gpt-4.1 variant
+    # including future `-chat-latest` suffixes.
     register_model_override(
         ModelCapability(
             provider=PROVIDER_OPENAI,
-            regex_pattern = r"^gpt-5\.[1-3]-chat-latest$",
+            regex_pattern=r"^gpt-4\.1",
+            profile_values={
+                ExecutionProfile.FAST: "medium",
+                ExecutionProfile.BALANCED: "medium",
+                ExecutionProfile.DEEP: "medium",
+                ExecutionProfile.MAX: "medium",
+            },
             force_temperature=1.0,
         )
     )

--- a/backend/tools/execution_profiles.py
+++ b/backend/tools/execution_profiles.py
@@ -141,6 +141,14 @@ class ModelCapability:
     supports_vision: Optional[bool] = None
     supports_json_mode: Optional[bool] = None
 
+    # When set, the runtime will force temperature to this exact value
+    # regardless of what the user or agent specifies.  Use this when a
+    # model accepts the temperature parameter but only the default (1.0)
+    # value is valid — passing anything else produces an API error.
+    #
+    # ``None`` means "do not force temperature".
+    force_temperature: Optional[float] = None
+
     # Model-specific reasoning kwarg name.  When present this value
     # overrides the provider's ``reasoning_kwarg`` — the model will
     # receive this kwarg *instead* of the provider default.
@@ -209,6 +217,13 @@ class ModelCapability:
             return False
         return self.disable_temperature
 
+    @property
+    def effective_force_temperature(self) -> Optional[float]:
+        """Return the temperature value to force, or None if no forcing needed."""
+        if self.force_temperature is not None:
+            return self.force_temperature
+        return None
+
 
 # ====================================================================
 # RuntimeConfig
@@ -253,6 +268,10 @@ class RuntimeConfig:
     # When the provider disables temperature alongside reasoning
     # (some models reject ``temperature`` when thinking is on).
     disable_temperature: bool = False
+
+    # When the model requires temperature to be a specific value (e.g. 1.0)
+    # regardless of what the user or agent specifies.
+    force_temperature: Optional[float] = None
 
     # Execution-profile metadata (default profile, available levels).
     # Exposed so callers can validate overrides.
@@ -318,6 +337,7 @@ class RuntimeConfigBuilder:
         # 4. Compute derived capability flags
         caps = model_cap.supports_reasoning or resolved.supported
         disallow_temp = model_cap.should_disable_temperature and caps
+        force_temp = model_cap.effective_force_temperature
 
         return RuntimeConfig(
             provider=provider,
@@ -331,6 +351,7 @@ class RuntimeConfigBuilder:
             supports_vision=model_cap.supports_vision or False,
             supports_json_mode=model_cap.supports_json_mode or False,
             disable_temperature=disallow_temp,
+            force_temperature=force_temp,
             default_profile=resolved.default_profile,
             profile_values=dict(resolved.profile_values),
         )
@@ -368,8 +389,13 @@ def build_runtime_kwargs(
     """
     kwargs: Dict[str, Any] = {}
 
-    # Temperature — may be skipped when the profile disables it.
-    if temperature is not None and not runtime_config.disable_temperature:
+    # Temperature — three possible modes driven by RuntimeConfig:
+    #   1. force_temperature: send the model's required value (e.g. 1.0)
+    #   2. disable_temperature: omit temperature entirely
+    #   3. default: send the caller-supplied temperature (may be None)
+    if runtime_config.force_temperature is not None:
+        kwargs["temperature"] = runtime_config.force_temperature
+    elif temperature is not None and not runtime_config.disable_temperature:
         kwargs["temperature"] = temperature
 
     # Provider-level reasoning parameter
@@ -620,6 +646,18 @@ def _register_builtin_model_overrides() -> None:
             regex_pattern=r"^gemini-1\.5",
             supports_reasoning=True,
             supports_vision=True,
+        )
+    )
+
+    # OpenAI gpt-5.4, gpt-5.5, and similar models reject reasoning_effort
+    # when function tools are used (they expect /v1/responses instead of
+    # /v1/chat/completions).  The safest approach: disable reasoning entirely
+    # for these models in the chat completions path.
+    register_model_override(
+        ModelCapability(
+            provider=PROVIDER_OPENAI,
+            regex_pattern=r"^gpt-5\.[4-9]",
+            supports_reasoning=False,
         )
     )
 

--- a/backend/tools/execution_profiles.py
+++ b/backend/tools/execution_profiles.py
@@ -652,12 +652,28 @@ def _register_builtin_model_overrides() -> None:
     # OpenAI gpt-5.4, gpt-5.5, and similar models reject reasoning_effort
     # when function tools are used (they expect /v1/responses instead of
     # /v1/chat/completions).  The safest approach: disable reasoning entirely
-    # for these models in the chat completions path.
+    # for these models in the chat completions path.  The regex uses `.` to
+    # match any minor version (gpt-5.X), not just single digits, so it scales
+    # to gpt-5.10, gpt-5.99, etc.
     register_model_override(
         ModelCapability(
             provider=PROVIDER_OPENAI,
-            regex_pattern=r"^gpt-5\.[4-9]",
+            regex_pattern=r"^gpt-5\.",
             supports_reasoning=False,
+        )
+    )
+
+    # gpt-5.1, gpt-5.2, gpt-5.3 — these models reject any temperature value
+    # other than the default (1.0).  The error message reads:
+    #   "Unsupported value: 'temperature' does not support 0.7 with this
+    #    model.  Only the default (1) value is supported."
+    # Force temperature to 1.0 so build_runtime_kwargs always includes the
+    # correct value regardless of what the agent or user configured.
+    register_model_override(
+        ModelCapability(
+            provider=PROVIDER_OPENAI,
+            regex_pattern=r"^gpt-5\.[1-3](?!\d)",
+            force_temperature=1.0,
         )
     )
 

--- a/backend/tools/execution_profiles.py
+++ b/backend/tools/execution_profiles.py
@@ -103,6 +103,13 @@ class ModelCapability:
     matching lets administrators define behaviour for an entire
     model family with a single entry (e.g. ``gpt-4o`` covers
     ``gpt-4o-2024-05-13``, ``gpt-4o-mini``, etc.).
+
+    Some models use a *different* reasoning mechanism than their
+    provider's default (e.g. OpenAI o1 models use ``max_completion_tokens``
+    instead of ``reasoning_effort``).  ``model_reasoning_kwarg`` and
+    ``model_reasoning_config`` provide an escape hatch for this case
+    without scattering provider-specific logic throughout the inference
+    layer.
     """
 
     # Regex prefix to match against the model id (e.g. ``o1``,
@@ -134,8 +141,22 @@ class ModelCapability:
     supports_vision: Optional[bool] = None
     supports_json_mode: Optional[bool] = None
 
+    # Model-specific reasoning kwarg name.  When present this value
+    # overrides the provider's ``reasoning_kwarg`` — the model will
+    # receive this kwarg *instead* of the provider default.
+    #
+    # Use this when a model uses a different reasoning mechanism than
+    # its provider (e.g. o1 uses ``max_completion_tokens`` instead of
+    # ``reasoning_effort``).
+    model_reasoning_kwarg: Optional[str] = None
+
+    # Model-specific reasoning values mapping profiles to values for
+    # the *model-specific* kwarg.  Only used when ``model_reasoning_kwarg``
+    # is set.
+    model_reasoning_config: Dict[ExecutionProfile, Any] = dataclasses.field(default_factory=dict)
+
     @classmethod
-    def for_model(cls, provider: str, model_id: str) -> ModelCapability:
+    def for_model(cls, provider: str, model_id: str) -> "ModelCapability":
         """Find the most specific ModelCapability for *model_id*.
 
         Walks the **global model overrides** registry (``_MODEL_OVERRIDES``)
@@ -150,7 +171,7 @@ class ModelCapability:
                 return rule
 
         # 2. Longest prefix match
-        best_match: Optional[ModelCapability] = None
+        best_match: Optional["ModelCapability"] = None
         best_len = 0
 
         for rule in _MODEL_OVERRIDES:
@@ -211,10 +232,17 @@ class RuntimeConfig:
     execution_profile: ExecutionProfile
 
     # Reasoning runtime parameter: the kwarg name and value that will
-    # be sent to the LLM client (e.g. ``("reasoning_effort", "high")``).
+    # be sent to the LLM client (e.g. ("reasoning_effort", "high")).
     # ``None`` when reasoning is not supported for this model/profile.
     reasoning_kwarg: Optional[str] = None
     reasoning_value: Optional[Any] = None
+
+    # Model-specific reasoning kwarg/overriding the provider default.
+    # These fields are set when a model uses a different reasoning
+    # mechanism than its provider (e.g. o1 models use
+    # ``max_completion_tokens`` instead of ``reasoning_effort``).
+    model_reasoning_kwarg: Optional[str] = None
+    model_reasoning_value: Optional[Any] = None
 
     # Capability flags — precomputed from provider + model override so
     # the inference layer only looks at runtime config.
@@ -248,6 +276,11 @@ class RuntimeConfigBuilder:
     1. Look up the provider's ``ProviderCapability`` in the global registry.
     2. Apply ``ModelCapability`` overrides from the global overrides.
     3. Populate the ``RuntimeConfig`` with the resolved kwarg mapping.
+
+    **Model-specific reasoning** takes priority: when a ``ModelCapability``
+    sets ``model_reasoning_kwarg``, the runtime uses that kwarg *instead* of
+    the provider's ``reasoning_kwarg`` and looks up values from
+    ``model_reasoning_config`` rather than ``profile_values``.
     """
 
     @staticmethod
@@ -264,13 +297,22 @@ class RuntimeConfigBuilder:
         resolved = model_cap.apply_provider_defaults(provider_cap)
 
         # 3. Resolve specific value for the chosen profile
+
+        # --- Model-specific reasoning (overrides provider default) ---
         reasoning_kwarg: Optional[str] = None
         reasoning_value: Optional[Any] = None
+        model_reasoning_kwarg: Optional[str] = None
+        model_reasoning_value: Optional[Any] = None
 
-        if resolved.has_reasoning_config:
+        if model_cap.model_reasoning_kwarg:
+            # Model overrides the provider's reasoning mechanism.
+            model_reasoning_kwarg = model_cap.model_reasoning_kwarg
+            model_reasoning_value = model_cap.model_reasoning_config.get(execution_profile)
+        elif resolved.has_reasoning_config:
+            # Fall back to provider-level reasoning.
+            reasoning_kwarg = resolved.reasoning_kwarg
             profile_val = resolved.profile_values.get(execution_profile)
             if profile_val is not None:
-                reasoning_kwarg = resolved.reasoning_kwarg
                 reasoning_value = profile_val
 
         # 4. Compute derived capability flags
@@ -283,6 +325,8 @@ class RuntimeConfigBuilder:
             execution_profile=execution_profile,
             reasoning_kwarg=reasoning_kwarg,
             reasoning_value=reasoning_value,
+            model_reasoning_kwarg=model_reasoning_kwarg,
+            model_reasoning_value=model_reasoning_value,
             supports_reasoning=caps,
             supports_vision=model_cap.supports_vision or False,
             supports_json_mode=model_cap.supports_json_mode or False,
@@ -316,8 +360,8 @@ def build_runtime_kwargs(
             execution_profile=ExecutionProfile.DEEP,
         )
         kwargs = build_runtime_kwargs(rc, temperature=0.7)
-        # kwargs = {"thinking_budget": 125_000, "temperature": 0.7}
-        llm = ChatAnthropic(**kwargs, api_key=...)
+        # kwargs = {"reasoning_effort": "high", "temperature": 0.7}
+        llm = ChatOpenAI(**kwargs, api_key=...)
 
     Adding a new provider with a new reasoning mechanism only requires
     registering it in ``_REGISTRY`` — the kwarg builder stays unchanged.
@@ -328,9 +372,14 @@ def build_runtime_kwargs(
     if temperature is not None and not runtime_config.disable_temperature:
         kwargs["temperature"] = temperature
 
-    # Reasoning parameter
+    # Provider-level reasoning parameter
     if runtime_config.reasoning_kwarg is not None and runtime_config.reasoning_value is not None:
         kwargs[runtime_config.reasoning_kwarg] = runtime_config.reasoning_value
+
+    # Model-specific reasoning parameter (overrides provider default)
+    # This handles models like o1 that use a different reasoning mechanism
+    if runtime_config.model_reasoning_kwarg is not None and runtime_config.model_reasoning_value is not None:
+        kwargs[runtime_config.model_reasoning_kwarg] = runtime_config.model_reasoning_value
 
     # Additional override kwargs (retrievers, custom metadata…)
     if additional_kwargs:
@@ -385,10 +434,10 @@ def clear_model_overrides() -> None:
 def _register_builtin_capabilities() -> None:
     """Wire up reasoning capabilities for every supported provider."""
 
-    # --------------------------------------------------------------
-    # OpenAI  — reasoning_effort parameter (o-series, gpt-4o+)
-    # "low" | "medium" | "high"  or None when disabled
-    # --------------------------------------------------------------
+    # ------ OpenAI — reasoning_effort parameter (non-o-series, gpt-4o+)
+    # "low" | "medium" | "high"  or None when disabled.
+    # NOTE: o1 models deliberately do NOT use reasoning_effort — they use
+    # max_completion_tokens and are handled via model overrides.
     register_provider_capability(
         ProviderCapability(
             supported=True,
@@ -404,10 +453,8 @@ def _register_builtin_capabilities() -> None:
         PROVIDER_OPENAI,
     )
 
-    # --------------------------------------------------------------
-    # Anthropic  — thinking_budget parameter (optional)
+    # ------ Anthropic — thinking_budget parameter (optional)
     # integer token budget (0-125000)
-    # --------------------------------------------------------------
     register_provider_capability(
         ProviderCapability(
             supported=True,
@@ -423,9 +470,7 @@ def _register_builtin_capabilities() -> None:
         PROVIDER_ANTHROPIC,
     )
 
-    # --------------------------------------------------------------
-    # MistralAI  — no native reasoning parameter yet
-    # --------------------------------------------------------------
+    # ------ MistralAI — no native reasoning parameter yet
     register_provider_capability(
         ProviderCapability(
             supported=False,
@@ -434,10 +479,7 @@ def _register_builtin_capabilities() -> None:
         PROVIDER_MISTRAL,
     )
 
-    # --------------------------------------------------------------
-    # Google Gemini  — thinking_config / thinking_budget token budget
-    # Gemini uses thinking_budget (int) via client_options.
-    # --------------------------------------------------------------
+    # ------ Google Gemini — thinking_budget token budget
     register_provider_capability(
         ProviderCapability(
             supported=True,
@@ -453,9 +495,7 @@ def _register_builtin_capabilities() -> None:
         PROVIDER_GOOGLE,
     )
 
-    # --------------------------------------------------------------
-    # Google Cloud (Vertex AI) — same mechanism as Gemini
-    # --------------------------------------------------------------
+    # ------ Google Cloud (Vertex AI) — same mechanism as Gemini
     register_provider_capability(
         ProviderCapability(
             supported=True,
@@ -471,9 +511,7 @@ def _register_builtin_capabilities() -> None:
         PROVIDER_GOOGLE_CLOUD,
     )
 
-    # --------------------------------------------------------------
-    # Azure OpenAI  — supports reasoning_effort via Azure's API
-    # --------------------------------------------------------------
+    # ------ Azure OpenAI — supports reasoning_effort via Azure's API
     register_provider_capability(
         ProviderCapability(
             supported=True,
@@ -489,10 +527,8 @@ def _register_builtin_capabilities() -> None:
         PROVIDER_AZURE,
     )
 
-    # --------------------------------------------------------------
-    # OpenRouter  — passes reasoning parameter through to underlying
+    # ------ OpenRouter — passes reasoning parameter through to underlying
     # model (provider-agnostic — OpenRouter normalises reasoning_effort).
-    # --------------------------------------------------------------
     register_provider_capability(
         ProviderCapability(
             supported=True,
@@ -508,10 +544,8 @@ def _register_builtin_capabilities() -> None:
         PROVIDER_OPENROUTER,
     )
 
-    # --------------------------------------------------------------
-    # Custom / Ollama  — may support reasoning parameters but
+    # ------ Custom / Ollama — may support reasoning parameters but
     # default to disabled until the user configures it.
-    # --------------------------------------------------------------
     register_provider_capability(
         ProviderCapability(
             supported=False,
@@ -529,20 +563,39 @@ def _register_builtin_capabilities() -> None:
 def _register_builtin_model_overrides() -> None:
     """Register per-model capability overrides."""
 
-    # OpenAI o-series: reasoning is mandatory and temperature is
-    # incompatible with thinking.
+    # OpenAI o1 models: do NOT use reasoning_effort — they use
+    # max_completion_tokens for controlling reasoning depth.
+    # Temperature is disabled.
     register_model_override(
         ModelCapability(
             provider=PROVIDER_OPENAI,
-            regex_pattern=r"^o\d",
+            regex_pattern=r"^o1",
+            supports_reasoning=True,
+            disable_temperature=True,
+            supports_vision=True,
+            model_reasoning_kwarg="max_completion_tokens",
+            model_reasoning_config={
+                ExecutionProfile.FAST: 128,
+                ExecutionProfile.BALANCED: 512,
+                ExecutionProfile.DEEP: 1024,
+                ExecutionProfile.MAX: 2048,
+            },
+        )
+    )
+
+    # OpenAI o3+ models: use reasoning_effort like the provider default,
+    # but are reasoning-only (no temperature).
+    register_model_override(
+        ModelCapability(
+            provider=PROVIDER_OPENAI,
+            regex_pattern=r"^o3",
             supports_reasoning=True,
             disable_temperature=True,
             supports_vision=True,
         )
     )
 
-    # Claude models: reasoning is always enabled; disable temperature
-    # when thinking budget > 0 (Anthropic's behaviour for some models).
+    # Claude models: reasoning is always enabled; vision support.
     register_model_override(
         ModelCapability(
             provider=PROVIDER_ANTHROPIC,

--- a/frontend/src/components/playground/ChatInterface.tsx
+++ b/frontend/src/components/playground/ChatInterface.tsx
@@ -43,6 +43,7 @@ interface ChatInterfaceProps {
   onMessageSent?: () => void;
   metadataFields?: SearchFilterMetadataField[];
   vectorDbType?: string;
+  defaultExecutionProfile?: number | null;
 }
 
 function ChatInterface({
@@ -54,6 +55,7 @@ function ChatInterface({
   onMessageSent,
   metadataFields,
   vectorDbType,
+  defaultExecutionProfile,
 }: Readonly<ChatInterfaceProps>) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputMessage, setInputMessage] = useState('');
@@ -68,6 +70,9 @@ function ChatInterface({
     undefined
   );
   const [filtersKey, setFiltersKey] = useState(0);
+  const [selectedExecutionProfile, setSelectedExecutionProfile] = useState<number | null>(
+    defaultExecutionProfile ?? null
+  );
   /** UI-only state to render the floating "scroll to bottom" button. Behaviour
    *  is driven by refs to avoid scroll-handler re-renders racing the streaming flush. */
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
@@ -265,6 +270,7 @@ function ChatInterface({
       const result = await sendMessage(messageText, {
         conversationId: currentConversationId,
         searchParams,
+        executionProfile: selectedExecutionProfile,
       });
 
       const rawResponse = result.response || '';
@@ -440,6 +446,91 @@ function ChatInterface({
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-4">
+      {/* Execution Profile Selector */}
+      <div className="pg-glass rounded-xl overflow-hidden">
+        <button
+          type="button"
+          className="w-full px-4 py-3 flex items-center justify-between text-left hover:bg-white/30 dark:hover:bg-gray-700/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition-colors"
+          onClick={() => setIsFilterExpanded((prev) => !prev)}
+          aria-expanded={isFilterExpanded}
+          aria-controls="execution-profile-section"
+        >
+          <span className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+            <svg
+              className="w-4 h-4 text-indigo-500"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M13 10V3L4 14h7v7l9-11h-7z"
+              />
+            </svg>
+            Execution Profile
+          </span>
+          <svg
+            className={`w-4 h-4 text-gray-400 transition-transform duration-200 ${
+              isFilterExpanded ? 'rotate-180' : ''
+            }`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </button>
+
+        <div
+          id="execution-profile-section"
+          className={`border-t border-white/20 dark:border-gray-700/30 px-4 py-3 bg-white/20 dark:bg-gray-800/20 ${
+            isFilterExpanded ? '' : 'hidden'
+          }`}
+        >
+          <div className="grid grid-cols-4 gap-2">
+            {[
+              { value: 0, label: 'FAST', color: 'bg-emerald-500 text-white' },
+              { value: 1, label: 'BALANCED', color: selectedExecutionProfile === 1 ? 'bg-indigo-600 text-white' : 'bg-white/30 text-gray-700 dark:bg-gray-700/60 dark:text-gray-300' },
+              { value: 2, label: 'DEEP', color: selectedExecutionProfile === 2 ? 'bg-indigo-600 text-white' : 'bg-white/30 text-gray-700 dark:bg-gray-700/60 dark:text-gray-300' },
+              { value: 3, label: 'MAX', color: selectedExecutionProfile === 3 ? 'bg-indigo-600 text-white' : 'bg-white/30 text-gray-700 dark:bg-gray-700/60 dark:text-gray-300' },
+            ].map((profile) => (
+              <button
+                key={profile.value}
+                type="button"
+                onClick={() => setSelectedExecutionProfile(profile.value)}
+                disabled={isStreaming}
+                className={`px-3 py-2 text-xs font-semibold rounded-lg transition-all ${profile.color} ${
+                  isStreaming ? 'opacity-50 cursor-not-allowed' : 'hover:opacity-80 cursor-pointer'
+                }`}
+              >
+                {profile.label}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+            {selectedExecutionProfile === null
+              ? 'Using agent default profile'
+              : selectedExecutionProfile === 0
+                ? 'FAST: Low latency, minimal reasoning'
+                : selectedExecutionProfile === 1
+                  ? 'BALANCED: Standard reasoning performance'
+                  : selectedExecutionProfile === 2
+                    ? 'DEEP: Extended reasoning and analysis'
+                    : 'MAX: Maximum reasoning and analysis'
+            }
+          </p>
+        </div>
+      </div>
+
       {/* Metadata Filters Section */}
       {metadataFields && metadataFields.length > 0 && (
         <div className="pg-glass rounded-xl overflow-hidden">

--- a/frontend/src/components/playground/ChatInterface.tsx
+++ b/frontend/src/components/playground/ChatInterface.tsx
@@ -46,6 +46,219 @@ interface ChatInterfaceProps {
   defaultExecutionProfile?: number | null;
 }
 
+const EXECUTION_PROFILES = [
+  { value: 0, label: 'FAST', description: 'Low latency, minimal reasoning' },
+  { value: 1, label: 'BALANCED', description: 'Standard reasoning performance' },
+  { value: 2, label: 'DEEP', description: 'Extended reasoning and analysis' },
+  { value: 3, label: 'MAX', description: 'Maximum reasoning and analysis' },
+] as const;
+
+type ExecutionProfileValue = (typeof EXECUTION_PROFILES)[number]['value'];
+
+/** Resolved profile: explicit override (0-3) or 'inherit' for null. */
+type ProfileResolvable = ExecutionProfileValue | 'inherit';
+
+function resolveDescription(value: ProfileResolvable): string {
+  switch (value) {
+    case 'inherit':
+      return 'Using agent default profile';
+    case 0:
+      return 'Low latency, minimal reasoning';
+    case 1:
+      return 'Standard reasoning performance';
+    case 2:
+      return 'Extended reasoning and analysis';
+    case 3:
+      return 'Maximum reasoning and analysis';
+  }
+}
+
+function resolveLabel(value: ProfileResolvable): string {
+  if (value === 'inherit') return 'Default';
+  return EXECUTION_PROFILES.find((p) => p.value === value)?.label ?? 'Default';
+}
+
+function resolveShortLabel(value: ProfileResolvable): string {
+  if (value === 'inherit') return '';
+  return EXECUTION_PROFILES.find((p) => p.value === value)?.label ?? 'Default';
+}
+
+function resolveValue(value: ProfileResolvable): number | null {
+  if (value === 'inherit') return null;
+  return value;
+}
+
+/** Minimal Combobox — no external dependency. */
+function ExecutionProfileCombobox({
+  value,
+  onChange,
+  disabled,
+  onOpenChange,
+}: {
+  value: ProfileResolvable;
+  onChange: (v: ProfileResolvable) => void;
+  disabled: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const activeIdxRef = useRef(-1);
+
+  useEffect(() => {
+    activeIdxRef.current = open ? (value === 'inherit' ? 0 : EXECUTION_PROFILES.indexOf(EXECUTION_PROFILES.find((p) => p.value === value)!) ?? -1) + 1 : -1;
+  }, [open, value]);
+
+  useEffect(() => {
+    onOpenChange?.(open);
+  }, [open, onOpenChange]);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!open) {
+      if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        setOpen(true);
+      }
+      return;
+    }
+    if (e.key === 'Escape') {
+      setOpen(false);
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      activeIdxRef.current = Math.min(activeIdxRef.current + 1, EXECUTION_PROFILES.length);
+      const opt = ref.current?.querySelector<HTMLButtonElement>(
+        `[data-option-index="${activeIdxRef.current}"]`
+      );
+      opt?.focus();
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      activeIdxRef.current = Math.max(activeIdxRef.current - 1, -1);
+      const opt = ref.current?.querySelector<HTMLButtonElement>(
+        `[data-option-index="${activeIdxRef.current}"]`
+      );
+      opt?.focus();
+      return;
+    }
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      if (activeIdxRef.current >= 0 && activeIdxRef.current <= EXECUTION_PROFILES.length) {
+        if (activeIdxRef.current === 0) {
+          onChange('inherit');
+        } else {
+          onChange(EXECUTION_PROFILES[activeIdxRef.current - 1].value);
+        }
+      }
+      setOpen(false);
+    }
+  };
+
+  const items = [
+    { value: 'inherit' as const, label: 'Default' },
+    ...EXECUTION_PROFILES.map((p) => ({ value: p.value as ProfileResolvable, label: p.label })),
+  ];
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => (!disabled ? setOpen((o) => !o) : undefined)}
+        onKeyDown={handleKeyDown}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        disabled={disabled}
+        className="inline-flex items-center gap-1 pl-1.5 pr-2 py-1 rounded-lg text-xs font-medium
+                   text-gray-500 dark:text-gray-400
+                   hover:text-indigo-600 dark:hover:text-indigo-400
+                   hover:bg-indigo-50 dark:hover:bg-indigo-900/20
+                   disabled:opacity-40 disabled:cursor-not-allowed
+                   transition-all duration-150
+                   border border-transparent hover:border-indigo-200 dark:hover:border-indigo-800/40"
+        title={resolveDescription(value)}
+      >
+        {resolveShortLabel(value) && (
+          <svg
+            className="w-3.5 h-3.5 text-indigo-500"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M13 10V3L4 14h7v7l9-11h-7z"
+            />
+          </svg>
+        )}
+        <span>{resolveLabel(value)}</span>
+        <svg
+          className={`w-3 h-3 transition-transform duration-150 ${open ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          className="absolute bottom-full left-0 mb-1 w-48 rounded-xl overflow-hidden
+                     bg-white/90 dark:bg-gray-800/90 backdrop-blur-sm
+                     border border-gray-200 dark:border-gray-700/50
+                     shadow-lg z-30 p-1"
+          role="listbox"
+        >
+          {items.map((item, idx) => {
+            const isSelected = item.value === value;
+            return (
+              <button
+                key={`${item.value}`}
+                data-option-index={idx}
+                type="button"
+                role="option"
+                aria-selected={isSelected}
+                onClick={() => {
+                  onChange(item.value);
+                  setOpen(false);
+                }}
+                onMouseDown={(e) => e.preventDefault()}
+                className={`w-full text-left px-3 py-1.5 rounded-lg text-xs font-medium transition-colors
+                           flex items-center justify-between
+                           ${isSelected
+                             ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300'
+                             : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700/50'
+                           }
+                           ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+              >
+                {item.label}
+                {isSelected && (
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function ChatInterface({
   appId,
   agentId,
@@ -70,8 +283,8 @@ function ChatInterface({
     undefined
   );
   const [filtersKey, setFiltersKey] = useState(0);
-  const [selectedExecutionProfile, setSelectedExecutionProfile] = useState<number | null>(
-    defaultExecutionProfile ?? null
+  const [selectedExecutionProfile, setSelectedExecutionProfile] = useState<ProfileResolvable>(
+    defaultExecutionProfile != null ? defaultExecutionProfile : 'inherit'
   );
   /** UI-only state to render the floating "scroll to bottom" button. Behaviour
    *  is driven by refs to avoid scroll-handler re-renders racing the streaming flush. */
@@ -239,7 +452,7 @@ function ChatInterface({
     }
   }, [metadataFields, filterMetadata]);
 
-  // ─── Message sending ─────────────────────────────────────────────────────────
+  // ─── Message sending ───────────────────────────────────────────────────
 
   const handleSendMessage = async () => {
     if (!inputMessage.trim() && persistentFiles.length === 0) return;
@@ -270,7 +483,7 @@ function ChatInterface({
       const result = await sendMessage(messageText, {
         conversationId: currentConversationId,
         searchParams,
-        executionProfile: selectedExecutionProfile,
+        executionProfile: resolveValue(selectedExecutionProfile),
       });
 
       const rawResponse = result.response || '';
@@ -414,7 +627,7 @@ function ChatInterface({
     }
   };
 
-  // ─── Misc handlers ────────────────────────────────────────────────────────────
+  // ─── Misc handlers ─────────────────────────────────────────────────────────────
 
   const handleFilterMetadataChange = useCallback(
     (metadata: Record<string, unknown> | undefined) => {
@@ -441,6 +654,8 @@ function ChatInterface({
   }));
 
   const canSend = !isStreaming && (inputMessage.trim().length > 0 || persistentFiles.length > 0);
+
+  let isProfileMenuOpen = false;
 
   // ─── Render ───────────────────────────────────────────────────────────────────
 
@@ -847,6 +1062,14 @@ function ChatInterface({
           {/* Input area */}
           <div className="px-4 pb-4 pt-3 border-t border-white/20 dark:border-gray-700/30">
             <div className="pg-glass rounded-xl px-3 py-2.5 flex items-end gap-2">
+              {/* Execution Profile Combobox */}
+              <ExecutionProfileCombobox
+                value={selectedExecutionProfile}
+                onChange={(v) => setSelectedExecutionProfile(v)}
+                disabled={isStreaming}
+                onOpenChange={(o) => { isProfileMenuOpen = o; }}
+              />
+
               {/* File attach button */}
               <div>
                 <input
@@ -893,7 +1116,7 @@ function ChatInterface({
                 onChange={(e) => setInputMessage(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder={`Message ${agentName}...`}
-                disabled={isStreaming}
+                disabled={isStreaming || isProfileMenuOpen}
                 className="flex-1 bg-transparent border-none outline-none resize-none
                            text-sm text-gray-800 dark:text-gray-100
                            placeholder:text-gray-400 dark:placeholder:text-gray-500

--- a/frontend/src/hooks/useStreamingChat.ts
+++ b/frontend/src/hooks/useStreamingChat.ts
@@ -46,6 +46,7 @@ export interface StreamFnOptions {
   readonly files?: File[];
   readonly searchParams?: any;
   readonly conversationId?: number | null;
+  readonly executionProfile?: number | null;
   readonly onEvent: (event: StreamEvent) => void;
   readonly signal?: AbortSignal;
 }
@@ -56,6 +57,7 @@ interface SendOptions {
   readonly files?: File[];
   readonly conversationId?: number | null;
   readonly searchParams?: any;
+  readonly executionProfile?: number | null;
 }
 
 interface UseStreamingChatReturn {
@@ -219,6 +221,7 @@ export function useStreamingChat(streamFn: StreamFn): UseStreamingChatReturn {
           files: options?.files,
           searchParams: options?.searchParams,
           conversationId: options?.conversationId,
+          executionProfile: options?.executionProfile,
           signal: abortController.signal,
           onEvent: (event: StreamEvent) => {
             switch (event.type) {

--- a/frontend/src/pages/AgentPlaygroundPage.tsx
+++ b/frontend/src/pages/AgentPlaygroundPage.tsx
@@ -273,6 +273,7 @@ function AgentPlaygroundPage() {
                     onMessageSent={handleMessageSent}
                     metadataFields={agent.silo?.metadata_definition?.fields}
                     vectorDbType={agent.silo?.vector_db_type}
+                    defaultExecutionProfile={agent.execution_profile ?? null}
                   />
                 )}
               </>

--- a/frontend/src/pages/MarketplaceChatPage.tsx
+++ b/frontend/src/pages/MarketplaceChatPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
-import { ArrowLeft, Bot, MessageCircle, Paperclip, Plus, Square } from 'lucide-react';
+import { ArrowLeft, Bot, MessageCircle, Paperclip, Plus, Square, Zap } from 'lucide-react';
 import { toast } from 'sonner';
 import { apiService } from '../services/api';
 import MessageContent from '../components/playground/MessageContent';
@@ -60,6 +60,18 @@ export default function MarketplaceChatPage() {
   const [quotaInfo, setQuotaInfo] = useState<QuotaInfo | null>(null);
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
 
+  const EXECUTION_PROFILES = [
+    { value: 0, label: 'FAST', description: 'Low latency, minimal reasoning' },
+    { value: 1, label: 'BALANCED', description: 'Standard reasoning performance' },
+    { value: 2, label: 'DEEP', description: 'Extended reasoning and analysis' },
+    { value: 3, label: 'MAX', description: 'Maximum reasoning and analysis' },
+  ] as const;
+
+  type ProfileResolvable = (typeof EXECUTION_PROFILES)[number]['value'] | 'inherit';
+
+  const [selectedExecutionProfile, setSelectedExecutionProfile] = useState<ProfileResolvable>('inherit');
+  const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
+
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -74,11 +86,38 @@ export default function MarketplaceChatPage() {
     !quotaInfo.is_exempt &&
     quotaInfo.call_count >= quotaInfo.quota;
 
+  const resolveProfileValue = (value: ProfileResolvable): number | null => {
+    if (value === 'inherit') return null;
+    return value;
+  };
+
+  const resolveProfileLabel = (value: ProfileResolvable): string =>
+    value === 'inherit' ? 'Default' : EXECUTION_PROFILES.find((p) => p.value === value)?.label || 'Default';
+
+  const resolveProfileDescription = (value: ProfileResolvable): string =>
+    value === 'inherit' ? 'Using agent default profile' : EXECUTION_PROFILES.find((p) => p.value === value)?.description || '';
+
+  const profileMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (profileMenuRef.current && !profileMenuRef.current.contains(e.target as Node)) {
+        setIsProfileMenuOpen(false);
+      }
+    };
+    if (isProfileMenuOpen) {
+      document.addEventListener('mousedown', handler);
+      return () => document.removeEventListener('mousedown', handler);
+    }
+    return undefined;
+  }, [isProfileMenuOpen]);
+
   const marketplaceStream = useCallback(
     (message: string, opts: StreamFnOptions) =>
       apiService.chatMarketplaceStream(numericId, message, {
         files: opts.files,
         fileReferences: persistentFiles.length > 0 ? persistentFiles.map((f) => f.file_id) : undefined,
+        executionProfile: opts.executionProfile,
         onEvent: opts.onEvent,
         signal: opts.signal,
       }),
@@ -282,6 +321,7 @@ export default function MarketplaceChatPage() {
       setHoldStreamingContent(true);
       const result = await sendMessage(trimmed, {
         conversationId: numericId,
+        executionProfile: resolveProfileValue(selectedExecutionProfile),
       });
 
       const rawResponse = result.response || '';
@@ -670,84 +710,156 @@ export default function MarketplaceChatPage() {
             </div>
           )}
 
-           <div className="pg-glass rounded-2xl px-4 py-3 flex items-end gap-3 shadow-sm border border-white/20 dark:border-gray-700/30">
-             <input
-               ref={fileInputRef}
-               type="file"
-               multiple
-               onChange={handleFileSelect}
-               className="hidden"
-               id="marketplace-file-upload"
-             />
-             <button
-               type="button"
-               onClick={() => fileInputRef.current?.click()}
-               disabled={isStreaming || isQuotaExceeded}
-               className="p-2 rounded-xl text-gray-400 dark:text-gray-500
-                          hover:text-indigo-600 dark:hover:text-indigo-400
-                          hover:bg-indigo-50 dark:hover:bg-indigo-900/20
-                          disabled:opacity-40 disabled:cursor-not-allowed
-                          transition-all duration-150"
-               title={isQuotaExceeded ? 'Monthly quota reached' : 'Attach file'}
-               aria-label="Attach file"
-             >
-               <Paperclip className="w-5 h-5" />
-             </button>
- 
-             <textarea
-               ref={textareaRef}
-               value={inputMessage}
-               onChange={(e) => setInputMessage(e.target.value)}
-               onKeyDown={handleKeyDown}
-               placeholder={`Message ${agentName}…`}
-               disabled={isStreaming || isQuotaExceeded}
-               rows={1}
-               className="flex-1 bg-transparent border-none outline-none resize-none
-                          text-sm text-gray-800 dark:text-gray-100
-                          placeholder:text-gray-400 dark:placeholder:text-gray-500
-                          disabled:opacity-50
-                          focus:outline-none focus:ring-0
-                          max-h-40 input-login"
-               style={{ minHeight: '1.5rem' }}
-             />
- 
-             {isStreaming ? (
-               <button
-                 type="button"
-                 onClick={abortStream}
-                 className="p-2 rounded-xl bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400
-                            hover:bg-red-200 dark:hover:bg-red-900/50 transition-all duration-150
-                            active:scale-95 shrink-0"
-                 aria-label="Stop generating"
-                 title="Stop generating"
-               >
-                 <Square className="w-4 h-4" />
-               </button>
-             ) : (
-               <button
-                 type="button"
-                 onClick={handleSendMessage}
-                 disabled={!canSend}
-                 className="pg-btn-send shrink-0 !p-2 rounded-xl"
-                 aria-label="Send message"
-               >
-                 <svg
-                   className="w-4 h-4"
-                   fill="none"
-                   stroke="currentColor"
-                   viewBox="0 0 24 24"
-                   aria-hidden="true"
-                 >
-                   <path
-                     strokeLinecap="round"
-                     strokeLinejoin="round"
-                     strokeWidth={2}
-                     d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"
-                   />
-                 </svg>
-               </button>
-             )}
-           </div>
+          <div className="pg-glass rounded-2xl px-4 py-3 flex items-end gap-3 shadow-sm border border-white/20 dark:border-gray-700/30">
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              onChange={handleFileSelect}
+              className="hidden"
+              id="marketplace-file-upload"
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isStreaming || isQuotaExceeded}
+              className="p-1.5 rounded-lg text-gray-400 dark:text-gray-500
+                         hover:text-indigo-600 dark:hover:text-indigo-400
+                         hover:bg-indigo-50 dark:hover:bg-indigo-900/20
+                         disabled:opacity-40 disabled:cursor-not-allowed
+                         transition-all duration-150"
+              title={isQuotaExceeded ? 'Monthly quota reached' : 'Attach file'}
+              aria-label="Attach file"
+            >
+              <Paperclip className="w-5 h-5" />
+            </button>
+
+            <div
+              ref={profileMenuRef}
+              className="relative flex-shrink-0"
+            >
+              <button
+                type="button"
+                onClick={() => setIsProfileMenuOpen((o) => !o)}
+                disabled={isStreaming || isQuotaExceeded}
+                className={`inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium
+                           transition-all duration-150 border
+                           text-gray-500 dark:text-gray-400
+                           hover:text-indigo-600 dark:hover:text-indigo-400
+                           hover:bg-indigo-50 dark:hover:bg-indigo-900/20
+                           disabled:opacity-40 disabled:cursor-not-allowed
+                           ${isProfileMenuOpen
+                             ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 border-indigo-200 dark:border-indigo-700/50'
+                             : 'border-transparent hover:border-indigo-200 dark:hover:border-indigo-800/40'
+                           }`}
+                title={resolveProfileDescription(selectedExecutionProfile)}
+              >
+                {selectedExecutionProfile !== 'inherit' && (
+                  <Zap className="w-3.5 h-3.5 text-indigo-500" />
+                )}
+                <span>{resolveProfileLabel(selectedExecutionProfile)}</span>
+              </button>
+
+              {isProfileMenuOpen && (
+                <div
+                  className="absolute bottom-full left-0 mb-1 w-52 rounded-xl overflow-hidden
+                             bg-white/90 dark:bg-gray-800/90 backdrop-blur-sm
+                             border border-gray-200 dark:border-gray-700/50
+                             shadow-lg z-30 p-1"
+                  role="listbox"
+                >
+                  {(['inherit', 0, 1, 2, 3] as const).map((v) => {
+                    const isSelected = v === selectedExecutionProfile;
+                    const label = v === 'inherit' ? 'Default'
+                      : EXECUTION_PROFILES.find((p) => p.value === v)?.label || '';
+                    const desc = v === 'inherit' ? 'Using agent default profile'
+                      : EXECUTION_PROFILES.find((p) => p.value === v)?.description || '';
+                    return (
+                      <button
+                        key={v}
+                        type="button"
+                        role="option"
+                        aria-selected={isSelected}
+                        onClick={() => {
+                          setSelectedExecutionProfile(v);
+                          setIsProfileMenuOpen(false);
+                        }}
+                        onMouseDown={(e) => e.preventDefault()}
+                        className={`w-full text-left px-3 py-1.5 rounded-lg text-sm font-medium
+                                   transition-colors flex items-center justify-between
+                                   ${isSelected
+                                     ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300'
+                                     : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700/50'
+                                   }
+                                   ${isStreaming || isQuotaExceeded ? 'opacity-50 cursor-not-allowed' : ''}`}
+                        title={desc}
+                      >
+                        {label}
+                        {isSelected && (
+                          <svg className="w-4 h-4 text-indigo-600 dark:text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                          </svg>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            <textarea
+              ref={textareaRef}
+              value={inputMessage}
+              onChange={(e) => setInputMessage(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={`Message ${agentName}…`}
+              disabled={isStreaming || isQuotaExceeded}
+              rows={1}
+              className="flex-1 bg-transparent border-none outline-none resize-none
+                         text-sm text-gray-800 dark:text-gray-100
+                         placeholder:text-gray-400 dark:placeholder:text-gray-500
+                         disabled:opacity-50
+                         max-h-40 input-login"
+              style={{ minHeight: '1.5rem' }}
+            />
+
+            {isStreaming ? (
+              <button
+                type="button"
+                onClick={abortStream}
+                className="p-2 rounded-xl bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400
+                           hover:bg-red-200 dark:hover:bg-red-900/50 transition-all duration-150
+                           active:scale-95 shrink-0"
+                aria-label="Stop generating"
+                title="Stop generating"
+              >
+                <Square className="w-4 h-4" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleSendMessage}
+                disabled={!canSend}
+                className="pg-btn-send shrink-0 !p-2"
+                aria-label="Send message"
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"
+                  />
+                </svg>
+              </button>
+            )}
+          </div>
 
           <p className="text-xs text-gray-400 dark:text-gray-500 mt-1.5 px-1">
             Press Enter to send, Shift+Enter for new line

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1798,7 +1798,7 @@ class ApiService {
     if (executionProfile != null) {
       formData.append('override_execution_profile', executionProfile.toString());
     }
-    
+
     if (files && files.length > 0) {
       files.forEach((file) => {
         formData.append(`files`, file);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1783,7 +1783,7 @@ class ApiService {
     });
   }
 
-  async chatWithAgent(appId: number, agentId: number, message: string, files?: File[], searchParams?: any, conversationId?: number | null): Promise<{ response: string | Record<string, unknown>; conversation_id?: number }> {
+  async chatWithAgent(appId: number, agentId: number, message: string, files?: File[], searchParams?: any, conversationId?: number | null, executionProfile?: number | null): Promise<{ response: string | Record<string, unknown>; conversation_id?: number }> {
     const formData = new FormData();
     formData.append('message', message);
     
@@ -1793,6 +1793,10 @@ class ApiService {
     
     if (conversationId) {
       formData.append('conversation_id', conversationId.toString());
+    }
+    
+    if (executionProfile != null) {
+      formData.append('override_execution_profile', executionProfile.toString());
     }
     
     if (files && files.length > 0) {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2279,6 +2279,7 @@ class ApiService {
     options: {
       files?: File[];
       fileReferences?: string[];
+      executionProfile?: number | null;
       onEvent: (event: StreamEvent) => void;
       signal?: AbortSignal;
     },
@@ -2288,6 +2289,9 @@ class ApiService {
 
     if (options.fileReferences && options.fileReferences.length > 0) {
       formData.append('file_references', JSON.stringify(options.fileReferences));
+    }
+    if (options.executionProfile !== undefined && options.executionProfile !== null) {
+      formData.append('override_execution_profile', options.executionProfile.toString());
     }
     if (options.files && options.files.length > 0) {
       options.files.forEach((file) => formData.append('files', file));

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1829,6 +1829,7 @@ class ApiService {
       files?: File[];
       searchParams?: unknown;
       conversationId?: number | null;
+      executionProfile?: number | null;
       onEvent: (event: StreamEvent) => void;
       signal?: AbortSignal;
     }
@@ -1841,6 +1842,9 @@ class ApiService {
     }
     if (options.conversationId) {
       formData.append('conversation_id', options.conversationId.toString());
+    }
+    if (options.executionProfile !== undefined && options.executionProfile !== null) {
+      formData.append('override_execution_profile', options.executionProfile.toString());
     }
     if (options.files && options.files.length > 0) {
       options.files.forEach((file) => formData.append('files', file));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "ai-core-tools-develop",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -26,7 +26,7 @@ from models.silo import Silo
 
 
 # ---------------------------------------------------------------------------
-# Base factory — all factories inherit from this
+# Base factory - all factories inherit from this
 # ---------------------------------------------------------------------------
 
 class BaseFactory(SQLAlchemyModelFactory):
@@ -81,6 +81,7 @@ class AIServiceFactory(BaseFactory):
     provider = "OpenAI"
     api_key = "sk-test-key"  # pragma: allowlist secret
     endpoint = None
+    execution_profile = 1
     app = factory.SubFactory(AppFactory)
 
     @factory.lazy_attribute
@@ -101,6 +102,7 @@ class AgentFactory(BaseFactory):
     system_prompt = "You are a helpful test assistant."
     has_memory = False
     temperature = 0.7
+    execution_profile = None
     request_count = 0
     is_tool = False
     app = factory.SubFactory(AppFactory)

--- a/tests/unit/services/test_execution_profiles.py
+++ b/tests/unit/services/test_execution_profiles.py
@@ -944,3 +944,152 @@ def test_all_profiles_produce_no_reasoning_when_not_supported(profile):
     assert rc.reasoning_kwarg is None
     assert rc.reasoning_value is None
     assert rc.supports_reasoning is False
+
+
+# ========================================================================
+# 99-101. gpt-5 temperature \u0026 reasoning handling
+# ========================================================================
+
+
+class TestGpt5TemperatureHandling:
+    """gpt-5.1/5.2/5.3 reject temperature != 1.0 — force_temperature=1.0."""
+
+    @pytest.mark.parametrize("profile", list(ExecutionProfile))
+    def test_gpt51_force_temperature_one(self, profile):
+        """gpt-5.1 should force temperature to 1.0 at every profile."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-5.1-chat-latest", profile)
+        assert rc.force_temperature == 1.0
+        kwargs = build_runtime_kwargs(rc, temperature=0.7)
+        assert kwargs["temperature"] == 1.0
+
+    @pytest.mark.parametrize("model_id", [
+        "gpt-5.2-chat-latest",
+        "gpt-5.3-chat-latest",
+    ])
+    @pytest.mark.parametrize("profile", list(ExecutionProfile))
+    def test_gpt52_gpt53_force_temperature_one(self, model_id, profile):
+        """gpt-5.2 and gpt-5.3 should also force temperature to 1.0."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, model_id, profile)
+        assert rc.force_temperature == 1.0
+        kwargs = build_runtime_kwargs(rc, temperature=0.0)
+        assert kwargs["temperature"] == 1.0
+
+    def test_gpt5_temperature_forcing_preserves_reasoning(self):
+        """gpt-5.1/5.2/5.3 should keep reasoning enabled (inherited)."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-5.1-chat-latest", ExecutionProfile.FAST)
+        assert rc.supports_reasoning is True
+        assert rc.reasoning_kwarg == "reasoning_effort"
+
+
+class TestGpt5ReasoningDisabled:
+    """gpt-5.4+ reject reasoning_effort with function tools — reasoning disabled."""
+
+    @pytest.mark.parametrize("model_id", [
+        "gpt-5.4-chat-latest",
+        "gpt-5.5-chat-latest",
+        "gpt-5.6-reasoning",
+        "gpt-5.9-pro",
+    ])
+    @pytest.mark.parametrize("profile", list(ExecutionProfile))
+    def test_gpt54_plus_no_reasoning(self, model_id, profile):
+        """gpt-5.4+ should have reasoning disabled regardless of profile."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, model_id, profile)
+        assert rc.supports_reasoning is False
+        assert rc.reasoning_kwarg is None
+        assert rc.reasoning_value is None
+        kwargs = build_runtime_kwargs(rc)
+        assert "reasoning_effort" not in kwargs
+
+    def test_gpt54_inherits_temperature(self):
+        """gpt-5.4 should NOT force temperature — it passes normal temperature through."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-5.4-chat-latest", ExecutionProfile.FAST)
+        # No force_temperature, no disable_temperature
+        assert rc.force_temperature is None
+        assert rc.disable_temperature is False
+        kwargs = build_runtime_kwargs(rc, temperature=0.7)
+        assert kwargs["temperature"] == 0.7
+
+
+class TestGpt5RegexScope:
+    """Verify the regex patterns match intended models and avoid false positives."""
+
+    def test_gpt5_minor_regex_matches_multi_digit(self):
+        """The gpt-5. reasoning pattern should match gpt-5.10 etc."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-5.10-chat-latest", ExecutionProfile.FAST)
+        # Should match gpt-5. reasoning-disabled pattern
+        assert rc.supports_reasoning is False
+
+    def test_gpt5_minor_pattern_does_not_match_gpt4(self):
+        """gpt-4 models should NOT match the gpt-5 pattern."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-4o", ExecutionProfile.DEEP)
+        assert rc.supports_reasoning is True
+        assert rc.reasoning_kwarg == "reasoning_effort"
+
+    def test_gpt51_does_not_disable_reasoning(self):
+        """gpt-5.1 should NOT disable reasoning — only force temperature."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-5.1-chat-latest", ExecutionProfile.DEEP)
+        assert rc.supports_reasoning is True
+        assert rc.force_temperature == 1.0
+        assert rc.reasoning_kwarg == "reasoning_effort"
+
+    def test_no_double_matching_gpt54(self):
+        """gpt-5.4 must NOT get force_temperature from gpt-5.[1-3] rule."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-5.4-chat-latest", ExecutionProfile.DEEP)
+        assert rc.force_temperature is None  # Must NOT be forced
+        assert rc.supports_reasoning is False
+        kwargs = build_runtime_kwargs(rc, temperature=0.7)
+        assert kwargs.get("temperature") == 0.7  # Normal temp allowed
+        assert "reasoning_effort" not in kwargs  # No reasoning
+
+    def test_no_double_matching_all_gpt5_versions(self):
+        """Verify correct behavior across the full gpt-5 family."""
+        _restore_builtins()
+        test_cases = [
+            ("gpt-5.1-chat-latest", True, 1.0, True),      # force_temp, has_reasoning
+            ("gpt-5.2-chat-latest", True, 1.0, True),
+            ("gpt-5.3-chat-latest", True, 1.0, True),
+            ("gpt-5.4-chat-latest", False, None, False),    # no force, no reasoning
+            ("gpt-5.5-reasoning", False, None, False),
+            ("gpt-5.9-pro", False, None, False),
+            ("gpt-5.10-mini", False, None, False),          # also no reasoning
+        ]
+        for model_id, has_force, force_val, should_reason in test_cases:
+            rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, model_id, ExecutionProfile.FAST)
+            if has_force:
+                assert rc.force_temperature == force_val, f"{model_id} should force temp"
+            else:
+                assert rc.force_temperature is None, f"{model_id} should NOT force temp"
+            assert rc.supports_reasoning == should_reason, f"{model_id} reasoning mismatch"
+
+    def test_o1_still_works_normal(self):
+        """Verify o1 models are unaffected by gpt-5 changes."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "o1", ExecutionProfile.BALANCED)
+        assert rc.force_temperature is None  # o1 disables temp differently
+        assert rc.disable_temperature is True  # o1 uses disable_temperature
+        assert rc.supports_reasoning is True
+
+    def test_gpt4o_still_works_normal(self):
+        """Verify gpt-4o is unaffected by gpt-5 changes."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-4o", ExecutionProfile.DEEP)
+        assert rc.force_temperature is None
+        assert rc.supports_reasoning is True
+        assert rc.reasoning_kwarg == "reasoning_effort"
+
+    def test_anthropic_claude_unaffected(self):
+        """Verify Anthropic models are unaffected."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_ANTHROPIC, "claude-sonnet-4", ExecutionProfile.MAX)
+        assert rc.force_temperature is None
+        assert rc.reasoning_kwarg == "thinking_budget"
+        assert rc.reasoning_value == 125000

--- a/tests/unit/services/test_execution_profiles.py
+++ b/tests/unit/services/test_execution_profiles.py
@@ -213,13 +213,13 @@ def test_google_family_reasoning(provider):
 
 
 def test_google_family_profile_values():
-    """Verify Google family profile values match Anthropic (integers)."""
+    """Verify Google family profile values capped at Gemini API limit (65535 for DEEP/MAX)."""
     for provider in (PROVIDER_GOOGLE, PROVIDER_GOOGLE_CLOUD):
         cap = get_provider_capability(provider)
         assert cap.profile_values[ExecutionProfile.FAST] == 1024
         assert cap.profile_values[ExecutionProfile.BALANCED] == 5000
-        assert cap.profile_values[ExecutionProfile.DEEP] == 50000
-        assert cap.profile_values[ExecutionProfile.MAX] == 125000
+        assert cap.profile_values[ExecutionProfile.DEEP] == 65535
+        assert cap.profile_values[ExecutionProfile.MAX] == 65535
 
 
 def test_custom_provider_not_supported():
@@ -293,10 +293,14 @@ def test_model_capability_prefix_matching():
         assert cap.disable_temperature is True
         # o3 uses the default reasoning_effort (no model_reasoning_kwarg)
 
-    # ^gemini-[2-9] should match gemini-2, gemini-2.5, etc.
+    # Gemini 2.x+ regex should match gemini-2.x, gemini-3, but NOT flash variants.
     for model in ("gemini-2.0-pro", "gemini-2.5", "gemini-3"):
         cap = ModelCapability.for_model(PROVIDER_GOOGLE, model)
-        assert cap.regex_pattern == "^gemini-[2-9]"
+        assert cap.supports_reasoning is True
+    # Flash models should NOT match the reasoning-capable pattern
+    for flash_model in ("gemini-2.5-flash-lite", "gemini-2.0-flash"):
+        cap = ModelCapability.for_model(PROVIDER_GOOGLE, flash_model)
+        assert cap.regex_pattern == "", f"Flash model {flash_model} should not match any reasoning pattern, got: {cap.regex_pattern}"
 
 
 def test_model_capability_override_inheritance():
@@ -485,10 +489,10 @@ class TestRuntimeConfigBuilderGoogle:
 
     @pytest.mark.parametrize("provider", [PROVIDER_GOOGLE, PROVIDER_GOOGLE_CLOUD])
     def test_google_thinking_budget(self, provider):
-        """Google providers should use thinking_budget kwarg."""
+        """Google providers should use thinking_budget kwarg, DEEP capped at 65535."""
         rc = RuntimeConfigBuilder.build(provider, "gemini-2.0-pro", ExecutionProfile.DEEP)
         assert rc.reasoning_kwarg == "thinking_budget"
-        assert rc.reasoning_value == 50000
+        assert rc.reasoning_value == 65535
 
 
 # ========================================================================
@@ -977,11 +981,12 @@ class TestGpt5TemperatureHandling:
         assert kwargs["temperature"] == 1.0
 
     def test_gpt5_temperature_forcing_preserves_reasoning(self):
-        """gpt-5.1/5.2/5.3 should keep reasoning enabled (inherited)."""
+        """gpt-5.1/5.2/5.3 should keep reasoning enabled with value=medium."""
         _restore_builtins()
         rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-5.1-chat-latest", ExecutionProfile.FAST)
         assert rc.supports_reasoning is True
         assert rc.reasoning_kwarg == "reasoning_effort"
+        assert rc.reasoning_value == "medium"
 
 
 class TestGpt5ReasoningDisabled:
@@ -1093,3 +1098,88 @@ class TestGpt5RegexScope:
         assert rc.force_temperature is None
         assert rc.reasoning_kwarg == "thinking_budget"
         assert rc.reasoning_value == 125000
+
+
+# ========================================================================
+# 102-104. gpt-5.1/2/3 reasoning restriction & gpt-4.1 tests
+# ========================================================================
+
+
+class TestGpt5ChatLatestReasoningRestriction:
+    """gpt-5.{1,2,3}-chat-latest models only accept reasoning_effort=medium."""
+
+    @pytest.mark.parametrize("model_id", [
+        "gpt-5.1-chat-latest",
+        "gpt-5.2-chat-latest",
+        "gpt-5.3-chat-latest",
+    ])
+    @pytest.mark.parametrize("profile", list(ExecutionProfile))
+    def test_chat_latest_reasoning_always_medium(self, model_id, profile):
+        """gpt-5.{1,2,3}-chat-latest should force reasoning_effort=medium at every profile."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, model_id, profile)
+        assert rc.supports_reasoning is True
+        assert rc.reasoning_kwarg == "reasoning_effort"
+        assert rc.reasoning_value == "medium"
+        kwargs = build_runtime_kwargs(rc, temperature=0.7)
+        assert kwargs["reasoning_effort"] == "medium"
+
+    @pytest.mark.parametrize("model_id", [
+        "gpt-5.1-chat-latest",
+        "gpt-5.2-chat-latest",
+        "gpt-5.3-chat-latest",
+    ])
+    def test_chat_latest_no_false_positive_gpt54(self, model_id):
+        """gpt-5.{1,2,3}-chat-latest should NOT match the gpt-5.4+ reasoning-disabled pattern."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, model_id, ExecutionProfile.DEEP)
+        assert rc.supports_reasoning is True
+        assert rc.force_temperature == 1.0
+
+
+class TestGpt41Override:
+    """gpt-4.1 series models only accept reasoning_effort=medium and force_temperature=1.0."""
+
+    @pytest.mark.parametrize("model_id", [
+        "gpt-4.1",
+        "gpt-4.1-mini",
+        "gpt-4.1-nano",
+        "gpt-4.1-mini-chat-latest",
+        "gpt-4.1-nano-chat-latest",
+    ])
+    @pytest.mark.parametrize("profile", list(ExecutionProfile))
+    def test_gpt41_reasoning_always_medium(self, model_id, profile):
+        """gpt-4.1 models should force reasoning_effort=medium at every profile."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, model_id, profile)
+        assert rc.supports_reasoning is True
+        assert rc.reasoning_kwarg == "reasoning_effort"
+        assert rc.reasoning_value == "medium"
+
+    @pytest.mark.parametrize("model_id", [
+        "gpt-4.1",
+        "gpt-4.1-mini",
+        "gpt-4.1-nano",
+    ])
+    def test_gpt41_force_temperature(self, model_id):
+        """gpt-4.1 models should force temperature to 1.0."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, model_id, ExecutionProfile.DEEP)
+        assert rc.force_temperature == 1.0
+        kwargs = build_runtime_kwargs(rc, temperature=0.7)
+        assert kwargs["temperature"] == 1.0
+
+    def test_gpt41_does_not_match_gpt54_pattern(self):
+        """gpt-4.1 should NOT be affected by gpt-5.4+ reasoning-disabled rule."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-4.1-mini", ExecutionProfile.MAX)
+        assert rc.supports_reasoning is True
+        assert "reasoning_effort" in build_runtime_kwargs(rc)
+
+    def test_gpt4o_unaffected_by_gpt41_override(self):
+        """gpt-4o should NOT match the gpt-4.1 regex pattern."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-4o", ExecutionProfile.DEEP)
+        assert rc.supports_reasoning is True
+        assert rc.reasoning_value == "high"
+        assert rc.force_temperature is None

--- a/tests/unit/services/test_execution_profiles.py
+++ b/tests/unit/services/test_execution_profiles.py
@@ -264,23 +264,34 @@ def test_has_reasoning_config_logic(supported, kwarg, expected):
 
 
 def test_model_capability_exact_match_o1():
-    """Verify exact match: model 'o1' gets overrides for regex pattern '^o\d'."""
+    """Verify o1 gets overrides: reasoning enabled, temperature disabled, max_completion_tokens kwarg."""
     _restore_builtins()  # Ensure builtins are present
-    # The built-in override uses regex_pattern r"^o\d" which matches "o1"
     cap = ModelCapability.for_model(PROVIDER_OPENAI, "o1")
-    assert cap.regex_pattern == "^o\\d"
+    assert cap.regex_pattern == "^o1"
     assert cap.supports_reasoning is True
     assert cap.disable_temperature is True
+    assert cap.supports_vision is True
+    assert cap.model_reasoning_kwarg == "max_completion_tokens"
+    assert ExecutionProfile.FAST in cap.model_reasoning_config
 
 
 def test_model_capability_prefix_matching():
     """Verify prefix matching works for model families."""
     _restore_builtins()
-    # ^o\d should match o1, o3, o4, o1-2024-12-17, etc.
-    for model in ("o1", "o3", "o4", "o1-mini", "o1-2024-12-17"):
+    # o1 prefix: max_completion_tokens, no temperature
+    for model in ("o1", "o1-mini", "o1-2024-12-17"):
         cap = ModelCapability.for_model(PROVIDER_OPENAI, model)
-        assert cap.regex_pattern == "^o\\d"
+        assert cap.regex_pattern == "^o1"
         assert cap.supports_reasoning is True
+        assert cap.model_reasoning_kwarg == "max_completion_tokens"
+
+    # o3 prefix: reasoning_effort (inherits provider default), no temperature
+    for model in ("o3", "o3-mini"):
+        cap = ModelCapability.for_model(PROVIDER_OPENAI, model)
+        assert cap.regex_pattern == "^o3"
+        assert cap.supports_reasoning is True
+        assert cap.disable_temperature is True
+        # o3 uses the default reasoning_effort (no model_reasoning_kwarg)
 
     # ^gemini-[2-9] should match gemini-2, gemini-2.5, etc.
     for model in ("gemini-2.0-pro", "gemini-2.5", "gemini-3"):
@@ -393,14 +404,46 @@ class TestRuntimeConfigBuilderOpenAI:
         assert rc.reasoning_kwarg == "reasoning_effort"
         assert rc.reasoning_value == expected_value
 
-    def test_openai_o1_max_disable_temperature(self):
-        """OpenAI o1 at MAX profile should have reasoning=high and disable_temperature=True."""
+    def test_openai_o3_reasoning(self):
+        """OpenAI o3 should use provider default reasoning_effort with temperature disabled."""
         _restore_builtins()
-        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "o1", ExecutionProfile.MAX)
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "o3", ExecutionProfile.DEEP)
+        # o3 uses provider default reasoning_effort (no model_reasoning_kwarg)
+        assert rc.model_reasoning_kwarg is None
+        assert rc.model_reasoning_value is None
         assert rc.reasoning_kwarg == "reasoning_effort"
         assert rc.reasoning_value == "high"
         assert rc.disable_temperature is True
         assert rc.supports_reasoning is True
+
+    def test_openai_o1_model_specific_reasoning(self):
+        """OpenAI o1 should use max_completion_tokens instead of reasoning_effort."""
+        _restore_builtins()
+        for profile, expected_token in [
+            (ExecutionProfile.FAST, 128),
+            (ExecutionProfile.BALANCED, 512),
+            (ExecutionProfile.DEEP, 1024),
+            (ExecutionProfile.MAX, 2048),
+        ]:
+            rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "o1", profile)
+            assert rc.model_reasoning_kwarg == "max_completion_tokens"
+            assert rc.model_reasoning_value == expected_token
+            # Should NOT use provider default reasoning_effort for o1
+            assert rc.reasoning_kwarg is None
+            assert rc.reasoning_value is None
+            assert rc.disable_temperature is True
+            assert rc.supports_reasoning is True
+
+    def test_openai_o1_model_reasoning_override_prevents_provider_kwarg(self):
+        """When model_reasoning_kwarg is set, the provider's kwarg must not appear."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "o1", ExecutionProfile.MAX)
+        # The model overrides the provider's reasoning mechanism entirely
+        assert rc.reasoning_kwarg is None
+        assert rc.reasoning_value is None
+        # But the model-specific config takes effect
+        assert rc.model_reasoning_kwarg == "max_completion_tokens"
+        assert rc.model_reasoning_value == 2048
 
 
 class TestRuntimeConfigBuilderAnthropic:
@@ -668,14 +711,16 @@ class TestBuildRuntimeKwargs:
         assert kwargs["temperature"] == 0.8
         assert kwargs["top_p"] == 0.9
 
-    def test_o1_no_temperature_in_kwargs(self):
-        """o-series models should not get temperature despite being passed."""
+    def test_o1_model_reasoning_no_temperature_in_kwargs(self):
+        """o1 models use max_completion_tokens (not reasoning_effort) and have no temperature."""
         _restore_builtins()
         rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "o1", ExecutionProfile.MAX)
         kwargs = build_runtime_kwargs(rc, temperature=0.7)
-        assert "reasoning_effort" in kwargs
-        assert kwargs["reasoning_effort"] == "high"
         assert "temperature" not in kwargs
+        # o1 uses model_reasoning_kwarg, not provider reasoning_effort
+        assert "max_completion_tokens" in kwargs
+        assert kwargs["max_completion_tokens"] == 2048
+        assert "reasoning_effort" not in kwargs
 
 
 # ========================================================================

--- a/tests/unit/services/test_execution_profiles.py
+++ b/tests/unit/services/test_execution_profiles.py
@@ -1,0 +1,901 @@
+"""Comprehensive unit tests for the execution profiles system.
+
+Covers ExecutionProfile enum, ProviderCapability / ModelCapability dataclasses,
+RuntimeConfigBuilder, build_runtime_kwargs, and the global registries.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from tools.execution_profiles import (
+    ExecutionProfile,
+    ProviderCapability,
+    ModelCapability,
+    RuntimeConfig,
+    RuntimeConfigBuilder,
+    build_runtime_kwargs,
+    get_provider_capability,
+    register_provider_capability,
+    register_model_override,
+    clear_model_overrides,
+    _REGISTRY,
+    _MODEL_OVERRIDES,
+)
+from tools.ai.model_catalog import (
+    PROVIDER_OPENAI,
+    PROVIDER_ANTHROPIC,
+    PROVIDER_MISTRAL,
+    PROVIDER_GOOGLE,
+    PROVIDER_GOOGLE_CLOUD,
+    PROVIDER_AZURE,
+    PROVIDER_OPENROUTER,
+    PROVIDER_CUSTOM,
+)
+
+
+# ========================================================================
+# Fixtures
+# ========================================================================
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    """Clear model overrides before every test to avoid cross-test pollution."""
+    clear_model_overrides()
+    yield
+
+
+# === Helper: register builtins for tests that need them ===
+
+
+def _restore_builtins():
+    """Re-register built-in model overrides (o1, claude, gemini) on top of
+    cleared state.  Tests that call clear_model_overrides() mid-body use
+    this to restore the baseline before continuing."""
+    from tools import execution_profiles as _ep
+    _MODEL_OVERRIDES.clear()  # Prevents duplicates on repeated calls
+    _ep._register_builtin_model_overrides()
+
+
+@pytest.fixture
+def built_in_providers():
+    """Return the set of providers registered by _register_builtin_capabilities()."""
+    builtin = {
+        PROVIDER_OPENAI,
+        PROVIDER_ANTHROPIC,
+        PROVIDER_MISTRAL,
+        PROVIDER_GOOGLE,
+        PROVIDER_GOOGLE_CLOUD,
+        PROVIDER_AZURE,
+        PROVIDER_OPENROUTER,
+        PROVIDER_CUSTOM,
+    }
+    return builtin
+
+
+@pytest.fixture
+def register_test_provider():
+    """Register a temporary provider and unregister it after the test."""
+    providers_added = []
+
+    def _register(cap, provider_name):
+        _REGISTRY[provider_name] = cap
+        providers_added.append(provider_name)
+        return cap
+
+    yield _register
+
+    for name in providers_added:
+        _REGISTRY.pop(name, None)
+
+
+# ========================================================================
+# 1-4. ExecutionProfile enum tests
+# ========================================================================
+
+
+@pytest.mark.parametrize("name,value", [
+    ("FAST", 0),
+    ("BALANCED", 1),
+    ("DEEP", 2),
+    ("MAX", 3),
+])
+def test_execution_profile_values(name, value):
+    """Verify the four profiles exist with correct integer values."""
+    profile = ExecutionProfile[name]
+    assert profile.value == value
+
+
+def test_execution_profile_intenum_ordering():
+    """Verify IntEnum ordering: FAST < BALANCED < DEEP < MAX."""
+    assert ExecutionProfile.FAST < ExecutionProfile.BALANCED
+    assert ExecutionProfile.BALANCED < ExecutionProfile.DEEP
+    assert ExecutionProfile.DEEP < ExecutionProfile.MAX
+    assert ExecutionProfile.FAST < ExecutionProfile.MAX
+
+
+@pytest.mark.parametrize("name", ["FAST", "BALANCED", "DEEP", "MAX"])
+def test_execution_profile_by_name_access(name):
+    """Verify by-name access works for all profiles."""
+    assert hasattr(ExecutionProfile, name)
+    profile = getattr(ExecutionProfile, name)
+    assert isinstance(profile, ExecutionProfile)
+
+
+def test_execution_profile_reverse_lookup():
+    """Verify reverse lookup: ExecutionProfile(0) == ExecutionProfile.FAST."""
+    assert ExecutionProfile(0) == ExecutionProfile.FAST
+    assert ExecutionProfile(1) == ExecutionProfile.BALANCED
+    assert ExecutionProfile(2) == ExecutionProfile.DEEP
+    assert ExecutionProfile(3) == ExecutionProfile.MAX
+
+
+# ========================================================================
+# 5-15. ProviderCapability tests
+# ========================================================================
+
+
+@pytest.mark.parametrize("provider,expected_kwarg", [
+    (PROVIDER_OPENAI, "reasoning_effort"),
+    (PROVIDER_AZURE, "reasoning_effort"),
+    (PROVIDER_OPENROUTER, "reasoning_effort"),
+])
+def test_provider_reasoning_with_reasoning_effort(provider, expected_kwarg):
+    """Verify providers that use reasoning_effort kwarg."""
+    cap = get_provider_capability(provider)
+    assert cap.supported is True
+    assert cap.reasoning_kwarg == expected_kwarg
+    assert cap.has_reasoning_config is True
+
+
+@pytest.mark.parametrize("provider", [
+    PROVIDER_OPENAI,
+    PROVIDER_AZURE,
+    PROVIDER_OPENROUTER,
+])
+def test_provider_profile_values_strings(provider):
+    """Verify string-based profile values for reasoning_effort providers."""
+    cap = get_provider_capability(provider)
+    assert cap.profile_values[ExecutionProfile.FAST] == "low"
+    assert cap.profile_values[ExecutionProfile.BALANCED] == "medium"
+    assert cap.profile_values[ExecutionProfile.DEEP] == "high"
+    assert cap.profile_values[ExecutionProfile.MAX] == "high"
+
+
+@pytest.mark.parametrize("provider", [
+    PROVIDER_OPENAI,
+    PROVIDER_AZURE,
+    PROVIDER_OPENROUTER,
+])
+def test_provider_default_profile_balanced(provider):
+    """Verify default profile is BALANCED for reasoning_effort providers."""
+    cap = get_provider_capability(provider)
+    assert cap.default_profile == ExecutionProfile.BALANCED
+
+
+def test_anthropic_reasoning_with_thinking_budget():
+    """Verify Anthropic has reasoning supported with kwarg thinking_budget."""
+    cap = get_provider_capability(PROVIDER_ANTHROPIC)
+    assert cap.supported is True
+    assert cap.reasoning_kwarg == "thinking_budget"
+    assert cap.has_reasoning_config is True
+
+
+def test_anthropic_profile_values():
+    """Verify Anthropic profile_values: integers (1024, 5000, 50000, 125000)."""
+    cap = get_provider_capability(PROVIDER_ANTHROPIC)
+    assert cap.profile_values[ExecutionProfile.FAST] == 1024
+    assert cap.profile_values[ExecutionProfile.BALANCED] == 5000
+    assert cap.profile_values[ExecutionProfile.DEEP] == 50000
+    assert cap.profile_values[ExecutionProfile.MAX] == 125000
+
+
+def test_mistral_reasoning_not_supported():
+    """Verify MistralAI has reasoning NOT supported."""
+    cap = get_provider_capability(PROVIDER_MISTRAL)
+    assert cap.supported is False
+    assert cap.reasoning_kwarg is None
+    assert cap.has_reasoning_config is False
+
+
+@pytest.mark.parametrize("provider", [
+    PROVIDER_GOOGLE,
+    PROVIDER_GOOGLE_CLOUD,
+])
+def test_google_family_reasoning(provider):
+    """Verify Google and GoogleCloud have reasoning supported with thinking_budget."""
+    cap = get_provider_capability(provider)
+    assert cap.supported is True
+    assert cap.reasoning_kwarg == "thinking_budget"
+    assert cap.has_reasoning_config is True
+
+
+def test_google_family_profile_values():
+    """Verify Google family profile values match Anthropic (integers)."""
+    for provider in (PROVIDER_GOOGLE, PROVIDER_GOOGLE_CLOUD):
+        cap = get_provider_capability(provider)
+        assert cap.profile_values[ExecutionProfile.FAST] == 1024
+        assert cap.profile_values[ExecutionProfile.BALANCED] == 5000
+        assert cap.profile_values[ExecutionProfile.DEEP] == 50000
+        assert cap.profile_values[ExecutionProfile.MAX] == 125000
+
+
+def test_custom_provider_not_supported():
+    """Verify Custom provider has reasoning NOT supported."""
+    cap = get_provider_capability(PROVIDER_CUSTOM)
+    assert cap.supported is False
+    assert cap.reasoning_kwarg is None
+    assert cap.has_reasoning_config is False
+
+
+@pytest.mark.parametrize("provider,expected_supported", [
+    (PROVIDER_OPENAI, True),
+    (PROVIDER_ANTHROPIC, True),
+    (PROVIDER_GOOGLE, True),
+    (PROVIDER_GOOGLE_CLOUD, True),
+    (PROVIDER_AZURE, True),
+    (PROVIDER_OPENROUTER, True),
+    (PROVIDER_MISTRAL, False),
+    (PROVIDER_CUSTOM, False),
+])
+def test_has_reasoning_config(provider, expected_supported):
+    """Verify has_reasoning_config property works correctly for all built-in providers."""
+    cap = get_provider_capability(provider)
+    assert cap.has_reasoning_config is expected_supported
+
+
+@pytest.mark.parametrize("supported, kwarg, expected", [
+    (True, "reasoning_effort", True),
+    (True, None, False),
+    (False, "reasoning_effort", False),
+    (False, None, False),
+])
+def test_has_reasoning_config_logic(supported, kwarg, expected):
+    """Verify has_reasoning_config is True only when both supported and kwarg non-None."""
+    cap = ProviderCapability(supported=supported, reasoning_kwarg=kwarg)
+    assert cap.has_reasoning_config is expected
+
+
+# ========================================================================
+# 16-20. ModelCapability tests
+# ========================================================================
+
+
+def test_model_capability_exact_match_o1():
+    """Verify exact match: model 'o1' gets overrides for regex pattern '^o\d'."""
+    _restore_builtins()  # Ensure builtins are present
+    # The built-in override uses regex_pattern r"^o\d" which matches "o1"
+    cap = ModelCapability.for_model(PROVIDER_OPENAI, "o1")
+    assert cap.regex_pattern == "^o\\d"
+    assert cap.supports_reasoning is True
+    assert cap.disable_temperature is True
+
+
+def test_model_capability_prefix_matching():
+    """Verify prefix matching works for model families."""
+    _restore_builtins()
+    # ^o\d should match o1, o3, o4, o1-2024-12-17, etc.
+    for model in ("o1", "o3", "o4", "o1-mini", "o1-2024-12-17"):
+        cap = ModelCapability.for_model(PROVIDER_OPENAI, model)
+        assert cap.regex_pattern == "^o\\d"
+        assert cap.supports_reasoning is True
+
+    # ^gemini-[2-9] should match gemini-2, gemini-2.5, etc.
+    for model in ("gemini-2.0-pro", "gemini-2.5", "gemini-3"):
+        cap = ModelCapability.for_model(PROVIDER_GOOGLE, model)
+        assert cap.regex_pattern == "^gemini-[2-9]"
+
+
+def test_model_capability_override_inheritance():
+    """Verify override applied to provider defaults (not replacing everything)."""
+    # Clear any user-registered overrides first
+    clear_model_overrides()
+    from tools import execution_profiles as _ep
+    _ep._register_builtin_model_overrides()
+
+    # Register a model override that only changes supports_vision
+    register_model_override(
+        ModelCapability(
+            provider=PROVIDER_OPENAI,
+            regex_pattern=r"^gpt-4o",
+            supports_vision=True,
+        )
+    )
+
+    # Get the override
+    cap = ModelCapability.for_model(PROVIDER_OPENAI, "gpt-4o-pro")
+    assert cap.supports_vision is True
+
+    # Apply provider defaults — should inherit provider's reasoning config
+    provider_cap = get_provider_capability(PROVIDER_OPENAI)
+    resolved = cap.apply_provider_defaults(provider_cap)
+    assert resolved.supported is True  # inherited from provider
+    assert resolved.reasoning_kwarg == "reasoning_effort"
+
+
+def test_disable_temperature_o_series():
+    """Verify disable_temperature works for o-series models."""
+    _restore_builtins()
+    for model in ("o1", "o3", "o1-mini-predictions"):
+        cap = ModelCapability.for_model(PROVIDER_OPENAI, model)
+        assert cap.should_disable_temperature is True
+
+
+@pytest.mark.parametrize("model", ["gpt-3.5-turbo", "gpt-4", "custom-model-x"])
+def test_model_capability_for_model_unknown(model):
+    """Verify for_model returns empty sentinel for models with no override."""
+    cap = ModelCapability.for_model(PROVIDER_OPENAI, model)
+    # Unknown models have no regex_pattern and empty model_id
+    assert cap.regex_pattern == ""
+    assert cap.model_id == ""
+    assert cap.supports_reasoning is None
+    assert cap.disable_temperature is False
+    assert cap.should_disable_temperature is False
+
+
+def test_model_capability_model_id_exact_match():
+    """Test exact match when model_id is set (not regex)."""
+    _restore_builtins()
+    register_model_override(
+        ModelCapability(
+            provider=PROVIDER_OPENAI,
+            model_id="gpt-4o-specific",
+            supports_reasoning=True,
+        )
+    )
+    cap = ModelCapability.for_model(PROVIDER_OPENAI, "gpt-4o-specific")
+    assert cap.model_id == "gpt-4o-specific"
+    assert cap.supports_reasoning is True
+
+
+def test_model_capability_precedence_exact_over_prefix():
+    """Verify exact match takes precedence over prefix match."""
+    _restore_builtins()
+    register_model_override(
+        ModelCapability(
+            provider=PROVIDER_OPENAI,
+            model_id="o1",
+            disable_temperature=False,
+        )
+    )
+
+    # Exact match should be applied even though o1 also matches ^o\d
+    cap = ModelCapability.for_model(PROVIDER_OPENAI, "o1")
+    # The for_model method returns the ModelCapability object from the registry
+    # For model_id "o1" with supports_reasoning=None, we need to check
+    # that the exact match o1 rule is returned (the one with disable_temperature=False)
+    # But wait — the built-in override has regex_pattern r"^o\d" for o1.
+    # The exact match check happens first: rule.model_id == model_id.
+    # So the ModelCapability(model_id="o1", disable_temperature=False) should be returned.
+    assert cap.model_id == "o1"
+    assert cap.disable_temperature is False
+
+
+# ========================================================================
+# 21-28. RuntimeConfigBuilder tests
+# ========================================================================
+
+
+class TestRuntimeConfigBuilderOpenAI:
+    """Build and verify RuntimeConfig for OpenAI providers."""
+
+    @pytest.mark.parametrize("profile,expected_value", [
+        (ExecutionProfile.FAST, "low"),
+        (ExecutionProfile.BALANCED, "medium"),
+        (ExecutionProfile.DEEP, "high"),
+        (ExecutionProfile.MAX, "high"),
+    ])
+    def test_openai_gpt4o_reasoning_values(self, profile, expected_value):
+        """OpenAI gpt-4o at various profiles should produce correct reasoning values."""
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-4o", profile)
+        assert rc.reasoning_kwarg == "reasoning_effort"
+        assert rc.reasoning_value == expected_value
+
+    def test_openai_o1_max_disable_temperature(self):
+        """OpenAI o1 at MAX profile should have reasoning=high and disable_temperature=True."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "o1", ExecutionProfile.MAX)
+        assert rc.reasoning_kwarg == "reasoning_effort"
+        assert rc.reasoning_value == "high"
+        assert rc.disable_temperature is True
+        assert rc.supports_reasoning is True
+
+
+class TestRuntimeConfigBuilderAnthropic:
+    """Build and verify RuntimeConfig for Anthropic provider."""
+
+    @pytest.mark.parametrize("profile,expected_value", [
+        (ExecutionProfile.FAST, 1024),
+        (ExecutionProfile.BALANCED, 5000),
+        (ExecutionProfile.DEEP, 50000),
+        (ExecutionProfile.MAX, 125000),
+    ])
+    def test_anthropic_thinking_budget_values(self, profile, expected_value):
+        """Anthropic models should produce correct thinking_budget values."""
+        rc = RuntimeConfigBuilder.build(PROVIDER_ANTHROPIC, "claude-sonnet-4", profile)
+        assert rc.reasoning_kwarg == "thinking_budget"
+        assert rc.reasoning_value == expected_value
+
+
+class TestRuntimeConfigBuilderNoReasoning:
+    """Build RuntimeConfig for providers/models that have no reasoning support."""
+
+    def test_mistral_no_reasoning(self):
+        """Mistral model at DEEP should have reasoning_kwarg=None."""
+        rc = RuntimeConfigBuilder.build(PROVIDER_MISTRAL, "mistral-large", ExecutionProfile.DEEP)
+        assert rc.reasoning_kwarg is None
+        assert rc.reasoning_value is None
+        assert rc.supports_reasoning is False
+
+    def test_custom_no_reasoning(self):
+        """Custom/Ollama model should not have reasoning config."""
+        rc = RuntimeConfigBuilder.build(PROVIDER_CUSTOM, "ollama-model", ExecutionProfile.DEEP)
+        assert rc.reasoning_kwarg is None
+        assert rc.reasoning_value is None
+        assert rc.supports_reasoning is False
+
+
+class TestRuntimeConfigBuilderGoogle:
+    """Build RuntimeConfig for Google / GoogleCloud providers."""
+
+    @pytest.mark.parametrize("provider", [PROVIDER_GOOGLE, PROVIDER_GOOGLE_CLOUD])
+    def test_google_thinking_budget(self, provider):
+        """Google providers should use thinking_budget kwarg."""
+        rc = RuntimeConfigBuilder.build(provider, "gemini-2.0-pro", ExecutionProfile.DEEP)
+        assert rc.reasoning_kwarg == "thinking_budget"
+        assert rc.reasoning_value == 50000
+
+
+# ========================================================================
+# 29-31. Runtime config builder inheritance tests
+# ========================================================================
+
+
+class TestModelOverrideInheritance:
+    """Model override inheritance from provider capabilities."""
+
+    def test_inherits_provider_supported_true(self):
+        """Model override inherits provider's supported=True when not overridden."""
+        _restore_builtins()
+        register_model_override(
+            ModelCapability(
+                provider=PROVIDER_OPENAI,
+                model_id="special-model",
+                # supports_reasoning NOT set — should inherit provider's True
+            )
+        )
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "special-model", ExecutionProfile.FAST)
+        assert rc.supports_reasoning is True
+
+    def test_model_override_disables_reasoning(self):
+        """Model override with supports_reasoning=False disables reasoning."""
+        _restore_builtins()
+        register_model_override(
+            ModelCapability(
+                provider=PROVIDER_OPENAI,
+                model_id="no-reason-model",
+                supports_reasoning=False,
+            )
+        )
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "no-reason-model", ExecutionProfile.DEEP)
+        assert rc.supports_reasoning is False
+        assert rc.reasoning_kwarg is None
+        assert rc.reasoning_value is None
+
+    def test_custom_profile_values_override(self):
+        """Custom profile_values override from model level replaces provider defaults."""
+        _restore_builtins()
+        custom_values = {
+            ExecutionProfile.FAST: "fast",
+            ExecutionProfile.BALANCED: "med",
+            ExecutionProfile.DEEP: "deep",
+            ExecutionProfile.MAX: "max",
+        }
+        register_model_override(
+            ModelCapability(
+                provider=PROVIDER_OPENAI,
+                model_id="custom-values-model",
+                supports_reasoning=True,
+                profile_values=custom_values,
+            )
+        )
+        rc = RuntimeConfigBuilder.build(
+            PROVIDER_OPENAI, "custom-values-model", ExecutionProfile.FAST
+        )
+        assert rc.profile_values == custom_values
+        assert rc.reasoning_value == "fast"
+
+        rc_deep = RuntimeConfigBuilder.build(
+            PROVIDER_OPENAI, "custom-values-model", ExecutionProfile.DEEP
+        )
+        assert rc_deep.reasoning_value == "deep"
+
+
+# ========================================================================
+# 32-39. build_runtime_kwargs tests
+# ========================================================================
+
+
+class TestBuildRuntimeKwargs:
+    """Test build_runtime_kwargs function."""
+
+    def test_with_reasoning_enabled(self):
+        """Build kwargs with reasoning enabled -> kwargs should contain reasoning_kwarg."""
+        rc = RuntimeConfig(
+            provider=PROVIDER_OPENAI,
+            model_id="gpt-4o",
+            execution_profile=ExecutionProfile.DEEP,
+            reasoning_kwarg="reasoning_effort",
+            reasoning_value="high",
+            supports_reasoning=True,
+        )
+        kwargs = build_runtime_kwargs(rc)
+        assert "reasoning_effort" in kwargs
+        assert kwargs["reasoning_effort"] == "high"
+
+    def test_with_reasoning_disabled(self):
+        """Build kwargs with reasoning disabled -> kwargs should NOT contain reasoning_kwarg."""
+        rc = RuntimeConfig(
+            provider=PROVIDER_MISTRAL,
+            model_id="mistral-large",
+            execution_profile=ExecutionProfile.DEEP,
+            reasoning_kwarg=None,
+            reasoning_value=None,
+            supports_reasoning=False,
+        )
+        kwargs = build_runtime_kwargs(rc)
+        assert "reasoning_effort" not in kwargs
+        assert kwargs == {}
+
+    def test_with_temperature(self):
+        """build_runtime_kwargs with temperature=0.7 -> should contain temperature."""
+        rc = RuntimeConfig(
+            provider=PROVIDER_OPENAI,
+            model_id="gpt-4o",
+            execution_profile=ExecutionProfile.FAST,
+        )
+        kwargs = build_runtime_kwargs(rc, temperature=0.7)
+        assert "temperature" in kwargs
+        assert kwargs["temperature"] == 0.7
+
+    @pytest.mark.parametrize("temperature", [0.0, 0.7, 1.0, 0.15])
+    def test_temperature_various_values(self, temperature):
+        """Build kwargs with various temperature values."""
+        rc = RuntimeConfig(
+            provider=PROVIDER_OPENAI,
+            model_id="gpt-4o",
+            execution_profile=ExecutionProfile.FAST,
+        )
+        kwargs = build_runtime_kwargs(rc, temperature=temperature)
+        assert kwargs["temperature"] == temperature
+
+    def test_disable_temperature_excludes_temperature(self):
+        """build_runtime_kwargs with disable_temperature=True -> excluded even if temperature passed."""
+        rc = RuntimeConfig(
+            provider=PROVIDER_OPENAI,
+            model_id="o1",
+            execution_profile=ExecutionProfile.MAX,
+            disable_temperature=True,
+            supports_reasoning=True,
+        )
+        kwargs = build_runtime_kwargs(rc, temperature=0.7)
+        assert "temperature" not in kwargs
+
+    def test_disable_temperature_false_includes_temperature(self):
+        """build_runtime_kwargs with disable_temperature=False -> includes temperature."""
+        rc = RuntimeConfig(
+            provider=PROVIDER_OPENAI,
+            model_id="gpt-4o",
+            execution_profile=ExecutionProfile.DEEP,
+            disable_temperature=False,
+        )
+        kwargs = build_runtime_kwargs(rc, temperature=0.7)
+        assert "temperature" in kwargs
+        assert kwargs["temperature"] == 0.7
+
+    def test_additional_kwargs_merged(self):
+        """build_runtime_kwargs with additional_kwargs -> merged into result."""
+        rc = RuntimeConfig(
+            provider=PROVIDER_OPENAI,
+            model_id="gpt-4o",
+            execution_profile=ExecutionProfile.FAST,
+        )
+        additional = {"top_p": 0.95, "presence_penalty": 0.1}
+        kwargs = build_runtime_kwargs(rc, temperature=0.7, additional_kwargs=additional)
+        assert kwargs["temperature"] == 0.7
+        assert kwargs["top_p"] == 0.95
+        assert kwargs["presence_penalty"] == 0.1
+
+    def test_additional_kwargs_override_reasoning(self):
+        """Additional kwargs can override reasoning values."""
+        rc = RuntimeConfig(
+            provider=PROVIDER_OPENAI,
+            model_id="gpt-4o",
+            execution_profile=ExecutionProfile.DEEP,
+            reasoning_kwarg="reasoning_effort",
+            reasoning_value="high",
+        )
+        kwargs = build_runtime_kwargs(rc, additional_kwargs={"reasoning_effort": "very_high"})
+        assert kwargs["reasoning_effort"] == "very_high"
+
+    def test_no_temperature_passed(self):
+        """build_runtime_kwargs with no temperature arg -> should not include temperature."""
+        rc = RuntimeConfig(
+            provider=PROVIDER_OPENAI,
+            model_id="gpt-4o",
+            execution_profile=ExecutionProfile.FAST,
+        )
+        kwargs = build_runtime_kwargs(rc)
+        assert "temperature" not in kwargs
+
+    def test_anthropic_fast_profile(self):
+        """Build kwargs for runtime config at FAST profile for Anthropic."""
+        rc = RuntimeConfigBuilder.build(
+            PROVIDER_ANTHROPIC,
+            "claude-sonnet-4",
+            ExecutionProfile.FAST,
+        )
+        kwargs = build_runtime_kwargs(rc, temperature=0.7)
+        assert kwargs["thinking_budget"] == 1024
+        assert kwargs["temperature"] == 0.7
+
+    def test_anthropic_max_profile(self):
+        """Build kwargs for runtime config at MAX profile for Anthropic."""
+        rc = RuntimeConfigBuilder.build(
+            PROVIDER_ANTHROPIC,
+            "claude-opus-4",
+            ExecutionProfile.MAX,
+        )
+        kwargs = build_runtime_kwargs(rc, temperature=0.5)
+        assert kwargs["thinking_budget"] == 125000
+        assert kwargs["temperature"] == 0.5
+
+    def test_combined_reasoning_and_temperature_and_additional(self):
+        """Build kwargs with reasoning, temperature, and additional kwargs all set."""
+        rc = RuntimeConfigBuilder.build(
+            PROVIDER_OPENAI,
+            "gpt-4o",
+            ExecutionProfile.BALANCED,
+        )
+        kwargs = build_runtime_kwargs(
+            rc,
+            temperature=0.8,
+            additional_kwargs={"top_p": 0.9},
+        )
+        assert kwargs["reasoning_effort"] == "medium"
+        assert kwargs["temperature"] == 0.8
+        assert kwargs["top_p"] == 0.9
+
+    def test_o1_no_temperature_in_kwargs(self):
+        """o-series models should not get temperature despite being passed."""
+        _restore_builtins()
+        rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "o1", ExecutionProfile.MAX)
+        kwargs = build_runtime_kwargs(rc, temperature=0.7)
+        assert "reasoning_effort" in kwargs
+        assert kwargs["reasoning_effort"] == "high"
+        assert "temperature" not in kwargs
+
+
+# ========================================================================
+# 40-42. Provider lookup tests
+# ========================================================================
+
+
+class TestProviderLookup:
+    """Test provider registry lookup and manipulation functions."""
+
+    def test_nonexistent_provider_returns_disabled(self):
+        """get_provider_capability for non-existent provider returns disabled ProviderCapability."""
+        cap = get_provider_capability("NonExistentProvider")
+        assert isinstance(cap, ProviderCapability)
+        assert cap.supported is False
+        assert cap.reasoning_kwarg is None
+        assert cap.has_reasoning_config is False
+        assert cap.default_profile == ExecutionProfile.BALANCED
+
+    def test_register_provider_capability(self, register_test_provider):
+        """register_provider_capability adds new provider to registry."""
+        new_cap = ProviderCapability(
+            supported=True,
+            reasoning_kwarg="custom_reasoning",
+            profile_values={
+                ExecutionProfile.FAST: 1,
+                ExecutionProfile.DEEP: 222,
+            },
+            default_profile=ExecutionProfile.FAST,
+        )
+        register_test_provider(new_cap, "CustomNewProvider")
+
+        cap = get_provider_capability("CustomNewProvider")
+        assert cap is new_cap
+        assert cap.supported is True
+        assert cap.reasoning_kwarg == "custom_reasoning"
+        assert cap.profile_values[ExecutionProfile.FAST] == 1
+        assert cap.default_profile == ExecutionProfile.FAST
+
+    def test_register_provider_overwrites(self, register_test_provider):
+        """register_provider_capability overwrites existing entry."""
+        cap1 = ProviderCapability(supported=True, default_profile=ExecutionProfile.FAST)
+        cap2 = ProviderCapability(supported=False, default_profile=ExecutionProfile.MAX)
+
+        register_test_provider(cap1, "OverwriteProvider")
+        register_test_provider(cap2, "OverwriteProvider")
+
+        cap = get_provider_capability("OverwriteProvider")
+        assert cap.supported is False
+        assert cap.default_profile == ExecutionProfile.MAX
+
+
+class TestClearModelOverrides:
+    """Test clear_model_overrides function."""
+
+    def test_clears_all_overrides(self):
+        """clear_model_overrides clears all overrides from the registry."""
+        register_model_override(
+            ModelCapability(model_id="model-1", supports_reasoning=True)
+        )
+        register_model_override(
+            ModelCapability(model_id="model-2", supports_reasoning=False)
+        )
+
+        assert len(_MODEL_OVERRIDES) == 2
+
+        clear_model_overrides()
+
+        assert len(_MODEL_OVERRIDES) == 0
+
+    def test_clear_does_not_affect_provider_registry(self):
+        """Clearing model overrides should not affect provider registry."""
+        # Built-in providers should still be registered after clearing model overrides
+        for provider in (PROVIDER_OPENAI, PROVIDER_ANTHROPIC, PROVIDER_MISTRAL):
+            cap = get_provider_capability(provider)
+            assert isinstance(cap, ProviderCapability)
+
+        # Also test a registered test provider
+        def register_test_provider(cap, provider_name):
+            _REGISTRY[provider_name] = cap
+
+        test_cap = ProviderCapability(supported=True, reasoning_kwarg="test")
+        register_test_provider(test_cap, "TestProvider")
+        assert get_provider_capability("TestProvider").supported is True
+
+        clear_model_overrides()
+
+        # Provider registry untouched
+        assert get_provider_capability("TestProvider").supported is True
+
+
+# ========================================================================
+# 43-46. Edge cases
+# ========================================================================
+
+
+@pytest.mark.parametrize("empty_value", [
+    ("", ""),       # empty provider + empty model_id
+    ("", "model"),  # empty provider
+    ("OpenAI", ""),  # empty model_id
+])
+def test_for_model_empty_strings(empty_value):
+    """ModelCapability.for_model with empty provider or model_id string."""
+    provider, model_id = empty_value
+    cap = ModelCapability.for_model(provider, model_id)
+    # Should return the base sentinel — no overrides for empty strings
+    assert cap is not None
+    assert isinstance(cap, ModelCapability)
+    assert cap.supports_reasoning is None
+    assert cap.disable_temperature is False
+
+
+def test_model_capability_empty_provider():
+    """for_model with empty provider returns empty sentinel regardless of model."""
+    cap = ModelCapability.for_model("", "o1")
+    assert cap.regex_pattern == ""
+    assert cap.model_id == ""
+
+
+def test_model_capability_empty_model_id():
+    """for_model with empty model_id returns empty sentinel."""
+    cap = ModelCapability.for_model(PROVIDER_OPENAI, "")
+    assert cap.regex_pattern == ""
+    assert cap.model_id == ""
+
+
+def test_fast_profile_boundary():
+    """Profile values at boundary (FAST level) — lowest reasoning effort."""
+    rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-4o", ExecutionProfile.FAST)
+    assert rc.reasoning_value is not None
+    assert rc.execution_profile == ExecutionProfile.FAST
+    # FAST is the minimum profile — should have the smallest/intensity value
+    assert rc.reasoning_value == "low"
+
+    rc_anthropic = RuntimeConfigBuilder.build(
+        PROVIDER_ANTHROPIC, "claude-sonnet-4", ExecutionProfile.FAST
+    )
+    assert rc_anthropic.reasoning_value == 1024
+
+
+def test_max_profile_boundary():
+    """Profile values at boundary (MAX level) — highest reasoning effort."""
+    rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-4o", ExecutionProfile.MAX)
+    assert rc.reasoning_value is not None
+    assert rc.execution_profile == ExecutionProfile.MAX
+    # MAX should be the highest intensity value
+    assert rc.reasoning_value == "high"
+
+    rc_anthropic = RuntimeConfigBuilder.build(
+        PROVIDER_ANTHROPIC, "claude-sonnet-4", ExecutionProfile.MAX
+    )
+    assert rc_anthropic.reasoning_value == 125000
+
+
+def test_runtime_config_frozen():
+    """RuntimeConfig is a frozen dataclass — immutable."""
+    rc = RuntimeConfig(
+        provider=PROVIDER_OPENAI,
+        model_id="gpt-4o",
+        execution_profile=ExecutionProfile.FAST,
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        rc.provider = "new-provider"  # type: ignore[assignment]
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        rc.model_id = "new-model"  # type: ignore[assignment]
+
+
+def test_provider_capability_frozen():
+    """ProviderCapability is a frozen dataclass."""
+    cap = ProviderCapability(supported=True, reasoning_kwarg="test")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cap.reasoning_kwarg = "new"  # type: ignore[misc]
+
+
+def test_model_capability_frozen():
+    """ModelCapability is a frozen dataclass."""
+    cap = ModelCapability(supports_reasoning=True)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cap.supports_vision = True  # type: ignore[misc]
+
+
+def test_build_runtime_kwargs_empty_config():
+    """build_runtime_kwargs with a minimal RuntimeConfig produces empty dict."""
+    rc = RuntimeConfig(
+        provider="Unknown",
+        model_id="unknown",
+        execution_profile=ExecutionProfile.FAST,
+    )
+    kwargs = build_runtime_kwargs(rc)
+    assert kwargs == {}
+
+    kwargs_with_temp = build_runtime_kwargs(rc, temperature=0.5)
+    assert kwargs_with_temp == {"temperature": 0.5}
+
+
+def test_runtime_config_profile_values_inheritance():
+    """RuntimeConfig should carry the effective profile_values."""
+    # Without model override — should use provider defaults
+    rc = RuntimeConfigBuilder.build(
+        PROVIDER_OPENAI, "gpt-4o", ExecutionProfile.BALANCED
+    )
+    assert ExecutionProfile.FAST in rc.profile_values
+    assert ExecutionProfile.MAX in rc.profile_values
+    assert rc.profile_values[ExecutionProfile.FAST] == "low"
+    assert rc.profile_values[ExecutionProfile.MAX] == "high"
+
+
+@pytest.mark.parametrize("profile", list(ExecutionProfile))
+def test_all_profiles_produce_reasoning_value_when_supported(profile):
+    """Every supported profile should produce a reasoning value for reasoning-capable providers."""
+    rc = RuntimeConfigBuilder.build(PROVIDER_OPENAI, "gpt-4o", profile)
+    assert rc.reasoning_kwarg is not None
+    assert rc.reasoning_value is not None
+
+
+@pytest.mark.parametrize("profile", list(ExecutionProfile))
+def test_all_profiles_produce_no_reasoning_when_not_supported(profile):
+    """Every profile should have no reasoning value for non-reasoning providers."""
+    rc = RuntimeConfigBuilder.build(PROVIDER_MISTRAL, "mistral-large", profile)
+    assert rc.reasoning_kwarg is None
+    assert rc.reasoning_value is None
+    assert rc.supports_reasoning is False


### PR DESCRIPTION
## Description

Adds configurable execution profiles for AI services and agents: FAST, BALANCED, DEEP, and MAX.

Profiles are resolved in this order:

1. Per-request override
2. Agent-level override
3. AI service default
4. Provider default

The selected profile is translated into provider-specific runtime parameters such as reasoning effort, thinking budgets, token limits, and temperature constraints. The feature is available in agent playground and marketplace chat flows for both streaming and non-streaming requests.

The implementation also preserves provider compatibility for Bedrock, OpenAI, Anthropic, Mistral, Google, Azure, OpenRouter, and custom/Ollama services.

## Related Issue(s)

No related issue was created. This PR contains the execution-profile feature implementation and its supporting fixes.

## Type of Change

* [ ] Bug fix
* [x] Feature
* [ ] Documentation
* [ ] Refactor
* [ ] Performance improvement
* [x] Test
* [ ] Build or infrastructure

## Dependencies Added

None. No new Python or frontend dependencies were added.

## Affected Components

Both backend and frontend.

Backend:
- Execution-profile registry and provider capability resolution
- AIService and Agent models
- Agent execution and streaming services
- Internal AI service, agent, and marketplace APIs
- Agent export/import handling
- Alembic migration
- Unit tests

Frontend:
- Agent playground profile selector
- Marketplace chat profile selector
- Streaming and non-streaming API request propagation

## Implementation Details

- Added the `ExecutionProfile` enum:
  - `FAST = 0`
  - `BALANCED = 1`
  - `DEEP = 2`
  - `MAX = 3`
- Added `AIService.execution_profile` with Balanced as the default.
- Added nullable `Agent.execution_profile`; `None` inherits the AI service profile.
- Added migration `execprof001_add_execution_profiles`.
- Added provider-agnostic runtime configuration through `backend/tools/execution_profiles.py`.
- Added model-specific overrides, including:
  - OpenAI reasoning models
  - GPT-4.1 temperature and reasoning constraints
  - Google Gemini token budgets
  - Mistral and Anthropic reasoning settings
- Added per-request profile overrides for regular, streaming, and marketplace chats.
- Added frontend controls for selecting profiles or inheriting the configured default.
- Added validation for profile values from `0` through `3`.
- Invalid marketplace profile values return `400`.
- Preserved Bedrock provider dispatch and runtime configuration.
- Removed logging of provider API credentials.
- Preserved execution profiles during agent export/import.

No new environment variables are required.

## How to Test

1. Open an agent playground.
2. Select FAST, BALANCED, DEEP, or MAX.
3. Send both streaming and non-streaming messages.
4. Confirm the selected profile is sent as `override_execution_profile`.
5. Open a marketplace conversation.
6. Verify explicit profiles and the `inherit` option.
7. Confirm inherited requests omit the override field.

## Checklist

* [ ] Commit messages follow Conventional Commits (`type(scope): description`).
* [x] I have read the contributing guidelines and my change adheres to the coding standards of this project (see `docs/README.md#contributing`).
* [x] I have added tests that prove my fix or feature works, or confirm that tests are not needed for this change.
* [ ] I have run all existing tests and they all pass locally.
* [x] I have updated any relevant documentation, configuration files, or environment examples as needed.
* [x] I have considered backwards compatibility and ensured that my change does not break existing functionality.
* [ ] For UI changes, I have included relevant screenshots or screencasts.

## Additional Notes

The migration reports execprof001 as the current Alembic head.

The focused pytest suite could not be executed in the current environment because Poetry and pytest are unavailable. Frontend lint, backend syntax compilation, migration-head validation, and diff hygiene checks completed successfully.

No breaking API changes are intended. Existing clients may omit [override_execution_profile] and continue using configured agent or AI service defaults.