### PR TITLE
fix(backend): silo score-threshold filtering broken on public API

### DIFF
--- a/backend/routers/public/v1/repositories.py
+++ b/backend/routers/public/v1/repositories.py
@@ -9,7 +9,6 @@ from .schemas import (
     RepositorySchema,
     CreateRepositoryRequestSchema,
     UpdateRepositoryRequestSchema,
-    SiloSearchSchema,
     DocsResponseSchema,
     MediaSchema,
     MediaListResponseSchema,
@@ -18,6 +17,7 @@ from .schemas import (
     YouTubeRequestSchema,
     MessageResponseSchema,
 )
+from schemas.silo_schemas import SiloSearchSchema
 from .auth import (
     get_api_key_auth,
     validate_api_key_for_app,
@@ -226,6 +226,12 @@ async def find_docs_in_repository(
             query=query,
             filter_metadata=request.filter_metadata,
             limit=request.limit,
+            search_type=request.search_type,
+            score_threshold=request.score_threshold,
+            fetch_k=request.fetch_k,
+            lambda_mult=request.lambda_mult,
+            min_content_length=request.min_content_length,
+            max_content_length=request.max_content_length,
             db=db,
         )
 

--- a/backend/routers/public/v1/schemas.py
+++ b/backend/routers/public/v1/schemas.py
@@ -162,12 +162,6 @@ class MultipleDocumentIndexSchema(BaseModel):
     """Schema for indexing multiple documents"""
     documents: List[Dict[str, Any]]
 
-class SiloSearchSchema(BaseModel):
-    """Schema for searching in a silo"""
-    query: str
-    limit: Optional[int] = None
-    filter_metadata: Optional[Dict[str, Any]] = None
-
 class DeleteDocsRequestSchema(BaseModel):
     """Schema for deleting documents"""
     ids: List[str]

--- a/backend/routers/public/v1/silos.py
+++ b/backend/routers/public/v1/silos.py
@@ -257,15 +257,17 @@ async def search_silo(
 
     try:
         result = SiloService.search_silo_documents_router(
-            silo_id,
-            request.query,
-            request.filter_metadata,
-            request.limit,
-            request.search_type,
-            request.score_threshold,
-            request.fetch_k,
-            request.lambda_mult,
-            db,
+            silo_id=silo_id,
+            query=request.query,
+            filter_metadata=request.filter_metadata,
+            limit=request.limit,
+            search_type=request.search_type,
+            score_threshold=request.score_threshold,
+            fetch_k=request.fetch_k,
+            lambda_mult=request.lambda_mult,
+            min_content_length=request.min_content_length,
+            max_content_length=request.max_content_length,
+            db=db,
         )
 
         if result is None:
@@ -520,6 +522,12 @@ async def find_docs_in_collection(
             query=query,
             filter_metadata=request.filter_metadata,
             limit=request.limit,
+            search_type=request.search_type,
+            score_threshold=request.score_threshold,
+            fetch_k=request.fetch_k,
+            lambda_mult=request.lambda_mult,
+            min_content_length=request.min_content_length,
+            max_content_length=request.max_content_length,
             db=db,
         )
 

--- a/tests/integration/routers/public/test_repositories.py
+++ b/tests/integration/routers/public/test_repositories.py
@@ -308,6 +308,32 @@ class TestFindDocs:
             assert len(data["docs"]) == 1
             assert data["docs"][0]["page_content"] == "Test content"
 
+    def test_find_docs_forwards_search_type_and_score_threshold(
+        self, client, fake_app, fake_repository, fake_api_key, db
+    ):
+        """Regression test for issue #217: this route imported a stale local
+        SiloSearchSchema without search_type/score_threshold fields at all,
+        and even after fixing that, never forwarded them to the service
+        call."""
+        with patch(
+            "routers.public.v1.repositories.SiloService.find_docs_in_collection",
+            return_value=[],
+        ) as mock_find:
+            resp = client.post(
+                repos_url(fake_app.app_id, fake_repository.repository_id, "/docs/find"),
+                json={
+                    "query": "test query",
+                    "search_type": "similarity_score_threshold",
+                    "score_threshold": 0.7,
+                },
+                headers=api_headers(fake_api_key.key),
+            )
+            assert resp.status_code == 200
+
+            _, kwargs = mock_find.call_args
+            assert kwargs["search_type"] == "similarity_score_threshold"
+            assert kwargs["score_threshold"] == 0.7
+
     def test_find_docs_repo_not_found_returns_404(
         self, client, fake_app, fake_api_key, db
     ):

--- a/tests/integration/routers/public/test_silos.py
+++ b/tests/integration/routers/public/test_silos.py
@@ -303,6 +303,43 @@ class TestSearchSilo:
         )
         assert resp.status_code == 404
 
+    @patch("routers.public.v1.silos.SiloService.find_docs_in_collection")
+    def test_search_forwards_real_db_session_and_score_threshold(
+        self, mock_find, client, fake_app, fake_silo, fake_api_key, db
+    ):
+        """Regression test for issue #217: the public /search route previously
+        called search_silo_documents_router with the wrong number of
+        positional args, which bound its `db` session to `min_content_length`
+        instead — leaving the real `db` param `None` and crashing with
+        'NoneType' object has no attribute 'query'. Only mocking the deepest
+        service call here (not search_silo_documents_router itself) exercises
+        the real argument binding end to end.
+        """
+        mock_doc = MagicMock()
+        mock_doc.page_content = "Test content"
+        mock_doc.metadata = {"source": "test", "_score": 0.87}
+
+        mock_find.return_value = [mock_doc]
+
+        resp = client.post(
+            silos_url(fake_app.app_id, fake_silo.silo_id, "search"),
+            json={
+                "query": "test query",
+                "search_type": "similarity_score_threshold",
+                "score_threshold": 0.5,
+            },
+            headers=api_headers(fake_api_key.key),
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_results"] == 1
+        assert data["results"][0]["score"] == 0.87
+
+        _, kwargs = mock_find.call_args
+        assert kwargs["search_type"] == "similarity_score_threshold"
+        assert kwargs["score_threshold"] == 0.5
+
 
 # ---------------------------------------------------------------------------
 # Document operations
@@ -373,6 +410,30 @@ class TestDocOperations:
         assert resp.status_code == 200
         assert len(resp.json()["docs"]) == 1
         assert resp.json()["docs"][0]["page_content"] == "Found content"
+
+    @patch("routers.public.v1.silos.SiloService.find_docs_in_collection")
+    def test_find_docs_forwards_search_type_and_score_threshold(
+        self, mock_find, client, fake_app, fake_silo, fake_api_key, db
+    ):
+        """Regression test for issue #217: docs/find accepted search_type and
+        score_threshold in the request body but never passed them through to
+        the service call, so filtering was silently ignored."""
+        mock_find.return_value = []
+
+        resp = client.post(
+            silos_url(fake_app.app_id, fake_silo.silo_id, "docs/find"),
+            json={
+                "query": "test search",
+                "search_type": "similarity_score_threshold",
+                "score_threshold": 0.9,
+            },
+            headers=api_headers(fake_api_key.key),
+        )
+        assert resp.status_code == 200
+
+        _, kwargs = mock_find.call_args
+        assert kwargs["search_type"] == "similarity_score_threshold"
+        assert kwargs["score_threshold"] == 0.9
 
     @patch("routers.public.v1.silos.SiloService.delete_docs_in_collection")
     def test_delete_docs(


### PR DESCRIPTION
## Summary
- `POST /public/v1/app/{app_id}/silos/{silo_id}/search` returned `400 Bad Request` on every request. The router passed 9 positional args to `SiloService.search_silo_documents_router`, which now takes 11 params (`min_content_length`/`max_content_length` were added later) — so the router's `db` session silently bound to `min_content_length` while the real `db` param defaulted to `None`, crashing with `'NoneType' object has no attribute 'query'`. Converted the call to keyword arguments and forwarded all fields.
- `POST /public/v1/app/{app_id}/silos/{silo_id}/docs/find` (and the equivalent repository endpoint) accepted `search_type`/`score_threshold` but never forwarded them to `SiloService.find_docs_in_collection`, so relevance filtering was silently ignored regardless of the threshold sent.
- `routers/public/v1/repositories.py` additionally imported a **stale duplicate** `SiloSearchSchema` (a local copy with only `query`/`limit`/`filter_metadata`) instead of the real schema in `schemas/silo_schemas.py`, so `search_type`/`score_threshold` weren't even reachable on that route. Fixed the import and removed the dead duplicate class.

No schema, service, or vector-store changes were needed — those layers already supported threshold filtering correctly; this was purely a router call-site wiring bug.

## Test plan
- [x] Added `test_search_forwards_real_db_session_and_score_threshold` (exercises real `search_silo_documents_router` argument binding instead of mocking it away — reproduces the `db`/`min_content_length` mismatch)
- [x] Added `test_find_docs_forwards_search_type_and_score_threshold` for both silos and repositories `docs/find` endpoints
- [x] Verified all 3 new tests fail against pre-fix code and pass post-fix (`git stash` toggle)
- [x] Full public silo/repository integration suite passes (46/46)
- [x] Full integration + unit suites run — no new regressions (pre-existing unrelated failures confirmed identical on a clean `develop` checkout)
- [x] Manually reproduced the issue's exact repro steps against a local Docker stack and confirmed `/search` now returns `200` and `/docs/find` results change with `score_threshold`

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)