### PR TITLE
feat(frontend): add chat response timers

### DIFF
--- a/frontend/src/components/playground/ChatInterface.tsx
+++ b/frontend/src/components/playground/ChatInterface.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { Timer } from 'lucide-react';
 import { apiService } from '../../services/api';
-import { useStreamingChat } from '../../hooks/useStreamingChat';
+import { StreamingChatError, useStreamingChat } from '../../hooks/useStreamingChat';
+import { formatDuration } from '../../utils/duration';
 import MessageContent from './MessageContent';
 import StreamingMessage from './StreamingMessage';
 import SearchFilters from './SearchFilters';
@@ -15,6 +17,7 @@ interface Message {
   content: string;
   timestamp: Date;
   files?: string[];
+  elapsedMs?: number;
 }
 
 /** Shape returned by the API for each history message. */
@@ -89,7 +92,7 @@ function ChatInterface({
     [appId, agentId],
   );
 
-  const { streamingContent, activeTools, thinkingMessage, isStreaming, sendMessage, abortStream, toolExecutionHistory, clearToolHistory } =
+  const { streamingContent, activeTools, thinkingMessage, isStreaming, responseElapsedMs, sendMessage, abortStream, toolExecutionHistory, clearToolHistory } =
     useStreamingChat(playgroundStream);
 
   // Hold streaming content visible briefly after isStreaming flips to false,
@@ -280,6 +283,7 @@ function ChatInterface({
         type: 'agent',
         content: responseContent,
         timestamp: new Date(),
+        elapsedMs: result.elapsedMs,
       };
       // Commit the message and release the streaming hold in the same batch
       setMessages((prev) => [...prev, agentMsg]);
@@ -299,6 +303,7 @@ function ChatInterface({
         type: 'error',
         content: error instanceof Error ? error.message : 'An error occurred',
         timestamp: new Date(),
+        elapsedMs: error instanceof StreamingChatError ? error.elapsedMs : responseElapsedMs,
       };
       setMessages((prev) => [...prev, errorMsg]);
     }
@@ -674,6 +679,12 @@ function ChatInterface({
                                 minute: '2-digit',
                               })}
                             </span>
+                            {message.elapsedMs !== undefined && (
+                              <span className="ml-2 inline-flex items-center gap-1 text-xs tabular-nums text-gray-400 dark:text-gray-500">
+                                <Timer className="h-3 w-3" aria-hidden="true" />
+                                {formatDuration(message.elapsedMs)}
+                              </span>
+                            )}
                           </div>
                         </div>
                       </div>
@@ -701,6 +712,12 @@ function ChatInterface({
                               minute: '2-digit',
                             })}
                           </span>
+                          {message.elapsedMs !== undefined && (
+                            <span className="ml-2 inline-flex items-center gap-1 text-xs tabular-nums text-gray-400 dark:text-gray-500">
+                              <Timer className="h-3 w-3" aria-hidden="true" />
+                              {formatDuration(message.elapsedMs)}
+                            </span>
+                          )}
                         </div>
                       </div>
                     </div>
@@ -714,6 +731,7 @@ function ChatInterface({
                   <StreamingMessage
                     content={streamingContent}
                     isStreaming={isStreaming}
+                    elapsedMs={responseElapsedMs}
                     activeTools={activeTools}
                     thinkingMessage={thinkingMessage}
                   />

--- a/frontend/src/components/playground/StreamingMessage.tsx
+++ b/frontend/src/components/playground/StreamingMessage.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { Timer } from 'lucide-react';
 import type { ActiveTool } from '../../types/streaming';
+import { formatDuration } from '../../utils/duration';
 import ActiveToolBar from './ActiveToolBar';
 import MessageContent from './MessageContent';
 
@@ -8,6 +10,8 @@ interface StreamingMessageProps {
   content: string;
   /** Whether tokens are still arriving */
   isStreaming: boolean;
+  /** Client-side wall-clock time since the current response started */
+  elapsedMs?: number;
   /** Active tools (shown as status pills) — rendered ABOVE the message */
   activeTools?: ActiveTool[];
   /** Human-readable thinking status */
@@ -17,6 +21,7 @@ interface StreamingMessageProps {
 const StreamingMessage: React.FC<StreamingMessageProps> = ({
   content,
   isStreaming,
+  elapsedMs,
   activeTools = [],
   thinkingMessage,
 }) => {
@@ -50,6 +55,16 @@ const StreamingMessage: React.FC<StreamingMessageProps> = ({
                 </span>
               </div>
             )}
+          </div>
+        )}
+
+        {isStreaming && elapsedMs !== undefined && (
+          <div
+            className="mt-1 ml-1 flex items-center gap-1.5 text-xs tabular-nums text-gray-400 dark:text-gray-500"
+            aria-live="polite"
+          >
+            <Timer className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>Generating for {formatDuration(elapsedMs)}</span>
           </div>
         )}
 

--- a/frontend/src/components/playground/ToolHistoryPanel.tsx
+++ b/frontend/src/components/playground/ToolHistoryPanel.tsx
@@ -1,15 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { Activity, ChevronRight, ChevronLeft, ChevronDown, Terminal, Trash2, Wrench } from 'lucide-react';
 import type { ToolExecutionRecord } from '../../hooks/useStreamingChat';
+import { formatDuration } from '../../utils/duration';
 
 function isCodeTool(toolName: string): boolean {
   return toolName === 'code_interpreter' || toolName.endsWith('_repl');
-}
-
-function formatDuration(startedAt: number, endedAt?: number): string {
-  const ms = (endedAt ?? Date.now()) - startedAt;
-  if (ms < 1000) return `${ms}ms`;
-  return `${(ms / 1000).toFixed(1)}s`;
 }
 
 /** Try to pretty-print a JSON string; return raw string if it's not valid JSON. */
@@ -166,7 +161,9 @@ function ToolEntryRow({
           </span>
         ) : (
           <span className="text-[10px] text-neutral-400 shrink-0 tabular-nums">
-            {formatDuration(record.startedAt, record.endedAt)}
+            {formatDuration((record.endedAt ?? Date.now()) - record.startedAt, {
+              showMillisecondsBelowSecond: true,
+            })}
           </span>
         )}
         {canExpand && (

--- a/frontend/src/hooks/useStreamingChat.ts
+++ b/frontend/src/hooks/useStreamingChat.ts
@@ -40,6 +40,17 @@ interface StreamResult {
   response: string | Record<string, unknown>;
   conversationId: number | null;
   files: Array<{ file_id: string; filename: string; file_type: string }>;
+  elapsedMs: number;
+}
+
+export class StreamingChatError extends Error {
+  readonly elapsedMs: number;
+
+  constructor(message: string, elapsedMs: number) {
+    super(message);
+    this.name = 'StreamingChatError';
+    this.elapsedMs = elapsedMs;
+  }
 }
 
 export interface StreamFnOptions {
@@ -63,6 +74,7 @@ interface UseStreamingChatReturn {
   readonly activeTools: ActiveTool[];
   readonly thinkingMessage: string | null;
   readonly isStreaming: boolean;
+  readonly responseElapsedMs: number;
   readonly streamError: string | null;
   readonly codeOutputLines: string[];
   readonly isCodeRunning: boolean;
@@ -159,6 +171,7 @@ export function useStreamingChat(streamFn: StreamFn): UseStreamingChatReturn {
   const [activeTools, setActiveTools] = useState<ActiveTool[]>([]);
   const [thinkingMessage, setThinkingMessage] = useState<string | null>(null);
   const [isStreaming, setIsStreaming] = useState(false);
+  const [responseElapsedMs, setResponseElapsedMs] = useState(0);
   const [streamError, setStreamError] = useState<string | null>(null);
   const [codeOutputLines, setCodeOutputLines] = useState<string[]>([]);
   const [isCodeRunning, setIsCodeRunning] = useState(false);
@@ -175,6 +188,22 @@ export function useStreamingChat(streamFn: StreamFn): UseStreamingChatReturn {
   const contentRef = useRef('');
   const flushRequestedRef = useRef(false);
   const rafIdRef = useRef<number | null>(null);
+  const streamStartedAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isStreaming || streamStartedAtRef.current === null) return;
+
+    const updateElapsedTime = () => {
+      const startedAt = streamStartedAtRef.current;
+      if (startedAt !== null) {
+        setResponseElapsedMs(Math.max(0, Math.round(performance.now() - startedAt)));
+      }
+    };
+
+    updateElapsedTime();
+    const intervalId = window.setInterval(updateElapsedTime, 100);
+    return () => window.clearInterval(intervalId);
+  }, [isStreaming]);
 
   const abortStream = useCallback(() => {
     if (abortControllerRef.current) {
@@ -189,6 +218,8 @@ export function useStreamingChat(streamFn: StreamFn): UseStreamingChatReturn {
       setActiveTools([]);
       setThinkingMessage(getStreamingMessage('thinking'));
       setIsStreaming(true);
+      streamStartedAtRef.current = performance.now();
+      setResponseElapsedMs(0);
       setStreamError(null);
       setCodeOutputLines([]);
       setIsCodeRunning(false);
@@ -213,6 +244,12 @@ export function useStreamingChat(streamFn: StreamFn): UseStreamingChatReturn {
       let conversationId: number | null = options?.conversationId ?? null;
       let finalResponse: string | Record<string, unknown> = '';
       let finalFiles: Array<{ file_id: string; filename: string; file_type: string }> = [];
+      let elapsedMs = 0;
+
+      const getElapsedMs = (): number => {
+        const startedAt = streamStartedAtRef.current;
+        return startedAt === null ? 0 : Math.max(0, Math.round(performance.now() - startedAt));
+      };
 
       try {
         await streamFnRef.current(message, {
@@ -401,9 +438,12 @@ export function useStreamingChat(streamFn: StreamFn): UseStreamingChatReturn {
         } else {
           const errMsg = err instanceof Error ? err.message : 'Streaming failed';
           setStreamError(errMsg);
-          throw err;
+          throw new StreamingChatError(errMsg, getElapsedMs());
         }
       } finally {
+        elapsedMs = getElapsedMs();
+        setResponseElapsedMs(elapsedMs);
+        streamStartedAtRef.current = null;
         if (rafIdRef.current) {
           cancelAnimationFrame(rafIdRef.current);
           rafIdRef.current = null;
@@ -424,6 +464,7 @@ export function useStreamingChat(streamFn: StreamFn): UseStreamingChatReturn {
         response: finalResponse || contentRef.current,
         conversationId,
         files: finalFiles,
+        elapsedMs,
       };
     },
     [],
@@ -434,6 +475,7 @@ export function useStreamingChat(streamFn: StreamFn): UseStreamingChatReturn {
     activeTools,
     thinkingMessage,
     isStreaming,
+    responseElapsedMs,
     streamError,
     codeOutputLines,
     isCodeRunning,

--- a/frontend/src/pages/MarketplaceChatPage.tsx
+++ b/frontend/src/pages/MarketplaceChatPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
-import { ArrowLeft, Bot, MessageCircle, Paperclip, Plus, Square } from 'lucide-react';
+import { ArrowLeft, Bot, MessageCircle, Paperclip, Plus, Square, Timer } from 'lucide-react';
 import { toast } from 'sonner';
 import { apiService } from '../services/api';
 import MessageContent from '../components/playground/MessageContent';
@@ -9,7 +9,8 @@ import AttachedFilesPanel from '../components/playground/AttachedFilesPanel';
 import type { PanelFile } from '../components/playground/AttachedFilesPanel';
 import { LoadingState } from '../components/ui/LoadingState';
 import { ErrorState } from '../components/ui/ErrorState';
-import { useStreamingChat, type StreamFnOptions } from '../hooks/useStreamingChat';
+import { StreamingChatError, useStreamingChat, type StreamFnOptions } from '../hooks/useStreamingChat';
+import { formatDuration } from '../utils/duration';
 import { errorMessage } from '../constants/messages';
 
 interface ChatMessage {
@@ -17,6 +18,7 @@ interface ChatMessage {
   readonly type: 'user' | 'agent' | 'error';
   readonly content: string;
   readonly timestamp: Date;
+  readonly elapsedMs?: number;
 }
 
 interface RawAttachedFile {
@@ -85,7 +87,7 @@ export default function MarketplaceChatPage() {
     [numericId, persistentFiles],
   );
 
-  const { streamingContent, activeTools, thinkingMessage, isStreaming, sendMessage, abortStream } =
+  const { streamingContent, activeTools, thinkingMessage, isStreaming, responseElapsedMs, sendMessage, abortStream } =
     useStreamingChat(marketplaceStream);
 
   const [holdStreamingContent, setHoldStreamingContent] = useState(false);
@@ -299,6 +301,7 @@ export default function MarketplaceChatPage() {
           type: 'agent',
           content: responseContent,
           timestamp: new Date(),
+          elapsedMs: result.elapsedMs,
         },
       ]);
       setHoldStreamingContent(false);
@@ -322,6 +325,7 @@ export default function MarketplaceChatPage() {
           type: 'error',
           content,
           timestamp: new Date(),
+          elapsedMs: err instanceof StreamingChatError ? err.elapsedMs : responseElapsedMs,
         },
       ]);
       void fetchQuotaInfo();
@@ -610,6 +614,12 @@ export default function MarketplaceChatPage() {
                         minute: '2-digit',
                       })}
                     </span>
+                    {message.elapsedMs !== undefined && (
+                      <span className="ml-2 inline-flex items-center gap-1 text-xs tabular-nums text-gray-400 dark:text-gray-500">
+                        <Timer className="h-3 w-3" aria-hidden="true" />
+                        {formatDuration(message.elapsedMs)}
+                      </span>
+                    )}
                   </div>
                 </div>
               </div>
@@ -620,6 +630,7 @@ export default function MarketplaceChatPage() {
             <StreamingMessage
               content={streamingContent}
               isStreaming={isStreaming}
+              elapsedMs={responseElapsedMs}
               activeTools={activeTools}
               thinkingMessage={thinkingMessage}
             />

--- a/frontend/src/utils/duration.ts
+++ b/frontend/src/utils/duration.ts
@@ -1,0 +1,16 @@
+interface FormatDurationOptions {
+  readonly showMillisecondsBelowSecond?: boolean;
+}
+
+export function formatDuration(
+  milliseconds: number,
+  { showMillisecondsBelowSecond = false }: FormatDurationOptions = {},
+): string {
+  const safeMilliseconds = Math.max(0, Math.round(milliseconds));
+
+  if (showMillisecondsBelowSecond && safeMilliseconds < 1000) {
+    return `${safeMilliseconds}ms`;
+  }
+
+  return `${(safeMilliseconds / 1000).toFixed(1)}s`;
+}


### PR DESCRIPTION
﻿## Summary

- add a live client-side response timer to Agent Playground and Marketplace chat
- retain the final elapsed duration on new assistant and error messages
- reuse a shared duration formatter for response and tool timings

## Validation

- `npm run lint`
- `npm run build:lib`
- manual verification of streaming, tool use, error, stop, and reset behavior

Closes #189
