### PR TITLE
fix(agents): enable having agents as tools and structured outputs at the same time

### DIFF
--- a/backend/tools/agentTools.py
+++ b/backend/tools/agentTools.py
@@ -914,7 +914,7 @@ class IACTTool(BaseTool):
         )
         return instance
 
-    def _run(self, query: str, *args, **kwargs) -> str:
+    def _run(self, query: str, **kwargs) -> str:
         """Synchronous execution of the agent tool"""
         if self.react_agent is None:
             raise RuntimeError(
@@ -1005,7 +1005,7 @@ class IACTTool(BaseTool):
             except Exception:
                 pass
 
-    async def _arun(self, query: str, *args, **kwargs) -> str:
+    async def _arun(self, query: str, **kwargs) -> str:
         """Asynchronous execution of the agent tool"""
         if self.react_agent is None:
             raise RuntimeError(

--- a/tests/unit/tools/test_agent_tools.py
+++ b/tests/unit/tools/test_agent_tools.py
@@ -6,10 +6,12 @@ Focus: the async factory ``IACTTool.create`` must load the sub-agent's MCP tools
 All external dependencies are mocked — no LLM, MCP server or database is touched.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from langchain_core.messages import AIMessage, ToolMessage
+from langchain_core.utils.function_calling import convert_to_openai_tool
 
 from models.agent import Agent
 from tools import agentTools
@@ -178,6 +180,69 @@ async def test_iact_tool_create_uses_sub_agent_rag_config():
 
     # The retriever tool is wired into the sub-agent's toolset.
     assert sentinel_tool in mock_create.call_args.kwargs["tools"]
+
+
+@pytest.mark.asyncio
+async def test_iact_tool_exposes_clean_single_arg_schema():
+    """The agent-as-tool advertises exactly one typed ``query`` parameter.
+
+    Regression: ``_run(self, query, *args, **kwargs)`` with no ``args_schema``
+    made LangChain derive the schema from the signature, which added an ``args``
+    parameter of type ``array`` with untyped ``items`` plus a free-form
+    ``kwargs`` object. Providers reject that schema under the strict validation
+    they apply when the calling agent also uses structured output, so an
+    orchestrator that both routes to sub-agents and returns a structured object
+    failed on every call.
+    """
+    agent = _make_agent("Schema Sub-Agent")
+
+    with (
+        patch("tools.agentTools.get_llm", return_value=object()),
+        patch("tools.agentTools.create_langchain_agent", return_value=MagicMock()),
+        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+    ):
+        tool = await agentTools.IACTTool.create(agent)
+
+    # ``args`` are the JSON-schema properties advertised for the tool call.
+    args = tool.args
+    assert set(args.keys()) == {"query"}, f"unexpected tool params: {args}"
+    assert args["query"]["type"] == "string"
+
+    # And the provider-facing payload — the schema that was actually rejected.
+    parameters = convert_to_openai_tool(tool)["function"]["parameters"]
+    assert set(parameters["properties"]) == {"query"}, f"unexpected tool params: {parameters}"
+    assert parameters["required"] == ["query"]
+    assert all(
+        "type" in prop_schema for prop_schema in parameters["properties"].values()
+    ), f"untyped parameter in tool schema: {parameters}"
+
+
+@pytest.mark.asyncio
+async def test_iact_tool_invoke_passes_query_to_sub_agent():
+    """Pinning ``args_schema`` keeps the ordinary call path working.
+
+    Guards the signature change that dropped ``*args`` from ``_run``/``_arun``:
+    a tool call still reaches the sub-agent with the query as its message.
+    """
+    agent = _make_agent("Callable Sub-Agent")
+
+    react_agent = MagicMock()
+    react_agent.ainvoke = AsyncMock(
+        return_value={"messages": [SimpleNamespace(content="sub-agent answer")]}
+    )
+
+    with (
+        patch("tools.agentTools.get_llm", return_value=object()),
+        patch("tools.agentTools.create_langchain_agent", return_value=react_agent),
+        patch.object(agentTools.MCPClientManager, "get_client", new=AsyncMock(return_value=None)),
+    ):
+        tool = await agentTools.IACTTool.create(agent)
+
+    answer = await tool.ainvoke({"query": "which grants are open?"})
+
+    assert answer == "sub-agent answer"
+    sent_messages = react_agent.ainvoke.await_args.args[0]["messages"]
+    assert [msg.content for msg in sent_messages] == ["which grants are open?"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

> **Rebased on `develop` (`ff68719`).** When this PR was opened, its base — `f57e81f` — had no `args_schema` on `IACTTool` at all. Since then `8970919` ("pin agent-as-tool args_schema so provider schema stays valid") reached `develop` and fixes the same bug this PR was opened for, by the same means. **The pin is no longer part of this PR.** What is left is the other half of the change plus the regression tests, described below. If you would rather close this, that is entirely reasonable — the tests are the only part I would argue for keeping.

`8970919` pins `IACTTool.args_schema` so the provider-facing function schema is exactly `{query: string}`. The signature it works around is still in place:

```python
def _run(self, query: str, *args, **kwargs) -> str: ...
async def _arun(self, query: str, *args, **kwargs) -> str: ...
```

Anything deriving a schema from the signature rather than from `args_schema` still sees the variadic tail as real tool parameters:

```json
{
  "query":  { "type": "string" },
  "args":   { "type": "array", "items": {}, "default": null },
  "kwargs": { "type": "object", "additionalProperties": true, "default": null }
}
```

`args` is an `array` whose `items` carry no `type` — the shape providers reject under the strict schema validation that applies once the calling agent also declares an OutputParser (`response_format`), where `args`/`kwargs` additionally get promoted into `required`. That was the real blocker behind "an orchestrator with sub-agents cannot return structured output": each half works on its own, only the combination breaks.

With `args_schema` pinned that inference no longer runs, so this is hardening rather than a live bug: it removes the pin's status as the only thing holding the schema together. `**kwargs` stays, so any extras LangChain injects keep being tolerated; nothing in the repo passes positional extras to these methods.

## Related Issue(s)

No existing issue. Found while configuring a multi-agent assistant on top of Mattin AI (an orchestrator with structured output routing to per-silo sub-agents exposed as tools). Happy to open an issue if you would rather have it tracked separately.

## Type of Change

* [x] Bug fix (a change that does not break existing functionality and fixes an issue)

## Dependencies Added

None.

## Affected Components

Backend only — `backend/tools/agentTools.py` (2 lines: the `_run`/`_arun` signatures) and its unit tests.

## Implementation Details

- `*args` dropped from `_run`/`_arun`.
- Two regression tests covering the failure `8970919` fixed, so it cannot come back silently.

## How to Test

```bash
poetry install --with test
pytest tests/unit/tools/test_agent_tools.py
```

- `test_iact_tool_exposes_clean_single_arg_schema` — the tool exposes exactly one typed parameter, asserted both on `tool.args` and on the provider-facing payload produced by `convert_to_openai_tool` (every property must carry a `type`). Drop the `args_schema` line from `IACTTool` and this test fails, which is the point.
- `test_iact_tool_invoke_passes_query_to_sub_agent` — guards the signature change: a tool call still reaches the sub-agent with the query as its message.

`tests/unit/tools/test_agent_tools.py`: **9 passed**.

Full unit suite: **1636 passed, 65 skipped**, plus 18 failures in `tests/unit/services/test_agent_execution_service_it4.py`. Those 18 are not from this branch — pristine `develop` at `ff68719` gives the identical 18 in the same environment (1634 passed, i.e. this branch's count minus the two tests added here), and they all pass when that file is run on its own, so it looks like cross-test state rather than anything real. Both failures reported when this PR was opened are gone, fixed on `develop` in the meantime.

## Checklist

* [x] Commit messages follow Conventional Commits (`type(scope): description`).
* [x] I have read the contributing guidelines and my change adheres to the coding standards of this project.
* [x] I have added tests that prove my fix works.
* [x] I have run all existing tests locally — see *How to Test*.
* [x] No documentation, configuration or environment changes are needed for this fix.
* [x] I have considered backwards compatibility: the tool keeps the same single meaningful parameter and the same runtime behaviour.
* [x] No UI changes.

## Additional Notes

The commit is GPG-signed. Sent from a fork, since I only have read access to this repository.

Two adjacent behaviours in the same area that this PR deliberately does **not** touch, in case they are of interest:

- An OutputParser assigned to an `is_tool=true` agent is silently ignored — `IACTTool.create` builds the sub-agent without `response_format`, so the sub-agent always answers in plain text and no warning is emitted.
- `IACTTool.name` is `agent.name.replace(" ", "_")`, which can still produce a provider-invalid function name when the agent name contains characters outside `[a-zA-Z0-9_-]` (accents, parentheses, dots).

Happy to send either as a separate PR.
