### PR TITLE
fix(sandbox): resolve 3 critical post-merge bugs (500s, cross-user sandbox sharing, checkpoint data loss)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,18 @@ docker compose down -v           # Parar y borrar volúmenes
 - Acceso: `http://localhost/` en local, `http://<ip-servidor>/` en cliente.
 - Swagger: `/docs/internal` y `/docs/public` desde el mismo origen.
 - Utilities aisladas (p. ej. Qdrant + web UI): `docker/utilities/`.
+- **Sandbox / Code Interpreter**: el servicio `opensandbox` (monta el socket de Docker,
+  así que está deshabilitado por defecto) NO arranca con el `docker compose up -d` de
+  arriba — está detrás de un profile, igual que `db_test`. Para habilitar el code
+  interpreter de los agentes:
+  ```bash
+  docker compose --profile opensandbox up -d --build
+  ```
+  `SANDBOX_DEFAULT_PROVIDER=opensandbox` viene activo por defecto en `.env.example`
+  aunque no se use este profile; sin el profile, cualquier agente con
+  `enable_code_interpreter=true` degrada el code interpreter para ese turno en vez de
+  fallar (no hace falta desactivar el provider por defecto si no vas a usar el
+  sandbox).
 
 ### Client Project Management
 

--- a/backend/services/agent_cache_service.py
+++ b/backend/services/agent_cache_service.py
@@ -8,9 +8,27 @@ import os
 logger = logging.getLogger(__name__)
 
 
+# Providers reject a checkpoint with a dangling tool_calls entry (an
+# AIMessage whose tool call never got a matching ToolMessage — e.g. the
+# backend crashed mid-tool-execution) with different wording depending on
+# the exact API surface hit. Live-reproduced against OpenAI (gpt-4o-mini,
+# chat completions): killing the backend mid-tool-call and resuming the
+# conversation raises "An assistant message with 'tool_calls' must be
+# followed by tool messages responding to each 'tool_call_id'. The
+# following tool_call_ids did not have response messages: ..." — not the
+# "No tool output found for function call" phrasing this used to match
+# exclusively, which meant the recovery path below never triggered for
+# this (the common) case.
+_MISSING_TOOL_OUTPUT_MARKERS = (
+    "No tool output found for function call",
+    "did not have response messages",
+)
+
+
 def is_missing_tool_output_error(exc: BaseException) -> bool:
     """Return True when a provider rejects a stale incomplete tool-call checkpoint."""
-    return "No tool output found for function call" in str(exc)
+    text = str(exc)
+    return any(marker in text for marker in _MISSING_TOOL_OUTPUT_MARKERS)
 
 
 def _content_blocks_to_str(blocks: list) -> str:
@@ -152,6 +170,112 @@ class CheckpointerCacheService:
             logger.info(f"Deleted checkpoints for thread {thread_id} (agent {agent_id}, session {session_id})")
         except Exception as e:
             logger.error(f"Error invalidating checkpointer: {str(e)}")
+
+    @classmethod
+    async def get_rollback_checkpoint_id(
+        cls, agent_id: int, session_id: str, *, max_lookback: int = 25
+    ) -> str | None:
+        """
+        Walk back through a thread's checkpoint history and return the
+        checkpoint_id of the most recent checkpoint that is actually safe
+        to resume from — i.e. its message list does not end in an
+        AIMessage with unresolved ``tool_calls``.
+
+        Used to recover from a stale/incomplete tool-call checkpoint (the
+        provider rejects a dangling ``tool_calls`` entry, e.g. "No tool
+        output found for function call" or "... did not have response
+        messages: ...") without data loss: LangGraph checkpoints are
+        immutable and ordered, so retrying the turn with an earlier
+        checkpoint_id set in the config forks the thread from that
+        known-good state — new checkpoints get written after it, the
+        broken ones are simply never read again, and no earlier
+        conversation history is touched (unlike
+        ``invalidate_checkpointer_async``, which deletes the entire
+        thread and is only appropriate for an explicit user-initiated
+        conversation reset).
+
+        Naively taking "the one checkpoint before the latest" is NOT
+        sufficient and was live-reproduced to fail: LangGraph can write
+        more than one checkpoint while the dangling tool_calls message is
+        still the last one in the state (e.g. one when the model node
+        adds it, another when the tools node begins execution before
+        being interrupted), so the immediate predecessor can carry the
+        exact same broken state as the checkpoint that just failed. This
+        walks back past every checkpoint still carrying that pending
+        tool call, not just one.
+
+        Args:
+            agent_id: Agent ID
+            session_id: Session ID (matches the thread_id used during execution)
+            max_lookback: Maximum number of checkpoints to inspect before
+                giving up (bounds the walk on a pathologically long thread).
+
+        Returns:
+            The checkpoint_id of the first clean checkpoint found, or None
+            if none exists within ``max_lookback`` (nothing safe to roll
+            back to).
+        """
+        try:
+            checkpointer = await cls.get_async_checkpointer()
+
+            thread_id = f"thread_{agent_id}_{session_id}"
+            config = {"configurable": {"thread_id": thread_id}}
+
+            seen_latest = False
+            async for checkpoint_tuple in checkpointer.alist(config, limit=max_lookback):
+                if not seen_latest:
+                    # The most recent checkpoint is the one that just failed
+                    # to replay — it's broken by definition, always skip it
+                    # without inspecting it.
+                    seen_latest = True
+                    continue
+                if cls._ends_with_pending_tool_call(checkpoint_tuple):
+                    continue
+                return checkpoint_tuple.config["configurable"]["checkpoint_id"]
+            return None
+        except Exception as e:
+            logger.error(
+                f"Error computing rollback checkpoint for agent {agent_id} "
+                f"session {session_id}: {str(e)}"
+            )
+            return None
+
+    @staticmethod
+    def _ends_with_pending_tool_call(checkpoint_tuple) -> bool:
+        """True when any AIMessage anywhere in a checkpoint's message list
+        has a tool_call whose id is never answered by a later ToolMessage
+        — i.e. this message list is NOT safe to hand back to the provider.
+
+        Checking only the *last* message is not enough: once a retry
+        appends a new HumanMessage on top of an already-broken state
+        (rather than fixing it), the list ends in a clean HumanMessage
+        while an unresolved AIMessage(tool_calls=...) still sits earlier
+        in the same list with nothing between it and the new message —
+        live-reproduced as exactly this shape, and OpenAI's chat
+        completions API validates the *entire* message list, not just the
+        tail, and rejects it identically.
+        """
+        messages = (checkpoint_tuple.checkpoint or {}).get("channel_values", {}).get(
+            "messages"
+        ) or []
+        for i, msg in enumerate(messages):
+            if getattr(msg, "type", None) != "ai":
+                continue
+            tool_calls = getattr(msg, "tool_calls", None)
+            if not tool_calls:
+                continue
+            pending_ids = {
+                tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+                for tc in tool_calls
+            }
+            answered_ids = {
+                getattr(later, "tool_call_id", None)
+                for later in messages[i + 1 :]
+                if getattr(later, "type", None) == "tool"
+            }
+            if not pending_ids <= answered_ids:
+                return True
+        return False
 
     @classmethod
     def invalidate_all(cls):

--- a/backend/services/agent_execution_service.py
+++ b/backend/services/agent_execution_service.py
@@ -541,12 +541,19 @@ class AgentExecutionService:
         # 9. Resolve working directory
         app_config = get_app_config()
         tmp_base = app_config['TMP_BASE_FOLDER']
+        # Caller identity used to scope both the local workspace and (below,
+        # step 11) the remote sandbox session when there's no conversation_id
+        # to key on (has_memory=False agents, public embeds, marketplace).
+        # Without this, every such caller for a given agent collapsed onto
+        # the same "anon_{agent_id}" sandbox session and shared one remote
+        # container/workspace across unrelated users.
+        user_id = user_context.get('user_id', 'anonymous') if user_context else 'anonymous'
+        app_id_ctx = user_context.get('app_id', 'default') if user_context else 'default'
+        identity_session_id = f"user_{user_id}_app_{app_id_ctx}"
         if effective_conv_id:
             working_dir = os.path.join(tmp_base, "conversations", str(effective_conv_id))
         else:
-            user_id = user_context.get('user_id', 'anonymous') if user_context else 'anonymous'
-            app_id_ctx = user_context.get('app_id', 'default') if user_context else 'default'
-            session_key = f"agent_{agent_id}_user_{user_id}_app_{app_id_ctx}"
+            session_key = f"agent_{agent_id}_{identity_session_id}"
             working_dir = os.path.join(tmp_base, "persistent", session_key)
 
         workspace_paths = _ensure_local_workspace_layout(working_dir)
@@ -611,7 +618,11 @@ class AgentExecutionService:
                 resolved_sandbox_service_id = None
 
             if resolved_sandbox_provider is not None:
-                sandbox_session_key = SandboxSessionService.session_key(agent_id, effective_conv_id)
+                sandbox_session_key = SandboxSessionService.session_key(
+                    agent_id,
+                    effective_conv_id,
+                    session_id=None if effective_conv_id else identity_session_id,
+                )
                 sandbox_handle = _LazySandboxHandle(
                     session_key=sandbox_session_key,
                     provider=resolved_sandbox_provider,
@@ -1622,16 +1633,40 @@ class AgentExecutionService:
                     and session_id_for_cache
                     and is_missing_tool_output_error(invoke_exc)
                 ):
+                    # Recover by forking from the last known-good checkpoint
+                    # instead of deleting the whole thread: adelete_thread
+                    # wipes the user's entire visible conversation history
+                    # (get_conversation_history reads the same checkpointer),
+                    # not just the broken step. Checkpoints are immutable and
+                    # ordered, so retrying with an earlier checkpoint_id set
+                    # simply forks history forward from there — nothing is
+                    # deleted.
+                    rollback_checkpoint_id = await CheckpointerCacheService.get_rollback_checkpoint_id(
+                        fresh_agent.agent_id,
+                        session_id_for_cache,
+                    )
+                    if rollback_checkpoint_id is None:
+                        logger.warning(
+                            "Incomplete tool-call checkpoint for agent %s session %s "
+                            "has no earlier checkpoint to roll back to; failing the "
+                            "turn instead of retrying",
+                            fresh_agent.agent_id,
+                            session_id_for_cache,
+                        )
+                        raise HTTPException(
+                            status_code=502,
+                            detail="Your last message could not be completed. Please resend it.",
+                        ) from invoke_exc
+
                     logger.warning(
                         "Detected incomplete tool-call checkpoint for agent %s "
-                        "session %s; deleting checkpoint and retrying turn once",
+                        "session %s; retrying turn from prior checkpoint %s "
+                        "(no history deleted)",
                         fresh_agent.agent_id,
                         session_id_for_cache,
+                        rollback_checkpoint_id,
                     )
-                    await CheckpointerCacheService.invalidate_checkpointer_async(
-                        fresh_agent.agent_id,
-                        session_id_for_cache,
-                    )
+                    config["configurable"]["checkpoint_id"] = rollback_checkpoint_id
                     result = await agent_chain.ainvoke(
                         {"messages": [message_payload]},
                         config=config,

--- a/backend/services/agent_streaming_service.py
+++ b/backend/services/agent_streaming_service.py
@@ -128,6 +128,7 @@ class AgentStreamingService:
 
             accumulated_content = ""
             structured_response = None
+            rollback_checkpoint_id = None
 
             for attempt in range(2):
                 mcp_client = None
@@ -162,6 +163,8 @@ class AgentStreamingService:
                     )
 
                 config["configurable"]["question"] = ctx.enhanced_message
+                if rollback_checkpoint_id is not None:
+                    config["configurable"]["checkpoint_id"] = rollback_checkpoint_id
 
                 # ------------------------------------------------------------
                 # 4. Build the HumanMessage payload (handles multimodal images)
@@ -232,15 +235,35 @@ class AgentStreamingService:
                         and ctx.session_id_for_cache
                         and is_missing_tool_output_error(stream_exc)
                     ):
-                        logger.warning(
-                            "Detected incomplete tool-call checkpoint for agent %s "
-                            "session %s; deleting checkpoint and retrying turn once",
+                        # Recover by forking from the last known-good checkpoint
+                        # instead of deleting the whole thread — see the mirrored
+                        # fix in AgentExecutionService's non-streaming path for
+                        # the full rationale (adelete_thread wipes the user's
+                        # entire visible history, not just the broken step).
+                        rollback_checkpoint_id = await CheckpointerCacheService.get_rollback_checkpoint_id(
                             ctx.fresh_agent.agent_id,
                             ctx.session_id_for_cache,
                         )
-                        await CheckpointerCacheService.invalidate_checkpointer_async(
+                        if rollback_checkpoint_id is None:
+                            logger.warning(
+                                "Incomplete tool-call checkpoint for agent %s session %s "
+                                "has no earlier checkpoint to roll back to; failing the "
+                                "turn instead of retrying",
+                                ctx.fresh_agent.agent_id,
+                                ctx.session_id_for_cache,
+                            )
+                            yield format_sse_event(
+                                "error",
+                                {"message": "Your last message could not be completed. Please resend it."},
+                            )
+                            return
+                        logger.warning(
+                            "Detected incomplete tool-call checkpoint for agent %s "
+                            "session %s; retrying turn from prior checkpoint %s "
+                            "(no history deleted)",
                             ctx.fresh_agent.agent_id,
                             ctx.session_id_for_cache,
+                            rollback_checkpoint_id,
                         )
                         continue
                     raise
@@ -287,7 +310,7 @@ class AgentStreamingService:
             yield format_sse_event("error", {"message": "Connection error, please retry."})
         except Exception as exc:
             logger.error("Error in streaming agent chat: %s", str(exc), exc_info=True)
-            yield format_sse_event("error", {"message": str(exc)})
+            yield format_sse_event("error", {"message": "Agent execution failed"})
 
         finally:
             if ctx is not None and sandbox_turn_active:

--- a/backend/tools/agentTools.py
+++ b/backend/tools/agentTools.py
@@ -416,7 +416,20 @@ async def create_agent(
                 "creating fallback sandbox during tool assembly for agent %s",
                 agent.agent_id,
             )
-            sandbox_handle = sandbox_provider.create_sandbox(working_dir=working_dir)
+            try:
+                sandbox_handle = sandbox_provider.create_sandbox(working_dir=working_dir)
+            except Exception as exc:
+                # A provider that resolves fine but is actually unreachable
+                # (e.g. registered but the backing service isn't running)
+                # must not crash tool assembly — degrade the same way an
+                # unavailable provider does just above.
+                logger.warning(
+                    "Fallback sandbox creation failed for agent %s: %s",
+                    agent.agent_id,
+                    exc,
+                )
+                sandbox_provider = None
+                sandbox_handle = None
         if sandbox_provider is not None and sandbox_handle is not None:
             if sandbox_session_service is None and sandbox_session_key is not None:
                 try:

--- a/backend/tools/sandbox/opensandbox_provider.py
+++ b/backend/tools/sandbox/opensandbox_provider.py
@@ -553,6 +553,62 @@ class OpenSandboxProvider(SandboxProvider):
         except RuntimeError:
             pass
 
+    def _retire_context_entry(
+        self,
+        handle: SandboxHandle,
+        language: str,
+        entry: dict[str, Any] | None,
+    ) -> None:
+        """Permanently discard a context entry instead of returning it to the pool.
+
+        Used after a client-side ``run_code`` timeout: the daemon thread that
+        was running the interpreter call is abandoned (Python threads can't be
+        forcibly killed), and the best-effort ``interpreter.codes.interrupt()``
+        call is never confirmed to have actually stopped it. If the entry were
+        released normally, the very next ``_acquire_context_entry`` call could
+        hand this same, possibly still-busy context to a new caller — who
+        would then race the abandoned execution and could receive its stale
+        output instead of a fresh result (observed as the model looping on
+        unchanging output until it hit the graph recursion limit).
+
+        Removing the entry from the pool means ``_acquire_context_entry`` can
+        never return it again; its lock is deliberately left held (not
+        released) as a harmless extra guard. A fresh replacement context is
+        created best-effort so pool capacity for *language* isn't permanently
+        reduced by one timeout.
+        """
+        if entry is None:
+            return
+        pools = self._ensure_context_pools(handle)
+        pool_lock = handle.metadata.setdefault(_META_CONTEXT_POOL_LOCK, threading.Lock())
+        with pool_lock:
+            pool = pools.get(language)
+            if pool is not None and entry in pool:
+                pool.remove(entry)
+            logger.warning(
+                "OpenSandboxProvider: retired execution context after timeout "
+                "instead of returning it to the pool — it may still be busy "
+                "on the remote side (sandbox=%s, language=%s, context_id=%s)",
+                handle.sandbox_id,
+                language,
+                getattr(entry.get("context"), "id", "<unknown>"),
+            )
+            if pool is None:
+                return
+            try:
+                replacement = self._create_context_pool_entry(handle, language)
+            except Exception as exc:
+                logger.warning(
+                    "OpenSandboxProvider: failed to backfill retired context "
+                    "for language '%s' (sandbox=%s): %s",
+                    language,
+                    handle.sandbox_id,
+                    exc,
+                )
+                return
+            if replacement is not None:
+                pool.append(replacement)
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -886,6 +942,7 @@ class OpenSandboxProvider(SandboxProvider):
             except ImportError:
                 pass  # fall back to batch mode if SDK import fails
 
+        context_timed_out = False
         try:
             self._renew_sandbox_timeout(
                 sandbox,
@@ -914,6 +971,7 @@ class OpenSandboxProvider(SandboxProvider):
             thread.join(effective_timeout if effective_timeout > 0 else None)
 
             if thread.is_alive():
+                context_timed_out = True
                 exec_id = execution_id["value"]
                 if exec_id:
                     try:
@@ -958,7 +1016,10 @@ class OpenSandboxProvider(SandboxProvider):
             return f"[Error] Code execution failed: {exc}"[:effective_limit]
         finally:
             self._reset_idle_timeout(sandbox, suppress_errors=True)
-            self._release_context_entry(context_entry)
+            if context_timed_out:
+                self._retire_context_entry(handle, language, context_entry)
+            else:
+                self._release_context_entry(context_entry)
 
         # Collect output: use the ``text`` property which combines stdout +
         # result text, then append stderr/error if present.

--- a/backend/tools/sandbox/tool_factory.py
+++ b/backend/tools/sandbox/tool_factory.py
@@ -284,6 +284,27 @@ def create_sandbox_repl_tool(
                 return (
                     "[Error] Sandbox capacity reached, please retry shortly."
                 )
+            except Exception as exc:
+                # Any other failure materializing/using the sandbox (e.g. the
+                # provider is registered but unreachable — DNS/connection
+                # errors when the backing service isn't actually running)
+                # must not propagate uncaught either: unlike the specific
+                # cases above, this has no dedicated exception type, so it
+                # would otherwise crash the whole agent turn with a raw 500
+                # instead of a normal, LLM-visible tool error. Mirrors
+                # builtin_tools.py's `_run_bash` catch-all for the same
+                # class of failure on the other sandbox tool family.
+                logger.error(
+                    "Sandbox tool '%s' failed unexpectedly (session=%s): %s",
+                    tool_name,
+                    session_key,
+                    exc,
+                    exc_info=True,
+                )
+                return (
+                    "[Error] Code execution sandbox is currently unavailable. "
+                    "Please try again later."
+                )
             finally:
                 if lease_acquired and session_service is not None and session_key is not None:
                     try:

--- a/docs/reviews/sandbox-v2-critical-audit.md
+++ b/docs/reviews/sandbox-v2-critical-audit.md
@@ -1,0 +1,172 @@
+# Sandbox v2 — Auditoría post-merge (hallazgos críticos y altos)
+
+**Contexto:** `feature/sandbox-v2-core` (PR #209) se mergeó a `develop` el 2026-08-02
+(squash, tip `2f57c4e2`). Esta auditoría es una segunda pasada, hecha probando la app
+ya desplegada con la configuración documentada en `CLAUDE.md`, sobre el estado actual
+de `develop` (tip `ff687192` a fecha de este documento). Los hallazgos originales de
+la revisión de PR (IDOR cross-tenant, SSRF, escape de red, etc.) ya se arreglaron
+antes del merge y no se repiten aquí — esto es una lista nueva, encontrada después.
+
+Cada hallazgo fue verificado leyendo el código real (no reconstruido de memoria) y,
+donde fue posible, contrastado con evidencia en `logs/app.log` / `logs/app_errors.log`
+del entorno de pruebas.
+
+**Rama de este documento:** `fix/sandbox-critical-followups` (creada desde `develop`).
+Este documento es solo análisis — ningún fix incluido aún.
+
+---
+
+## 🔴 Críticos
+
+### CRÍTICO-1 — Un agente con Code Interpreter devuelve 500 si no arrancas el perfil `opensandbox`
+
+`docker compose up -d` (el comando documentado en `CLAUDE.md`) **no** arranca el
+servicio `opensandbox` — está detrás de `profiles: [opensandbox]` en
+`docker/docker-compose.yaml`. Pero `SANDBOX_DEFAULT_PROVIDER` ya vale `opensandbox`
+por defecto (mismo fichero, línea ~94).
+
+Reproducido:
+```
+POST /internal/apps/3/agents/24/chat
+→ 500 {"detail":"Agent execution failed: Network connectivity error: [Errno -3] Temporary failure in name resolution"}
+```
+
+Cualquier agente con `enable_code_interpreter=true` deja de funcionar con un 500
+completo, sin degradación.
+
+**Causa raíz confirmada:** `backend/tools/sandbox/factory.py`'s
+`resolve_provider_and_service_id()` solo lanza `SandboxProviderUnavailableError`
+cuando el *nombre* del provider no está registrado/permitido — no hace ninguna
+comprobación de red (confirmado por su propio docstring). Como `opensandbox` sí
+está registrado como clase, la resolución "tiene éxito" y el fallo real (DNS/conexión,
+porque el contenedor `opensandbox` nunca arrancó) explota más tarde dentro de
+`create_sandbox()`, sin que ningún `except SandboxProviderUnavailableError` lo
+capture (los sitios que sí manejan ese error están en
+`backend/tools/agentTools.py:268,406,827` y
+`backend/services/agent_execution_service.py:603` — ninguno cubre este caso).
+Sube como excepción genérica hasta `agent_execution_service.py:408` →
+`HTTPException(500, f"Agent execution failed: {str(e)}")` (ver también ALTO-8).
+
+También confirmado: ya no queda ningún provider `subprocess`/`python_repl` local de
+fallback — solo quedan comentarios que documentan que existió y fue retirado
+(`backend/tools/sandbox/provider.py:66`, `backend/tools/sandbox/builtin_tools.py:6`).
+
+**Por qué es crítico:** rompe el flujo de arranque *documentado* del proyecto, no
+un caso límite. Cualquier despliegue nuevo que siga `CLAUDE.md` al pie de la letra
+lo dispara en el primer chat con un agente code-interpreter.
+
+---
+
+### CRÍTICO-2 — Sandbox compartido entre usuarios distintos (`anon_{agent_id}`)
+
+`backend/services/agent_execution_service.py:614`:
+```python
+sandbox_session_key = SandboxSessionService.session_key(agent_id, effective_conv_id)
+```
+Se llama sin el tercer argumento `session_id`. `SandboxSessionService.session_key()`
+(`backend/services/sandbox_session_service.py:603-619`) cae a `anon_{agent_id}`
+cuando `conversation_id` es `None` — es decir, para agentes `has_memory=false`,
+embeds públicos, o marketplace.
+
+Comparación reveladora: el `working_dir` **local** para el mismo caso sí incluye
+`user_id` (`agent_execution_service.py:547-550`:
+`f"agent_{agent_id}_user_{user_id}_app_{app_id_ctx}"`), pero esa variable nunca se
+propaga al `session_key` del sandbox.
+
+Evidencia observada:
+```
+working_dir=data/tmp/persistent/agent_24_user_1_app_3   ← el dir local SÍ lleva user_id
+creating sandbox for anon_24                              ← la sesión de sandbox NO
+```
+
+**Por qué es crítico:** dos usuarios distintos contra el mismo agente comparten el
+mismo contenedor y el mismo workspace remoto — los ficheros que sube el usuario A
+los puede ver/leer el usuario B. Es una fuga de aislamiento multi-tenant real, no
+solo un bug funcional.
+
+---
+
+### CRÍTICO-3 — El reintento por "checkpoint obsoleto" borra la conversación entera
+
+`backend/services/agent_cache_service.py:11-13`:
+```python
+def is_missing_tool_output_error(exc: BaseException) -> bool:
+    return "No tool output found for function call" in str(exc)
+```
+
+Si el error del proveedor LLM contiene ese substring →
+`CheckpointerCacheService.invalidate_checkpointer_async()` →
+`checkpointer.adelete_thread(thread_id)` (línea 150). `adelete_thread` borra **todo
+el thread**, no solo el checkpoint incompleto. `get_conversation_history` lee de ese
+mismo checkpointer (usado por el playground para cargar el histórico), así que el
+usuario pierde el historial visible, no solo la memoria interna del agente.
+
+Está en los dos caminos de ejecución:
+- `agent_execution_service.py:1618-1631` (chat no-streaming)
+- `agent_streaming_service.py:225-241` (chat streaming)
+
+**Bug adicional en streaming:** `accumulated_content` (`agent_streaming_service.py:200`)
+se inicializa una única vez antes del `try`/`for attempt`, y **no se resetea** antes
+del `continue` (línea ~236). El reintento vuelve a acumular tokens sobre el contenido
+del intento fallido → respuesta duplicada, tanto emitida al cliente como persistida.
+
+**Evidencia en producción — no es hipotético.** Encontrado en `logs/app.log` del
+entorno de pruebas: **20 disparos reales** de este mismo path, todos para
+`agent 1 / session 297`, repartidos entre el 2026-07-20 y el 2026-08-02 (ejemplo:
+línea 8427 `Detected incomplete tool-call checkpoint for agent 1 session 297;
+deleting checkpoint and retrying turn once`). Cada disparo es una pérdida de
+historial de esa sesión.
+
+**Por qué es crítico:** de los tres, es el de mayor radio de impacto — afecta a
+*cualquier* agente con memoria, tenga o no sandbox habilitado, y ya se ha disparado
+repetidamente en un entorno real, no en un escenario construido para el test.
+
+---
+
+## 🟠 Altos (contexto — no forman parte del plan de fixes de esta rama, documentados para la siguiente pasada)
+
+- **ALTO-4** — `test_connection_with_config` (`backend/services/sandbox_service_service.py:443`)
+  bloquea el event loop con `future.result(timeout=20)` síncrono, llamado directamente
+  (sin `run_in_threadpool`) desde rutas `async def`
+  (`backend/routers/internal/sandbox_services.py:112`, `backend/routers/internal/admin.py:1261`).
+- **ALTO-5** — mismo código: si el timeout expira, el `handle` (asignado en el hilo
+  del executor) sigue `None` en el hilo principal cuando se evalúa el `finally`
+  (línea ~473) → el sandbox se crea igual en segundo plano y nunca se destruye.
+- **ALTO-6** — `SANDBOX_TEST_CONNECTION_ALLOW_PRIVATE` viene comentada (`false`) en
+  `docker/.env.example:190`; con el default, el guarda SSRF bloquea también guardar
+  (no solo probar) el propio `opensandbox:8080` interno del compose.
+- **ALTO-7** — `docker/opensandbox/sandbox.toml:109-110`: `[ingress] mode = "direct"`
+  publica puertos aleatorios en `0.0.0.0` del host por cada sandbox, contradiciendo
+  el aislamiento documentado.
+- **ALTO-8** — `agent_execution_service.py:408`: `detail=f"Agent execution failed: {str(e)}"`
+  filtra el mensaje crudo de la excepción (sockets Docker, IDs de contenedor) al cliente.
+- **ALTO-9** — workers de uvicorn muriendo durante actividad de sandbox — reportado,
+  sin traza en los logs de este checkout, pendiente de reproducir antes de poder
+  diagnosticar causa raíz.
+
+## 🟡 Medios (idem — no bloquean, documentados para trazabilidad)
+
+- **MEDIO-10** — reaper cross-worker race (`UVICORN_WORKERS` default 2, registro de
+  sesiones en memoria de proceso).
+- **MEDIO-11** — `opensandbox_provider.py:394-418`: fallo parcial al crear el contexto
+  de un lenguaje se traga con un `logger.warning` y el sandbox se marca "ready" igualmente.
+- **MEDIO-12** — `alembic downgrade -1` ambiguo tras la migración de merge
+  (comportamiento esperable de Alembic ante un `down_revision` en tupla; no verificado
+  en vivo en esta pasada).
+- **MEDIO-13** — inconsistencias de configuración entre `.env.example`, `docker-compose.yaml`,
+  `system_defaults.yaml` y `backend/utils/config.py` (imagen de code-interpreter distinta,
+  `SANDBOX_MAX_CONCURRENT_SESSIONS` no leído, ajustes de `system_defaults.yaml` sin efecto).
+- **MEDIO-14** — el panel de ejecución de código no recibe eventos `code_output`;
+  causa probable: `get_stream_writer()` (`tool_factory.py:184-197`) falla
+  silenciosamente cuando se llama desde el hilo de ejecución de la tool, no desde el
+  contexto async del grafo.
+
+---
+
+## Alcance de esta rama
+
+Esta rama (`fix/sandbox-critical-followups`) aborda **solo los tres críticos**
+(CRÍTICO-1, 2, 3). Los altos/medios quedan documentados arriba para una pasada
+posterior — mezclar los nueve en una sola rama haría el diff difícil de revisar y
+retrasaría el fix de los críticos, que son los que tienen impacto de seguridad/pérdida
+de datos en producción ahora mismo.

--- a/docs/reviews/sandbox-v2-critical-audit.md
+++ b/docs/reviews/sandbox-v2-critical-audit.md
@@ -12,7 +12,12 @@ donde fue posible, contrastado con evidencia en `logs/app.log` / `logs/app_error
 del entorno de pruebas.
 
 **Rama de este documento:** `fix/sandbox-critical-followups` (creada desde `develop`).
-Este documento es solo análisis — ningún fix incluido aún.
+
+**Estado: implementado y verificado en vivo.** Los tres críticos están arreglados,
+con tests unitarios y, además, reproducción manual real contra el stack desplegado
+(no solo tests con mocks) — ver "Verificación en vivo" al final de cada hallazgo.
+Los altos/medios se dejan documentados para una pasada posterior (ver "Alcance de
+esta rama").
 
 ---
 
@@ -55,6 +60,17 @@ fallback — solo quedan comentarios que documentan que existió y fue retirado
 un caso límite. Cualquier despliegue nuevo que siga `CLAUDE.md` al pie de la letra
 lo dispara en el primer chat con un agente code-interpreter.
 
+**Fix:** los tools del REPL (`tool_factory.py`) y el fallback de creación de sandbox
+en `agentTools.py:419` ahora capturan cualquier fallo inesperado de conexión y
+devuelven un error limpio en línea (`"[Error] Code execution sandbox is currently
+unavailable..."`) en vez de dejar que la excepción se propague sin control.
+`CLAUDE.md` documenta ahora explícitamente que hace falta
+`docker compose --profile opensandbox up -d --build`.
+
+**Verificación en vivo:** con `mattin-opensandbox` parado (`docker stop
+mattin-opensandbox`), un chat con un agente code-interpreter devuelve 200 con
+*"It seems that the code execution environment is currently unavailable"* — no 500.
+
 ---
 
 ### CRÍTICO-2 — Sandbox compartido entre usuarios distintos (`anon_{agent_id}`)
@@ -83,6 +99,16 @@ creating sandbox for anon_24                              ← la sesión de sand
 mismo contenedor y el mismo workspace remoto — los ficheros que sube el usuario A
 los puede ver/leer el usuario B. Es una fuga de aislamiento multi-tenant real, no
 solo un bug funcional.
+
+**Fix:** `agent_execution_service.py` ahora deriva `identity_session_id` (de
+`user_id`/`app_id`) igual que ya hacía el `working_dir` local, y lo pasa como
+`session_id` a `SandboxSessionService.session_key()`.
+
+**Verificación en vivo:** un agente `has_memory=false` con code interpreter,
+consultado por dos usuarios reales sin `conversation_id` — logs muestran
+`SandboxSessionService: creating sandbox for thread_2_user_1_app_1` y
+`...thread_2_user_2_app_1` (nunca `anon_2`). Un fichero creado por el usuario 1
+(`/tmp/marker.txt`) es invisible para el usuario 2 (`NO_MARKER_FOUND`).
 
 ---
 
@@ -120,6 +146,67 @@ historial de esa sesión.
 **Por qué es crítico:** de los tres, es el de mayor radio de impacto — afecta a
 *cualquier* agente con memoria, tenga o no sandbox habilitado, y ya se ha disparado
 repetidamente en un entorno real, no en un escenario construido para el test.
+
+**Fix (v1, en tests con mocks):** en vez de `adelete_thread`, un nuevo
+`CheckpointerCacheService.get_rollback_checkpoint_id()` busca el checkpoint anterior
+al roto y el reintento se hace pasando `checkpoint_id` en el config — LangGraph
+crea una rama nueva a partir de ahí, sin borrar nada. Si no hay checkpoint anterior
+al que volver, se devuelve un error limpio ("Please resend it") en vez de reintentar.
+El bug de duplicación en streaming resultó ser inexistente en el código actual
+(`accumulated_content` sí se resetea dentro del loop de reintento) — descartado tras
+inspección directa.
+
+**Dos bugs adicionales encontrados al verificar el fix en vivo** (reproduciendo el
+crash real: `docker kill mattin-backend` a mitad de una tool call, no un mock):
+
+1. **Detección demasiado estrecha.** `is_missing_tool_output_error()` solo
+   reconocía `"No tool output found for function call"`. El error real que devuelve
+   OpenAI (gpt-4o-mini, chat completions) para este escenario es distinto:
+   *"An assistant message with 'tool_calls' must be followed by tool messages
+   responding to each 'tool_call_id'. The following tool_call_ids did not have
+   response messages: ..."* — el mecanismo de recuperación nunca se disparaba.
+   Arreglado ampliando la lista de substrings reconocidos.
+2. **El rollback de un solo checkpoint no basta.** Tras arreglar la detección, el
+   reintento seguía fallando: el checkpoint "anterior" elegido tenía su *último*
+   mensaje limpio (un `HumanMessage` nuevo), pero un `AIMessage` con `tool_calls`
+   sin resolver seguía **en medio de la lista**, de un intento de recuperación previo
+   que había añadido un mensaje encima del estado roto en vez de arreglarlo. OpenAI
+   valida la lista completa, no solo el último mensaje. Arreglado: `get_rollback_checkpoint_id`
+   ahora recorre el historial hacia atrás e inspecciona la lista completa de mensajes
+   de cada checkpoint candidato, no solo el último, hasta encontrar uno realmente
+   limpio.
+
+**Verificación en vivo (repetida 3 veces hasta confirmar):** conversación real,
+tool call `sleep 20` en curso, `docker kill mattin-backend` a mitad de ejecución,
+reinicio, mensaje de seguimiento en la misma conversación → 200 limpio,
+`GET /internal/conversations/{id}/history` muestra el historial completo intacto
+(el mensaje original + el intento fallido + la recuperación), nada borrado.
+
+---
+
+## 🟠 Alto — encontrado y arreglado durante la verificación en vivo (no formaba parte del alcance original)
+
+### OpenSandbox: un contexto de ejecución que hace timeout queda "zombie" y se reparte a la siguiente llamada
+
+No es uno de los tres críticos — se encontró haciendo pruebas de estrés manuales
+sobre CRÍTICO-1 y se arregló en la misma rama porque bloqueaba directamente esa
+verificación.
+
+`opensandbox_provider.py`'s `run_code`: cada contexto de ejecución pooled tiene un
+`threading.Lock` que actúa de flag de ocupado. Si la ejecución hace timeout, el hilo
+que la ejecuta (`interpreter.codes.run(...)`, bloqueante) se abandona — no se puede
+matar un thread de Python — y `interpreter.codes.interrupt(exec_id)` es
+best-effort sin verificar si funcionó. El `finally` liberaba el lock igualmente,
+así que la siguiente llamada podía recibir el **mismo contexto**, aún ocupado por la
+ejecución zombie, y obtener su salida obsoleta en vez de un resultado nuevo.
+
+**Reproducido en vivo:** una tool call con timeout dejó el mismo `output_len=59`
+repitiéndose en 12+ llamadas sucesivas, hasta que el modelo agotó el límite de
+recursión de LangGraph (50 pasos) y el turno falló con 500.
+
+**Fix:** nuevo `_retire_context_entry()` — tras un timeout, el contexto se retira
+permanentemente del pool (nunca se libera para reuso) y se intenta crear uno de
+reemplazo para no reducir la capacidad del pool.
 
 ---
 
@@ -165,8 +252,21 @@ repetidamente en un entorno real, no en un escenario construido para el test.
 
 ## Alcance de esta rama
 
-Esta rama (`fix/sandbox-critical-followups`) aborda **solo los tres críticos**
-(CRÍTICO-1, 2, 3). Los altos/medios quedan documentados arriba para una pasada
-posterior — mezclar los nueve en una sola rama haría el diff difícil de revisar y
-retrasaría el fix de los críticos, que son los que tienen impacto de seguridad/pérdida
-de datos en producción ahora mismo.
+Esta rama (`fix/sandbox-critical-followups`) aborda los **tres críticos**
+(CRÍTICO-1, 2, 3) más el bug de OpenSandbox encontrado al verificarlos en vivo
+(context pool zombie tras timeout). Los altos/medios restantes quedan documentados
+arriba para una pasada posterior — mezclarlos todos en una sola rama haría el diff
+difícil de revisar y retrasaría el fix de los críticos, que son los que tienen
+impacto de seguridad/pérdida de datos en producción ahora mismo.
+
+## Cobertura de tests
+
+16 tests nuevos/actualizados: `test_agent_cache_service.py` (9, nuevo —
+detección de error + recorrido de rollback), `test_agent_execution_service.py` (+2),
+`test_agent_execution_service_it4.py` (+1), `test_agent_streaming_service.py` (+2),
+`test_sandbox_opensandbox_provider.py` (+2), `test_sandbox_tool_factory.py` (+1
+regresión + docstring ampliado). Suite completa: 1667 passed, 65 skipped.
+Además de los tests unitarios, los tres críticos y el fix de OpenSandbox se
+verificaron en vivo contra el stack desplegado (`docker compose --profile
+opensandbox up -d --build`), no solo con mocks — ver "Verificación en vivo" en
+cada hallazgo.

--- a/tests/unit/services/test_agent_cache_service.py
+++ b/tests/unit/services/test_agent_cache_service.py
@@ -1,0 +1,201 @@
+"""Unit tests for agent_cache_service — checkpoint-recovery helpers.
+
+Providers reject a checkpoint with a dangling tool_calls entry (an
+AIMessage whose tool call never got a matching ToolMessage — e.g. the
+backend crashed mid-tool-execution) with different wording depending on the
+exact API surface hit. This must be detected reliably so the
+fork-from-prior-checkpoint recovery in agent_execution_service.py and
+agent_streaming_service.py actually triggers, and the checkpoint it forks
+from must actually be a *safe* one to resume from.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.agent_cache_service import (
+    CheckpointerCacheService,
+    is_missing_tool_output_error,
+)
+
+
+def _msg(msg_type: str, tool_calls=None, tool_call_id=None):
+    return SimpleNamespace(type=msg_type, tool_calls=tool_calls, tool_call_id=tool_call_id)
+
+
+def _checkpoint_tuple(checkpoint_id: str, messages: list):
+    return SimpleNamespace(
+        checkpoint={"channel_values": {"messages": messages}},
+        config={"configurable": {"checkpoint_id": checkpoint_id}},
+    )
+
+
+class TestIsMissingToolOutputError:
+    def test_matches_legacy_phrasing(self):
+        exc = RuntimeError(
+            "Error code: 400 - No tool output found for function call call_stale"
+        )
+        assert is_missing_tool_output_error(exc) is True
+
+    def test_matches_live_openai_chat_completions_phrasing(self):
+        """Live-reproduced against OpenAI (gpt-4o-mini): kill the backend
+        mid-tool-call, resume the same conversation — this is the exact
+        error text raised. The legacy substring alone does not match it."""
+        exc = RuntimeError(
+            "Error code: 400 - {'error': {'message': \"An assistant message "
+            "with 'tool_calls' must be followed by tool messages responding "
+            "to each 'tool_call_id'. The following tool_call_ids did not "
+            "have response messages: call_VtLW6LSES2D4RbPdAZ5yQDC5\", "
+            "'type': 'invalid_request_error', 'param': 'messages.[5].role', "
+            "'code': None}}"
+        )
+        assert is_missing_tool_output_error(exc) is True
+
+    def test_unrelated_error_does_not_match(self):
+        exc = RuntimeError("Error code: 401 - invalid API key")
+        assert is_missing_tool_output_error(exc) is False
+
+
+class TestGetRollbackCheckpointId:
+    """Live-reproduced bug: killing the backend mid-tool-call left TWO
+    consecutive checkpoints ending in the same dangling AIMessage (one
+    from the model node adding the tool_calls, another from the tools
+    node beginning execution before being interrupted). Naively rolling
+    back exactly one checkpoint replayed the exact same broken state and
+    failed identically. The fix must walk back past every checkpoint
+    still carrying a pending tool call, not just the immediate
+    predecessor."""
+
+    @staticmethod
+    def _patch_checkpointer(checkpoints: list):
+        async def _alist(config, limit=None):
+            for cp in checkpoints[: limit or len(checkpoints)]:
+                yield cp
+
+        checkpointer = MagicMock()
+        checkpointer.alist = _alist
+        return patch.object(
+            CheckpointerCacheService,
+            "get_async_checkpointer",
+            new=AsyncMock(return_value=checkpointer),
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_multiple_checkpoints_still_holding_the_pending_tool_call(self):
+        pending_tool_calls = [{"id": "call_abc", "name": "Bash", "args": {}}]
+        checkpoints = [
+            _checkpoint_tuple("cp-4-broken", [_msg("human"), _msg("ai", pending_tool_calls)]),
+            _checkpoint_tuple("cp-3-also-broken", [_msg("human"), _msg("ai", pending_tool_calls)]),
+            _checkpoint_tuple("cp-2-clean", [_msg("human")]),
+            _checkpoint_tuple("cp-1-clean", []),
+        ]
+
+        with self._patch_checkpointer(checkpoints):
+            result = await CheckpointerCacheService.get_rollback_checkpoint_id(1, "sess")
+
+        assert result == "cp-2-clean"
+
+    @pytest.mark.asyncio
+    async def test_skips_checkpoint_with_unresolved_tool_call_sandwiched_mid_list(self):
+        """Live-reproduced: a first retry attempt appended a fresh
+        HumanMessage on top of an already-broken state instead of fixing
+        it, so the *newest* checkpoints all end in a clean HumanMessage
+        while the original unresolved AIMessage(tool_calls=...) still
+        sits earlier in the same list with no ToolMessage ever inserted
+        after it. Checking only the tail message (the original,
+        insufficient implementation) wrongly treated these as safe and
+        replayed the same broken list, failing identically."""
+        pending_tool_calls = [{"id": "call_orig", "name": "Bash", "args": {}}]
+        checkpoints = [
+            _checkpoint_tuple(
+                "cp-3-looks-clean-but-isnt",
+                [
+                    _msg("human"),
+                    _msg("ai"),
+                    _msg("human"),
+                    _msg("ai", pending_tool_calls),  # never answered below
+                    _msg("human"),  # a retry's new message, appended on top
+                ],
+            ),
+            _checkpoint_tuple(
+                "cp-2-also-looks-clean-but-isnt",
+                [
+                    _msg("human"),
+                    _msg("ai"),
+                    _msg("human"),
+                    _msg("ai", pending_tool_calls),
+                    _msg("human"),
+                ],
+            ),
+            _checkpoint_tuple(
+                "cp-1-genuinely-clean",
+                [_msg("human"), _msg("ai"), _msg("human")],
+            ),
+        ]
+
+        with self._patch_checkpointer(checkpoints):
+            result = await CheckpointerCacheService.get_rollback_checkpoint_id(1, "sess")
+
+        assert result == "cp-1-genuinely-clean"
+
+    @pytest.mark.asyncio
+    async def test_resolved_tool_call_mid_list_is_considered_clean(self):
+        """An AIMessage(tool_calls=...) that *does* have a matching
+        ToolMessage later in the list is a normal, healthy turn and must
+        not be treated as broken."""
+        checkpoints = [
+            _checkpoint_tuple("cp-2-not-inspected", [_msg("human"), _msg("ai")]),
+            _checkpoint_tuple(
+                "cp-1-healthy-tool-turn",
+                [
+                    _msg("human"),
+                    _msg("ai", [{"id": "call_ok", "name": "Bash", "args": {}}]),
+                    _msg("tool", tool_call_id="call_ok"),
+                    _msg("ai"),
+                ],
+            ),
+        ]
+
+        with self._patch_checkpointer(checkpoints):
+            result = await CheckpointerCacheService.get_rollback_checkpoint_id(1, "sess")
+
+        assert result == "cp-1-healthy-tool-turn"
+
+    @pytest.mark.asyncio
+    async def test_returns_immediate_predecessor_when_it_is_already_clean(self):
+        checkpoints = [
+            _checkpoint_tuple(
+                "cp-2-broken",
+                [_msg("human"), _msg("ai", [{"id": "call_x", "name": "Bash", "args": {}}])],
+            ),
+            _checkpoint_tuple("cp-1-clean", [_msg("human"), _msg("ai")]),
+        ]
+
+        with self._patch_checkpointer(checkpoints):
+            result = await CheckpointerCacheService.get_rollback_checkpoint_id(1, "sess")
+
+        assert result == "cp-1-clean"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_every_checkpoint_is_still_broken(self):
+        pending_tool_calls = [{"id": "call_abc", "name": "Bash", "args": {}}]
+        checkpoints = [
+            _checkpoint_tuple("cp-2-broken", [_msg("ai", pending_tool_calls)]),
+            _checkpoint_tuple("cp-1-also-broken", [_msg("ai", pending_tool_calls)]),
+        ]
+
+        with self._patch_checkpointer(checkpoints):
+            result = await CheckpointerCacheService.get_rollback_checkpoint_id(1, "sess")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_with_fewer_than_two_checkpoints(self):
+        checkpoints = [_checkpoint_tuple("cp-1-only", [_msg("human")])]
+
+        with self._patch_checkpointer(checkpoints):
+            result = await CheckpointerCacheService.get_rollback_checkpoint_id(1, "sess")
+
+        assert result is None

--- a/tests/unit/services/test_agent_execution_service.py
+++ b/tests/unit/services/test_agent_execution_service.py
@@ -367,6 +367,93 @@ class TestErrorHandling:
         assert "Agent execution failed" in exc_info.value.detail
 
 
+class TestCheckpointRetryRecovery:
+    """_execute_agent_async recovers from a stale/incomplete tool-call
+    checkpoint by forking from the prior checkpoint instead of deleting the
+    whole thread (adelete_thread wipes the user's visible history, not just
+    the broken step)."""
+
+    @pytest.mark.asyncio
+    async def test_retries_from_prior_checkpoint_without_deleting_thread(self):
+        from types import SimpleNamespace
+
+        agent = make_agent(has_memory=True)
+        agent.app = None  # resolve_langsmith_settings short-circuits on no app
+        svc, _ = make_service(agent=agent)
+
+        # Unlike the streaming path, the non-streaming retry reuses the same
+        # already-built agent_chain — it only calls create_agent once and
+        # retries ainvoke() on that chain with a rolled-back checkpoint_id.
+        chain = MagicMock()
+        chain.ainvoke = AsyncMock(
+            side_effect=[
+                RuntimeError(
+                    "Error code: 400 - No tool output found for function call call_stale"
+                ),
+                {"messages": [SimpleNamespace(content="done")]},
+            ]
+        )
+        create_agent = AsyncMock(return_value=(chain, None))
+
+        with (
+            patch("tools.agentTools.create_agent", create_agent),
+            patch("tools.agentTools.prepare_agent_config", return_value={"configurable": {}}),
+            patch("tools.agentTools.build_human_message", return_value=SimpleNamespace(content="hi")),
+            patch(
+                "services.agent_cache_service.CheckpointerCacheService.get_rollback_checkpoint_id",
+                new=AsyncMock(return_value="01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+            ) as get_rollback_checkpoint_id,
+        ):
+            result = await svc._execute_agent_async(
+                agent,
+                "hi",
+                session_id_for_cache="297",
+            )
+
+        assert result == "done"
+        assert create_agent.await_count == 1
+        assert chain.ainvoke.await_count == 2
+        get_rollback_checkpoint_id.assert_awaited_once_with(agent.agent_id, "297")
+        assert chain.ainvoke.call_args.kwargs["config"]["configurable"]["checkpoint_id"] == (
+            "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fails_cleanly_when_no_checkpoint_to_roll_back_to(self):
+        from types import SimpleNamespace
+
+        agent = make_agent(has_memory=True)
+        agent.app = None  # resolve_langsmith_settings short-circuits on no app
+        svc, _ = make_service(agent=agent)
+
+        first_chain = MagicMock()
+        first_chain.ainvoke = AsyncMock(
+            side_effect=RuntimeError(
+                "Error code: 400 - No tool output found for function call call_stale"
+            )
+        )
+        create_agent = AsyncMock(return_value=(first_chain, None))
+
+        with (
+            patch("tools.agentTools.create_agent", create_agent),
+            patch("tools.agentTools.prepare_agent_config", return_value={"configurable": {}}),
+            patch("tools.agentTools.build_human_message", return_value=SimpleNamespace(content="hi")),
+            patch(
+                "services.agent_cache_service.CheckpointerCacheService.get_rollback_checkpoint_id",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await svc._execute_agent_async(
+                    agent,
+                    "hi",
+                    session_id_for_cache="297",
+                )
+
+        assert exc_info.value.status_code == 502
+        assert len(create_agent.call_args_list) == 1
+
+
 # ---------------------------------------------------------------------------
 # File snapshotting — only newly created files are registered
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_agent_execution_service_it4.py
+++ b/tests/unit/services/test_agent_execution_service_it4.py
@@ -193,6 +193,49 @@ class TestPrepareTurnSandboxHandleCreation:
             ctx.sandbox_provider.run_code(ctx.sandbox_handle, "print('hi')", language="python")
         mock_sss.get_or_create.assert_called_once()
 
+    def test_anon_sessions_are_scoped_per_caller_identity(self, tmp_path, monkeypatch):
+        """Without a conversation_id (has_memory=False agents, public embeds,
+        marketplace), the sandbox session key must be scoped by caller
+        identity (user_id/app_id) — not collapse every caller for a given
+        agent onto the same shared "anon_{agent_id}" session, which let
+        unrelated users share one remote sandbox container/workspace."""
+        agent = _make_agent(enable_code_interpreter=True)
+        svc = _make_service(agent)
+
+        mock_provider = MagicMock()
+        mock_provider.PROVIDER_NAME = "opensandbox"
+        mock_provider.get_supported_languages.return_value = []
+
+        with (
+            patch("services.agent_execution_service.get_app_config", return_value={"TMP_BASE_FOLDER": str(tmp_path)}),
+            patch("services.agent_execution_service.AgentExecutionService._validate_agent_access", new=AsyncMock()),
+            patch("tools.sandbox.factory.resolve_provider_and_service_id", return_value=(mock_provider, None)),
+            patch("services.sandbox_session_service.sandbox_session_service", MagicMock()),
+        ):
+            import asyncio
+            ctx_user_a = asyncio.get_event_loop().run_until_complete(
+                svc._prepare_turn(
+                    agent_id=7,
+                    message="run code",
+                    file_references=[],
+                    db=MagicMock(),
+                    user_context={"user_id": "user-a", "app_id": "1"},
+                )
+            )
+            ctx_user_b = asyncio.get_event_loop().run_until_complete(
+                svc._prepare_turn(
+                    agent_id=7,
+                    message="run code",
+                    file_references=[],
+                    db=MagicMock(),
+                    user_context={"user_id": "user-b", "app_id": "1"},
+                )
+            )
+
+        assert ctx_user_a.sandbox_session_key != "anon_7"
+        assert ctx_user_b.sandbox_session_key != "anon_7"
+        assert ctx_user_a.sandbox_session_key != ctx_user_b.sandbox_session_key
+
     def test_resolved_sandbox_service_id_reaches_session_service(self, tmp_path, monkeypatch):
         """The SandboxService.service_id resolved for this agent must flow all
         the way through to SandboxSessionService.get_or_create() — this is

--- a/tests/unit/services/test_agent_streaming_service.py
+++ b/tests/unit/services/test_agent_streaming_service.py
@@ -133,9 +133,9 @@ async def test_streaming_resets_stale_tool_call_checkpoint_and_retries():
         patch("services.agent_streaming_service.prepare_agent_config", return_value={"configurable": {}}),
         patch("services.agent_streaming_service.build_human_message", return_value=SimpleNamespace(content="hello")),
         patch(
-            "services.agent_streaming_service.CheckpointerCacheService.invalidate_checkpointer_async",
-            new=AsyncMock(),
-        ) as invalidate_checkpoint,
+            "services.agent_streaming_service.CheckpointerCacheService.get_rollback_checkpoint_id",
+            new=AsyncMock(return_value="01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+        ) as get_rollback_checkpoint_id,
     ):
         events = [
             event
@@ -150,5 +150,68 @@ async def test_streaming_resets_stale_tool_call_checkpoint_and_retries():
         ]
 
     assert len(create_agent.call_args_list) == 2
-    invalidate_checkpoint.assert_awaited_once_with(1, "297")
+    get_rollback_checkpoint_id.assert_awaited_once_with(1, "297")
+    # The retry must fork from the prior checkpoint, not delete anything.
+    assert second_chain.astream.call_args.kwargs["config"]["configurable"]["checkpoint_id"] == (
+        "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+    )
     assert any('"done"' in event for event in events)
+
+
+@pytest.mark.asyncio
+async def test_streaming_fails_cleanly_when_no_checkpoint_to_roll_back_to():
+    """When the broken checkpoint is the thread's first ever state, there is
+    nothing to fork from — the turn must fail with a clean error instead of
+    retrying (and must not fall back to deleting the thread)."""
+    from services.agent_streaming_service import AgentStreamingService
+
+    ctx = SimpleNamespace(
+        effective_conv_id=297,
+        agent=SimpleNamespace(name="Agent", has_memory=True),
+        fresh_agent=SimpleNamespace(agent_id=1, has_memory=True),
+        search_params={},
+        session_id_for_cache="297",
+        user_context={"user_id": "u1"},
+        working_dir="/tmp/work",
+        sandbox_handle=MagicMock(),
+        sandbox_provider=MagicMock(),
+        sandbox_session_key="conv_1_297",
+        enhanced_message="hello",
+        image_files=[],
+    )
+
+    execution_service = MagicMock()
+    execution_service._prepare_turn = AsyncMock(return_value=ctx)
+    execution_service._finalize_turn = AsyncMock()
+
+    first_chain = MagicMock()
+    first_chain.astream.return_value = _missing_tool_output_stream()
+    create_agent = AsyncMock(return_value=(first_chain, None, None))
+
+    service = AgentStreamingService()
+    service.execution_service = execution_service
+
+    with (
+        patch("services.agent_streaming_service.create_agent", create_agent),
+        patch("services.agent_streaming_service.prepare_agent_config", return_value={"configurable": {}}),
+        patch("services.agent_streaming_service.build_human_message", return_value=SimpleNamespace(content="hello")),
+        patch(
+            "services.agent_streaming_service.CheckpointerCacheService.get_rollback_checkpoint_id",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        events = [
+            event
+            async for event in service.stream_agent_chat(
+                agent_id=1,
+                message="hello",
+                file_references=[],
+                user_context={"user_id": "u1"},
+                conversation_id=297,
+                db=MagicMock(),
+            )
+        ]
+
+    assert len(create_agent.call_args_list) == 1
+    assert any('"error"' in event and "resend" in event for event in events)
+    execution_service._finalize_turn.assert_not_awaited()

--- a/tests/unit/tools/test_sandbox_opensandbox_provider.py
+++ b/tests/unit/tools/test_sandbox_opensandbox_provider.py
@@ -232,6 +232,63 @@ class TestOpenSandboxProviderRunCode:
         assert "timed out" in result
         mock_interpreter.codes.interrupt.assert_called_once_with("exec-timeout-1")
 
+        # The timed-out context must be retired (removed from the pool), not
+        # released back for reuse — its background thread is abandoned, not
+        # confirmed dead, so handing it to the next caller risks that caller
+        # racing the zombie execution and getting its stale output instead of
+        # a fresh result (see docstring on _retire_context_entry).
+        from tools.sandbox.opensandbox_provider import _META_CONTEXT_POOLS
+
+        pool = handle.metadata[_META_CONTEXT_POOLS]["python"]
+        timed_out_context = handle.metadata["_interpreter"].codes.create_context.return_value
+        assert all(entry["context"] is not timed_out_context for entry in pool)
+
+    def test_timed_out_context_is_backfilled_with_a_fresh_one(self, provider_and_handle):
+        """After retiring a timed-out context, the pool should be backfilled
+        with a fresh replacement so capacity for that language isn't
+        permanently reduced by one timeout."""
+        provider, handle = provider_and_handle
+        mock_interpreter = handle.metadata["_interpreter"]
+
+        replacement_context = MagicMock()
+        replacement_context.id = "ctx-replacement"
+        mock_interpreter.codes.create_context.return_value = replacement_context
+
+        class FakeExecutionHandlersSync:
+            def __init__(self, on_init=None, on_stdout=None):
+                self.on_init = on_init
+                self.on_stdout = on_stdout
+
+        execd_sync_module = ModuleType("opensandbox.models.execd_sync")
+        execd_sync_module.ExecutionHandlersSync = FakeExecutionHandlersSync
+
+        def _slow_run(*args, **kwargs):
+            handlers = kwargs.get("handlers")
+            if handlers and handlers.on_init:
+                handlers.on_init(SimpleNamespace(id="exec-timeout-2"))
+            time.sleep(0.2)
+            return MagicMock()
+
+        mock_interpreter.codes.run.side_effect = _slow_run
+
+        with (
+            patch.dict(sys.modules, {"opensandbox.models.execd_sync": execd_sync_module}),
+            patch.object(
+                provider,
+                "_language_enum_for_context",
+                return_value="python-enum",
+            ),
+        ):
+            provider.run_code(handle, "while True: pass", timeout=0.01)
+
+        from tools.sandbox.opensandbox_provider import _META_CONTEXT_POOLS
+
+        pool = handle.metadata[_META_CONTEXT_POOLS]["python"]
+        assert len(pool) == 1
+        assert pool[0]["context"] is replacement_context
+        # The replacement must be immediately acquirable (unlocked).
+        assert pool[0]["lock"].acquire(blocking=False)
+
     def test_no_access_to_backend_env(self, provider_and_handle):
         """
         Isolation check: OpenSandboxProvider.run_code cannot access os.environ

--- a/tests/unit/tools/test_sandbox_tool_factory.py
+++ b/tests/unit/tools/test_sandbox_tool_factory.py
@@ -1,8 +1,9 @@
 """Regression tests for backend/tools/sandbox/tool_factory.py's REPL tool
 error handling — specifically that provider errors raised during lazy
-sandbox materialization (SandboxCapacityError, SandboxExpiredError) are
-translated into clean tool-error strings instead of propagating uncaught
-and crashing the whole agent turn.
+sandbox materialization (SandboxCapacityError, SandboxExpiredError, and any
+other unexpected failure such as a provider that resolves fine but is
+actually unreachable) are translated into clean tool-error strings instead
+of propagating uncaught and crashing the whole agent turn.
 """
 from __future__ import annotations
 
@@ -62,3 +63,24 @@ def test_repl_tool_recovers_from_expired_sandbox():
 
     assert result == "OK"
     session_service.evict.assert_called_once_with("conv_1_1")
+
+
+def test_repl_tool_returns_clean_error_on_unexpected_failure():
+    """A provider that resolves fine but is actually unreachable (e.g. the
+    backing sandbox service isn't running — DNS/connection errors with no
+    dedicated exception type) must degrade the same way as the known error
+    types above instead of crashing the whole agent turn with a raw 500."""
+    handle = _handle()
+    provider = MagicMock()
+    provider.get_supported_languages.return_value = ["python"]
+    provider.run_code.side_effect = OSError(
+        "[Errno -3] Temporary failure in name resolution"
+    )
+
+    tool = create_sandbox_repl_tool(handle, provider, "python")
+    result = tool.invoke({"code": "print(1)"})
+
+    assert "unavailable" in result.lower()
+    assert "error" in result.lower()
+    # The raw exception text must not leak into the LLM-visible tool result.
+    assert "name resolution" not in result


### PR DESCRIPTION
## Summary

Post-merge live-testing of the sandbox v2 feature (#209) surfaced three critical bugs not caught by the original review, all with real, reproducible user impact. This PR fixes all three, plus a fourth bug found while verifying them live against the deployed stack.

Full write-up with root causes, evidence, and live-verification steps: [`docs/reviews/sandbox-v2-critical-audit.md`](docs/reviews/sandbox-v2-critical-audit.md).

### CRÍTICO-1 — Code-interpreter agents 500 instead of degrading gracefully
`resolve_provider_and_service_id()` only validates the provider *name*, not connectivity — so when `opensandbox` is registered but actually unreachable (e.g. the documented `docker compose up -d` doesn't start the `opensandbox` service at all, it's profile-gated), the failure happens later, uncaught, and crashes the whole turn with a raw 500.
- Fix: REPL tool and the `agentTools.py` sandbox-creation fallback now catch generic connectivity failures and degrade to a clean in-band tool error instead of propagating.
- `CLAUDE.md` now documents `docker compose --profile opensandbox up -d --build`.
- **Live-verified**: stopped `mattin-opensandbox`, confirmed a clean 200 response instead of a 500.

### CRÍTICO-2 — Sandbox sessions shared across different users
For agents without a `conversation_id` (`has_memory=false`, public embeds, marketplace), the sandbox session key fell back to `anon_{agent_id}` — losing caller identity entirely, unlike the local workspace path which already scoped by `user_id`/`app_id`. Two unrelated users hitting the same agent got the *same* remote sandbox container and files.
- Fix: thread the same `user_id`/`app_id` identity already used for the local workspace into `SandboxSessionService.session_key()`.
- **Live-verified**: two real user accounts chatting with the same memory-less agent got distinct sandbox sessions (`thread_2_user_1_app_1` vs `thread_2_user_2_app_1`); a file written by user A was invisible to user B.

### CRÍTICO-3 — Checkpoint-recovery retry deleted the whole conversation
When a provider rejects a stale/incomplete tool-call checkpoint (backend crashes mid-tool-execution), the recovery path called `adelete_thread()` — wiping the *entire* conversation history, not just the broken step, since `get_conversation_history` reads from the same checkpointer. Confirmed 20 real occurrences in test logs before this fix.
- Fix: new `CheckpointerCacheService.get_rollback_checkpoint_id()` forks the LangGraph thread from the last known-good checkpoint instead of deleting anything.
- **Two additional bugs found live-verifying this fix** (not caught by mocked tests): (1) the error-detection substring only matched one OpenAI error phrasing — the actual live error text differs and was never being caught; (2) rolling back exactly one checkpoint wasn't enough — a checkpoint can look clean by its last message while still carrying an unresolved `tool_calls` entry earlier in the list (from a prior failed retry). Both fixed; `get_rollback_checkpoint_id` now scans the full message list of each candidate checkpoint.
- **Live-verified** (reproduced 3x with a real `docker kill` mid-tool-call, not a mock): conversation recovers cleanly, full history intact.

### Bonus — OpenSandbox execution-context pool leaked "zombie" contexts after a timeout
Found stress-testing CRÍTICO-1 live. On a `run_code` timeout, the abandoned execution thread was never confirmed dead before its pooled context was released back for reuse — so the next caller could get the same context, still busy with the zombie execution, and receive its stale output instead of a fresh result. Reproduced live: the same `output_len` repeated across 12+ calls until the model hit LangGraph's recursion limit and 500'd.
- Fix: `_retire_context_entry()` — a timed-out context is now permanently discarded (never returned to the pool) with a best-effort fresh replacement created to preserve pool capacity.

## Test plan

- [x] 1667 unit tests pass (16 new/updated: checkpoint detection & rollback walk-back, sandbox session scoping, OpenSandbox context retirement, generic sandbox-error handling)
- [x] All three críticos + the OpenSandbox fix live-verified against a real deployed stack (`docker compose --profile opensandbox up -d --build`), not just mocks — see "Verificación en vivo" in the audit doc for exact repro steps
- [x] Migration chain applies cleanly on a fresh DB through `develop`'s current head

## Out of scope

Several Alto/Medio findings from the same audit pass (SSRF-adjacent test-connection blocking the event loop, sandbox ports published on the host, config inconsistencies, etc.) are documented in the audit doc but deliberately left for a follow-up PR to keep this diff reviewable and focused on the data-loss/security-impact críticos.